### PR TITLE
updated documentation for contributor use.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# Genie 5 Developer Documentation
+
+Genie 5 is a cross-platform Avalonia / .NET 8 rebuild of [Genie 4](https://github.com/GenieClient) — a long-running client for [DragonRealms](https://www.play.net/dr), Simutronics' text MMO. These docs cover the internals: how the client speaks to the server, how a line of game text turns into UI/scripts/state, how scripts execute, and how the mapper finds and walks paths.
+
+The codebase splits into two projects:
+
+- **`Genie.Core`** — pure engine library, zero UI dependencies. Connection, protocol parsing, game-state, the script engine, rule engines, the mapper, and the AI pipe. (Builds as an exe only so the headless [TestHarness](../src/Genie.Core/TestHarness.cs) can run.)
+- **`Genie.App`** — the Avalonia GUI host. Binds to `Genie.Core` observables and owns no game-logic state.
+
+If you're new to the codebase, read in this order: **[SGE Protocol](SGE_PROTOCOL.md)** → **[DR XML Protocol](dr-xml-protocol.md)** → **[Line Pipeline](line-pipeline.md)**. Almost every quirk elsewhere traces back to how the server speaks and how a line flows through the engine.
+
+## Table of contents
+
+| Topic | Status | Summary |
+| --- | --- | --- |
+| [SGE Protocol](SGE_PROTOCOL.md) | ✅ | The Simutronics login flow at `eaccess.play.net:7900` — how [SgeAuthClient](../src/Genie.Core/SgeAuthClient.cs) authenticates and gets a game host/port/key. |
+| [DR XML Protocol](dr-xml-protocol.md) | ✅ | The DragonRealms XML-ish stream, its tag vocabulary, and how [DrXmlParser](../src/Genie.Core/DrXmlParser.cs) turns it into typed `GameEvent`s. |
+| [Line Pipeline](line-pipeline.md) | ✅ | How one `GameEvent` fans out: [GenieCore](../src/Genie.Core/GenieCore.cs) → state / scripts / triggers / globals, and the UI render path in [GameTextViewModel](../src/Genie.App/ViewModels/GameTextViewModel.cs). |
+| [Scripting Engine](scripting-engine.md) | ✅ | [ScriptEngine](../src/Genie.Core/Scripting/ScriptEngine.cs): tick loop, type-ahead, match/wait/pause semantics, the roundtime gate, and the `%`/`$` variable scopes. |
+| [Mapper](mapper.md) | ✅ | [AutoMapperEngine](../src/Genie.Core/Mapper/AutoMapperEngine.cs) + [AutoWalkService](../src/Genie.App/Services/AutoWalkService.cs): node resolution, in-zone pathfinding, and the attended-mode walker. Companion to [AUTOMAPPER_DESIGN.md](AUTOMAPPER_DESIGN.md). |
+| [Multi-Zone Travel](multi-zone-travel.md) | 🚧 partial | [MultiZonePathfinder](../src/Genie.Core/Mapper/MultiZonePathfinder.cs) + [ZoneConnection](../src/Genie.Core/Mapper/ZoneConnection.cs): cross-zone routing over the community `ZoneConnections.xml` graph. |
+| [Build & Release](build-and-release.md) | ✅ | `dotnet publish` per-platform, the single-file self-contained settings, and version stamping. |
+| [Genie 4 vs Genie 5](GENIE4_VS_GENIE5.md) | ✅ | Comprehensive feature-by-feature comparison against the original Windows client. |
+| [AutoMapper Design](AUTOMAPPER_DESIGN.md) | 🚧 | The full auto-walk design proposal: skill-weighted paths, cross-zone travel, user-editable connection database. |
+
+End-user documentation (install, folders, importing, updating maps) lives in the [`wiki/`](../wiki/) folder.
+
+## Conventions
+
+- **File references** use repo-relative paths and link to the source (e.g. [DrXmlParser.cs](../src/Genie.Core/DrXmlParser.cs)). Line-specific references look like `DrXmlParser.cs:184`.
+- **Genie 4 references** point at the original client; it is the authoritative reference for behaviour we replicate (especially the `.cmd` script dialect and `.cfg` formats).
+- **Load-bearing comments.** The source carries long "why" comments next to tricky logic. These pages summarise and link rather than restate — when in doubt, the comment in the code wins.
+
+## Contributing
+
+When you change a documented subsystem, update the corresponding page in the same PR. The docs live in-tree so they're reviewed alongside the code change. See [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -1,0 +1,119 @@
+# Build & Release
+
+Genie 5 builds for Windows, macOS, and Linux from one source tree on .NET 8. The published artifact is **self-contained** — the .NET runtime and native libraries are bundled, so end users don't install anything.
+
+There are no platform build scripts checked in (no `build-mac.sh` / `build-win.sh`). Packaging is driven entirely by `dotnet publish` and the publish properties already set in [Genie.App.csproj](../src/Genie.App/Genie.App.csproj). This page documents the commands and what those properties do.
+
+## Projects
+
+| Project | Output | Notes |
+| --- | --- | --- |
+| [Genie.Core](../src/Genie.Core/Genie.Core.csproj) | library (`AssemblyName=Genie.Core`) | Pure engine. Marked `SelfContained` so the App can reference it from a self-contained publish (NETSDK1150). Builds as an exe only so the headless [TestHarness](../src/Genie.Core/TestHarness.cs) can run via `dotnet run`. |
+| [Genie.App](../src/Genie.App/Genie.App.csproj) | `WinExe` (`AssemblyName=Genie`) | The Avalonia GUI. References Genie.Core. |
+
+Solution file: [Genie.slnx](../Genie.slnx). Target framework: `net8.0`. UI stack: Avalonia 11.3.6 + Dock.Avalonia + ReactiveUI (with ReactiveUI.Fody).
+
+## Local development
+
+```bash
+# from repo root
+dotnet build -c Release
+dotnet run --project src/Genie.App
+```
+
+A plain `dotnet build` produces an unbundled `bin/Debug/net8.0/Genie` you can run directly. The self-contained single-file artifact is only needed for distribution.
+
+To run the headless engine harness (no UI):
+
+```bash
+dotnet run --project src/Genie.Core
+```
+
+## Publishing a distributable
+
+The csproj defaults make `dotnet publish` emit a single self-contained executable with the runtime + native libs (SkiaSharp / HarfBuzz / Avalonia) folded in. Pick the runtime identifier (RID) for the target:
+
+```bash
+# Windows x64
+dotnet publish src/Genie.App -c Release -r win-x64   -o publish/win-x64
+
+# Windows arm64
+dotnet publish src/Genie.App -c Release -r win-arm64 -o publish/win-arm64
+
+# macOS Apple Silicon
+dotnet publish src/Genie.App -c Release -r osx-arm64 -o publish/osx-arm64
+
+# macOS Intel
+dotnet publish src/Genie.App -c Release -r osx-x64   -o publish/osx-x64
+
+# Linux x64
+dotnet publish src/Genie.App -c Release -r linux-x64 -o publish/linux-x64
+```
+
+Each produces a single `Genie` / `Genie.exe` that a tester can copy and double-click — no .NET install, no loose DLLs.
+
+### What the publish properties do
+
+From [Genie.App.csproj](../src/Genie.App/Genie.App.csproj):
+
+| Property | Effect |
+| --- | --- |
+| `PublishSingleFile=true` | Bundle everything into one executable. |
+| `SelfContained=true` | Embed the .NET runtime so the target machine needs nothing pre-installed. |
+| `IncludeNativeLibrariesForSelfExtract=true` | Fold the native shim libraries (Skia/HarfBuzz/Avalonia) into the single file too. |
+| `EnableCompressionInSingleFile=true` | Compress the bundle to keep the download smaller. |
+| `DebugType=embedded` | Keep PDB symbols inside the exe so field crash reports have readable stack traces. |
+
+Because these live in the csproj, the `dotnet publish -r <rid>` command above is all that's needed — no extra `-p:` flags.
+
+## Version stamping
+
+Version metadata is set in [Genie.App.csproj](../src/Genie.App/Genie.App.csproj):
+
+```xml
+<Version>5.0.0-alpha.1</Version>
+<AssemblyVersion>5.0.0.0</AssemblyVersion>
+<FileVersion>5.0.0.0</FileVersion>
+<InformationalVersion>5.0.0-alpha.1</InformationalVersion>
+```
+
+To stamp a different version at publish time, override on the CLI:
+
+```bash
+dotnet publish src/Genie.App -c Release -r win-x64 \
+  -p:Version=5.0.0-alpha.2 -p:FileVersion=5.0.0.2 -o publish/win-x64
+```
+
+Keep `AssemblyVersion` pinned (e.g. `5.0.0.0`) across point releases so the friendly/display version can move without breaking strong-name binding for any future plugin reference. The friendly version (`Version` / `InformationalVersion`) is what the About box and window title surface; `FileVersion` shows in the Windows file-properties dialog.
+
+## Platform packaging notes
+
+The raw publish output is runnable as-is. To make it feel native you'll want to wrap it — these steps are **not** scripted in-repo yet:
+
+### macOS — `.app` bundle and Gatekeeper
+
+A bare `osx-*` publish is a Unix executable, not an app bundle. To ship a `.app`:
+
+1. Lay out `Genie5.app/Contents/MacOS/Genie` (the publish output), `Contents/Resources/` (an `.icns`), and a generated `Contents/Info.plist`.
+2. `xattr -cr Genie5.app` to strip quarantine attributes.
+3. `codesign --force --deep --sign - Genie5.app` for ad-hoc signing — without it, Apple Silicon kills the unsigned binary as "damaged."
+
+Ad-hoc signing is not notarisation. Users still need the right-click → **Open** dance on first launch (documented in the [Installation](../wiki/Installation.md) wiki page). Real Gatekeeper-clean distribution requires an Apple Developer ID certificate plus `xcrun notarytool` + `stapler`.
+
+### Windows — SmartScreen
+
+The published `.exe` is unsigned, so SmartScreen shows a "Windows protected your PC" prompt on first run (**More info → Run anyway**). An Authenticode certificate would remove this; an MSI installer ([WiX](https://wixtoolset.org/), now cross-platform) is the path if a real installer is wanted later. Neither is in scope for the current alpha — the recommended distribution is a zip of the publish folder.
+
+### Linux
+
+`linux-x64` publish runs directly. No packaging (AppImage/.deb/Flatpak) is set up yet.
+
+## CI
+
+No CI pipeline is checked in. A reasonable starter: a GitHub Actions matrix on `windows-latest` / `macos-latest` / `ubuntu-latest` running `dotnet build -c Release`, then `dotnet publish` per RID, uploading the artifacts and cutting a release on tag push.
+
+## Code references
+
+- **[Genie.App.csproj](../src/Genie.App/Genie.App.csproj)** — assembly name (`Genie`), framework, publish + version properties, package refs.
+- **[Genie.Core.csproj](../src/Genie.Core/Genie.Core.csproj)** — engine library, `SelfContained`, embedded `ZoneConnections.baseline.xml` resource.
+- **[Genie.slnx](../Genie.slnx)** — solution layout.

--- a/docs/dr-xml-protocol.md
+++ b/docs/dr-xml-protocol.md
@@ -1,0 +1,149 @@
+# DragonRealms XML Protocol
+
+Once [SGE auth](SGE_PROTOCOL.md) hands off and the FE handshake completes, the DragonRealms game server streams a continuous flow of **XML-ish markup interleaved with bare text**. This page documents that stream, the tag vocabulary Genie 5 recognises, and how [DrXmlParser](../src/Genie.Core/DrXmlParser.cs) turns it into strongly-typed [GameEvent](../src/Genie.Core/GameEvents.cs) objects.
+
+For the login handshake that precedes any of this — the `eaccess.play.net` flow, the FE identifier, StormFront vs. Wizard mode — see [SGE_PROTOCOL.md](SGE_PROTOCOL.md). This page picks up after the socket is live.
+
+## What the stream is (and isn't)
+
+DR's wire format looks like XML but is **not a well-formed document**:
+
+- There is no root element. Tags arrive in a stream, sometimes nested, sometimes self-closed.
+- A single logical element can be split across socket reads at any byte boundary.
+- Bare text (room descriptions, combat, speech) is interleaved freely between tags.
+- Some "tags" the standard `XmlReader` rejects outright — most notably a bare `<d>` with no attributes.
+
+The parser's job is to consume whatever arrives, recover from malformations, and emit a clean event for each thing that happened. It deliberately does **not** try to build a DOM.
+
+## Pipeline position
+
+```
+GameConnection           raw socket bytes, split into chunks at '>' boundaries
+    │  RawXmlStream (hot IObservable<string>)
+    ▼
+DrXmlParser.Feed(chunk)  accumulate → ProcessBuffer → ParseTag / AccumulateText
+    │  GameEvents (Subject<GameEvent>)
+    ▼
+GenieCore subscribers    GameStateEngine · ScriptGlobalsSync · Scripts · Triggers
+                         GameTextViewModel (UI)
+```
+
+[GenieCore](../src/Genie.Core/GenieCore.cs) wires `_connection.RawXmlStream.Subscribe(_parser.Feed)` ([GenieCore.cs:187](../src/Genie.Core/GenieCore.cs#L187)). Everything downstream consumes `GameEvents`, never the raw stream (except the optional AI pipe and the Session Recorder, which tap raw XML directly).
+
+## How parsing works
+
+[DrXmlParser](../src/Genie.Core/DrXmlParser.cs) is a streaming character scanner, not a DOM parser. The hot path in `ProcessBuffer` ([DrXmlParser.cs:109](../src/Genie.Core/DrXmlParser.cs#L109)):
+
+1. Append the incoming chunk to `_rawBuffer`.
+2. Find the next `<`.
+   - Text before it → `AccumulateText`.
+   - No `<` at all → it's all text; accumulate and return.
+3. At a `<`, find the matching `>`.
+   - No `>` yet → the tag is split across reads; **return and wait** for more data. This is how mid-tag TCP splits are handled — the partial tag simply stays in `_rawBuffer`.
+   - Otherwise slice out the full tag and hand it to `ParseTag`.
+
+### Tag parsing with a fallback
+
+`ParseTag` ([DrXmlParser.cs:227](../src/Genie.Core/DrXmlParser.cs#L227)) handles three cases:
+
+- **End tags** (`</component>`) — `XmlReader` in fragment mode can't read standalone end tags, so the name is scraped directly and dispatched to `HandleEndElement`.
+- **Start/self-closing tags** — parsed with an `XmlReader` in `ConformanceLevel.Fragment` mode.
+- **Tags `XmlReader` rejects** — caught `XmlException` falls through to a regex attribute scraper (`ParseAttributesFallback`) wrapped in a minimal `RawAttrReader` shim, so `HandleElement` works unchanged. This is what keeps bare `<d>` links working.
+
+### Text-line accumulation
+
+Because `GameConnection` splits chunks at every `>`, inline formatting tags (`<pushBold/>`, `<d>…</d>`) fragment a single visible line into many pieces. `AccumulateText` ([DrXmlParser.cs:152](../src/Genie.Core/DrXmlParser.cs#L152)) buffers raw fragments in `_textLineBuffer` and only emits a `TextEvent` when it sees a `\n` or an explicit `FlushTextLine()` (triggered at logical boundaries like `<prompt>`, `<pushStream>`, `</inv>`).
+
+`EmitLine` ([DrXmlParser.cs:184](../src/Genie.Core/DrXmlParser.cs#L184)) does the final cleanup: HTML-decode, strip any embedded XML/ANSI, and **trim trailing whitespace only** — leading whitespace is significant (DR uses it for column alignment in `info`/`exp` output). Whitespace-only lines are dropped. A bare-text prompt (`>`, `H>`, `HR>`) emits a `PromptEvent` instead of a `TextEvent`.
+
+### Link and bold spans
+
+Clickable `<d cmd="…">` and external `<a href="…">` tags don't break the text — the inner text flows through normally. The parser bookmarks the buffer offset on the open tag and, on close, commits a [LinkSpan](../src/Genie.Core/GameEvents.cs) (`IsUrl=true` for `<a>`) attached to the resulting `TextEvent`. `<pushBold/>`/`<popBold/>` work the same way, producing `BoldSpan`s. When the `cmd` attribute is missing, the inner text doubles as the command (DR convention: `<d>BANK DEBT</d>` sends `BANK DEBT`). Both use small defensive stacks for nesting even though DR doesn't nest them in practice.
+
+## Tag reference
+
+Each recognised tag emits one or more `GameEvent`s. Tags in the `_settingsTags` skip-set ([DrXmlParser.cs:343](../src/Genie.Core/DrXmlParser.cs#L343)) — the initial Wrayth settings dump and UI-layout-only markup — are consumed silently.
+
+### Vitals and resources
+
+| Tag | Event | Notes |
+| --- | --- | --- |
+| `<progressBar id='health' value='80' text='…'/>` | `ProgressBarEvent(id, value, text)` | `id` ∈ health, mana, spirit, stamina, concentration, encumbrance. Dropped (logged) if `id` or `value` is missing. |
+| `<resource id='…' value='N'/>` | `ResourceEvent(id, value)` | Absolute mana/spirit/stamina values. `<resource picture='0'/>` (a UI image hint) is ignored. |
+
+### Time
+
+| Tag | Event | Notes |
+| --- | --- | --- |
+| `<roundTime value='N'/>` | `RoundTimeEvent(expiresAt)` | `value` is the absolute Unix epoch when RT expires. Stored as `Combat.RoundTimeEnd`. |
+| `<castTime value='N'/>` | `CastTimeEvent(expiresAt)` | Same shape, for spell prep. |
+| `<prompt time='N'>…</prompt>` | `PromptEvent(serverTime)` | Open tag fires the event with the real timestamp; the element body (the visual `>`) is discarded. Also flushes any partial text line first. |
+
+### Room and navigation
+
+| Tag | Event | Notes |
+| --- | --- | --- |
+| `<streamWindow id='room' subtitle=' - [Foo, Bar]'/>` | `WindowEvent(id, title)` + synthetic `ComponentEvent("room title", "[Foo, Bar]")` | DR carries the **room title in the subtitle** of the room stream window — there is no `<component id='room title'>`. The parser bridges it so the mapper sees titles. Nested brackets pair last-`[` with last-`]`. |
+| `<component id='room desc'>…</component>` | `ComponentEvent("room desc", text)` | Also: `room objs`, `room players`, `room exits`. Content accumulates between open/close. |
+| `<component id='exp Climbing'>…</component>` | `ComponentEvent("exp climbing", text)` | Skill rank ticks. [GameStateEngine](../src/Genie.Core/GameStateEngine.cs) parses the rank int into `LiveSkills` for the weighted pathfinder. |
+| `<compass><dir value='n'/>…</compass>` | `CompassEvent(rawXml)` | Space-joined direction tokens. Surfaced as `$roomexits` and per-exit booleans. |
+| `<nav rm='12345'/>` | `NavEvent(roomId)` | Server-assigned room id — the mapper's most reliable fingerprint. |
+
+### Hands, spell, inventory
+
+| Tag | Event | Notes |
+| --- | --- | --- |
+| `<right exist='29' noun='sword'>an iron sword</right>` | `HeldItemEvent(Hand.Right, noun, exist)` | Event fires from the attributes immediately; the body text is currently discarded (so `$righthand` == `$righthandnoun` for now). `<left>` mirrors it. |
+| `<spell>Fire Strike</spell>` | `SpellEvent(name)` | Prepared spell; content accumulates between tags. |
+| `<inv id='stow'>a finely carved shortbow</inv>` | (routed to `inv` stream) | The parser treats `<inv>` as an implicit push to the `inv` stream so item lines don't leak into the main window, popping back on `</inv>`. |
+| `<container id='stow' title='My Backpack' target='#37666728'/>` | `ContainerEvent(logicalId, title, targetId)` | Lets the UI render `#NNNN` ids as human names in click-echoes. Skipped if `target` is empty. |
+
+### Streams and styling
+
+| Tag | Event | Notes |
+| --- | --- | --- |
+| `<pushStream id='familiar'/>` | `StreamPushEvent(id)` | Subsequent text routes to the named stream; flushes the current line first. |
+| `<popStream/>` | `StreamPopEvent(from, to)` | Returns to the previous stream. |
+| `<clearStream id='…'/>` | `ClearStreamEvent(id)` | Tells the UI to wipe a stream panel. |
+| `<output class='mono'/>` | `OutputClassEvent(class)` | Monospace toggle (used during EXP dumps). |
+| `<preset id='roomDesc'>…</preset>` | (sets `_currentPresetId`) | Drives a `FlushTextLine` on close for `roomDesc`/`inv` so the following exits/items land on their own line. |
+| `<d cmd='…'>…</d>`, `<a href='…'>…</a>` | `LinkSpan` on the next `TextEvent` | See [Link and bold spans](#link-and-bold-spans). |
+| `<pushBold/>` … `<popBold/>` | `BoldSpan` on the next `TextEvent` | DR uses bold for unread news, emphasis, etc. |
+
+### Status indicators
+
+| Tag | Event | Notes |
+| --- | --- | --- |
+| `<indicator id='IconWEBBED' visible='y'/>` | `IndicatorEvent(id, visible)` | `visible` is `y`/`n`. [GameStateEngine](../src/Genie.Core/GameStateEngine.cs) maps the icon id to a `CharacterStatus`; [ScriptGlobalsSync](../src/Genie.Core/Scripting/ScriptGlobalsSync.cs) mirrors it to `$webbed`/`$standing`/etc. |
+
+### Session lifecycle
+
+| Tag | Event | Notes |
+| --- | --- | --- |
+| `<endSetup/>` | `EndSetupEvent` | End of the settings burst. |
+| `<settingsInfo/>` | `SettingsInfoEvent` | Authoritative "ready for input" signal. `GenieCore` sends `look` once on this. See [SGE_PROTOCOL.md](SGE_PROTOCOL.md#after-auth). |
+
+### Anything unrecognised
+
+Unknown tags emit an `UnknownTagEvent(name, rawXml)` and are logged at trace level. `GameStateEngine` logs these at debug — useful when DR introduces a tag we don't yet handle, and a feed for AI-training analysis.
+
+## Quirks the parser handles
+
+- **Mid-tag TCP splits.** A tag cut in half across socket reads is left in `_rawBuffer` until its `>` arrives. No carry gymnastics — the incomplete tag simply isn't parsed yet.
+- **`XmlReader`-hostile tags.** Bare `<d>` and friends fall through to the regex attribute scraper rather than being dropped.
+- **Leading whitespace preservation.** Required for `info`/`exp` column alignment; only trailing whitespace is trimmed.
+- **Inline-tag line fragmentation.** Buffered and reassembled in `_textLineBuffer`, flushed at `\n` and logical boundaries.
+- **Inventory bleed.** `<inv>` content is implicitly re-routed to the `inv` stream so it doesn't appear in the main window.
+
+## Diagnostics
+
+- **Session Recorder** (**File → Record Session (raw XML)**) captures the verbatim raw stream to disk — the fastest way to inspect exactly what the server sent. Replay it through the engine via DevReplay mode (see [DevReplayServer](../src/Genie.Core/DevReplayServer.cs)).
+- **Trace logging** on `DrXmlParser` surfaces every unknown tag.
+
+## Code references
+
+- **[DrXmlParser.cs](../src/Genie.Core/DrXmlParser.cs)** — the scanner, tag dispatch, span tracking, fallback attribute parser.
+- **[GameEvents.cs](../src/Genie.Core/GameEvents.cs)** — the `GameEvent` record hierarchy every consumer matches on.
+- **[GameConnection.cs](../src/Genie.Core/GameConnection.cs)** — socket, chunking, `RawXmlStream`, FE handshake.
+- **[GameStateEngine.cs](../src/Genie.Core/GameStateEngine.cs)** — turns events into the live `GameState` snapshot.
+- **[GenieCore.cs](../src/Genie.Core/GenieCore.cs)** — wires the parser to every consumer.

--- a/docs/line-pipeline.md
+++ b/docs/line-pipeline.md
@@ -1,0 +1,108 @@
+# Line Pipeline
+
+This page documents what happens to a unit of game output between the [DrXmlParser](../src/Genie.Core/DrXmlParser.cs) emitting a `GameEvent` and that event reaching the UI, scripts, game-state, and rule engines. Most "the line didn't appear where I expected" / "my trigger didn't fire" questions are answered by getting this fan-out right.
+
+Unlike Genie 4 (and the earlier Kzin prototype), there is **no single `LineReceived` handler**. Genie 5 is event-driven: the parser publishes typed events on a [Reactive](https://github.com/dotnet/reactive) `IObservable<GameEvent>`, and each consumer subscribes to exactly the event types it cares about. The "order of operations" is therefore the set of subscriptions wired in [GenieCore](../src/Genie.Core/GenieCore.cs), plus the UI-side render path in [GameTextViewModel](../src/Genie.App/ViewModels/GameTextViewModel.cs).
+
+## End-to-end view
+
+```
+GameConnection.RawXmlStream  (hot IObservable<string>)
+    │
+    ├─► DrXmlParser.Feed → GameEvents (IObservable<GameEvent>)
+    │        │
+    │        ├─► GameStateEngine.Apply          live GameState snapshot (vitals, room, RT, statuses)
+    │        ├─► ScriptGlobalsSync.OnEvent       mirror state into Scripts.Globals ($health, $north, …)
+    │        ├─► GenieCore._gameEventSub:
+    │        │       TextEvent   → Scripts.OnGameLine + Triggers.ProcessLine
+    │        │       PromptEvent → Scripts.OnPrompt
+    │        │       NavEvent    → Scripts.OnRoomChanged
+    │        ├─► MapperGameStateAdapter           feeds AutoMapperEngine.OnStateChanged
+    │        └─► GameTextViewModel (UI):
+    │                TextEvent(stream=="main") → Substitutes → Gags → highlight render
+    │                side-stream TextEvents     → their own stream VMs / tabs
+    │
+    └─► AiRawStream (toggleable) → AiContextBuffer   (never blocks the parser)
+```
+
+The two engine-side state consumers — `GameStateEngine` and `ScriptGlobalsSync` — each subscribe **independently** to `GameEvents` in the `GenieCore` constructor ([GenieCore.cs:183](../src/Genie.Core/GenieCore.cs#L183), [GenieCore.cs:274](../src/Genie.Core/GenieCore.cs#L274)). Rx delivers events to subscribers in subscription order, and both are wired before the `_gameEventSub` that drives scripts/triggers. That ordering is load-bearing — see below.
+
+## Why the ordering matters
+
+- **State and globals are applied before scripts see the line.** `GameStateEngine` and `ScriptGlobalsSync` subscribe before `_gameEventSub`. So by the time `Scripts.OnGameLine(text)` runs for a `TextEvent`, `$webbed`, `$health`, `$roomexits` etc. already reflect any indicator/vital/compass events that arrived earlier in the same burst. A script's `matchwait`/`waiteval` evaluates against current state, not last line's.
+- **Scripts run before triggers, both on every `TextEvent`.** `_gameEventSub` calls `Scripts.OnGameLine` then `Triggers.ProcessLine` ([GenieCore.cs:286-289](../src/Genie.Core/GenieCore.cs#L286)). Scripts get first crack at a line (to satisfy a pending `matchwait`); triggers fire their command actions after.
+- **`PromptEvent` advances RT-gated scripts.** A prompt is the natural unblock for `wait`, decrements in-flight type-ahead, and lets the roundtime gate re-check. The DR server only prompts in response to commands — see the [scripting engine's roundtime gate](scripting-engine.md#the-roundtime-gate).
+- **`NavEvent` unblocks `move`.** A new server room id is what releases a script blocked on `move`/`nextroom`.
+- **The AI pipe is a separate tap on raw XML**, gated by `AiPipeEnabled`, and is structured so it can never block the parser or the game.
+
+## Engine-side consumers
+
+### GameStateEngine — the live snapshot
+
+[GameStateEngine](../src/Genie.Core/GameStateEngine.cs) is the single source of truth for "what is the character doing right now." It matches on event type and writes into the shared [GameState](../src/Genie.Core/GameState.cs):
+
+- `ProgressBarEvent` → `Vitals.*`
+- `ComponentEvent` → `Room.*` (title/desc/exits/objs/players), `Combat.Stance`, `CharacterName`; `exp <skill>` → `LiveSkills`
+- `RoundTimeEvent`/`CastTimeEvent` → `Combat.RoundTimeEnd`/`CastTimeEnd`
+- `IndicatorEvent` → adds/removes a `CharacterStatus` in `ActiveStatuses`
+- `HeldItemEvent` → `Inventory.LeftHand`/`RightHand` (+ exist ids)
+- `SpellEvent` → `Combat.PreparedSpell`, `NavEvent` → `Room.RoomId`, `CompassEvent` → `Room.CompassExits`
+
+The UI binds to `GameState`; scripts read it indirectly through globals; the mapper reads it through an adapter.
+
+### ScriptGlobalsSync — Genie 4 reserved variables
+
+[ScriptGlobalsSync](../src/Genie.Core/Scripting/ScriptGlobalsSync.cs) mirrors state into `Scripts.Globals` so community scripts can read the Genie 4 vocabulary: `$health`, `$mana`, `$stamina`/`$fatigue`, `$righthand`/`$righthandnoun`/`$righthandid`, `$preparedspell`, `$stance`, the status flags (`$standing`, `$webbed`, …), the per-exit booleans (`$north`, `$up`, …), and the room fields (`$roomname`, `$roomdesc`, `$roomexits`, `$gameroomid`). It uses **per-event-type dispatch** (each callback touches only the 1–12 variables relevant to that event) and writes into a `ConcurrentDictionary` so the parser thread and script reads don't need a lock. Defaults are seeded at construction so a script launched the instant after connect sees usable values.
+
+## UI render path — GameTextViewModel
+
+The user-facing rule pipeline lives in [GameTextViewModel.Attach](../src/Genie.App/ViewModels/GameTextViewModel.cs#L26). For each `TextEvent` on the `main` stream, observed on the UI thread:
+
+1. **Display filter** — skip if **Window → Game Text** is toggled off (`DisplaySettings.ShowGameText`).
+2. **Substitutes** — `core.Substitutes.Apply(text)` rewrites the text. Genie 4 ordering: substitute first, then gag.
+3. **Gags** — `core.Gags.ShouldGag(text)` drops the whole line if any enabled rule matches.
+4. **Span carry** — link and bold spans are kept **only if no substitute fired** (`ReferenceEquals(text, e.Text)`). A substitution shifts character offsets, so spans are dropped rather than remapped — clickable text is a UX bonus, not a correctness requirement.
+5. **Render** — `AddLine` appends a `TextLine`. Highlighting is applied lazily by `TextLine.Inlines`, which tokenizes via [DefaultHighlights](../src/Genie.App/Highlighting/DefaultHighlights.cs) (user rules + link/bold spans). The buffer is capped at `MaxLines = 2000`.
+
+Echoes (typed commands, `#echo`, `[script]`/`[recorder]` diagnostics) arrive on the `EchoLine` event, not as `TextEvent`s. They render with the `System` colour and are gated by `ShowEchoText` (bare) or `ShowScriptText` (bracketed `[tag]` lines).
+
+### Live re-highlighting
+
+When the user adds or edits a highlight rule, `UserHighlights.RulesChanged` fires and `RetokenizeAllLines` replaces every existing `TextLine` with a fresh instance so already-rendered text repaints — not just future lines.
+
+### Side streams
+
+`TextEvent`s on non-`main` streams (`logons`, `talk`, `whispers`, `thoughts`, `familiar`, …) route to their own stream view-models / dock tabs. When a stream's panel is closed, its lines can be folded back into the main window via `AddStreamLine`, prefixed with `[stream]`. Side-stream lines do not run the trigger pass — triggers are a main-window concern (a trigger that runs `put …` shouldn't fire on a whisper).
+
+## Class gating
+
+[ClassEngine](../src/Genie.Core/Classes/ClassEngine.cs) holds boolean classes the user toggles. Triggers, highlights, substitutes, and gags can each be scoped to a class; if the class is off, the rule is skipped at evaluation time. State is live — toggling a class affects every associated rule on the next line. This is wired by assigning `Classes` onto each engine in the `GenieCore` constructor.
+
+## Command path (the other direction)
+
+User input flows the opposite way, through [CommandEngine](../src/Genie.Core/Commanding/CommandEngine.cs) via `GenieCore.ProcessInput`:
+
+```
+ProcessInput(text)
+  → alias expansion + separator split (`;`)
+  → #cmd routing (#var, #trigger, #echo, #class, … — see CommandEngine)
+  → ICommandHost.SendToGame → local echo (EchoLine) + AutoMapper.OnCommandSent + socket
+```
+
+`AutoMapper.OnCommandSent` lets the mapper observe outgoing movement verbs so it can correlate the next room change with the direction you moved. Note there is **no** `#goto`/`#travel`/`#mapper` meta-command — walking is driven from the Mapper UI ([AutoWalkService](../src/Genie.App/Services/AutoWalkService.cs)); see [mapper.md](mapper.md).
+
+## Diagnostics
+
+- **Window → Game Text / Echo Lines / Script Lines** toggle what's rendered.
+- **File → Record Session (raw XML)** captures the verbatim stream for replay.
+- Trace/debug logging on `DrXmlParser` and `GameStateEngine` surfaces unknown tags.
+
+## Code references
+
+- **[GenieCore.cs](../src/Genie.Core/GenieCore.cs)** — all engine-side subscriptions; the `_gameEventSub` fan-out; the command host.
+- **[GameStateEngine.cs](../src/Genie.Core/GameStateEngine.cs)** — events → live `GameState`.
+- **[ScriptGlobalsSync.cs](../src/Genie.Core/Scripting/ScriptGlobalsSync.cs)** — events → script globals.
+- **[GameTextViewModel.cs](../src/Genie.App/ViewModels/GameTextViewModel.cs)** — UI substitute → gag → highlight render path.
+- **[SubstituteEngine.cs](../src/Genie.Core/Substitutes/SubstituteEngine.cs)**, **[GagEngine.cs](../src/Genie.Core/Gags/GagEngine.cs)**, **[HighlightEngine.cs](../src/Genie.Core/Highlights/HighlightEngine.cs)**, **[NameHighlightEngine.cs](../src/Genie.Core/Highlights/NameHighlightEngine.cs)** — user-rule engines.
+- **[TriggerEngineFinal.cs](../src/Genie.Core/Triggers/TriggerEngineFinal.cs)** — command-firing triggers.
+- **[CommandEngine.cs](../src/Genie.Core/Commanding/CommandEngine.cs)** — input routing and `#cmd` dispatch.

--- a/docs/mapper.md
+++ b/docs/mapper.md
@@ -1,0 +1,117 @@
+# Mapper
+
+The mapper knows where the player is, owns the zone files, plans paths between rooms, and (in the UI) walks the player along them. It splits cleanly across the two projects:
+
+- **[AutoMapperEngine](../src/Genie.Core/Mapper/AutoMapperEngine.cs)** (`Genie.Core`) — pure game-state logic. Given a loaded zone and a game-state feed, it resolves the current node, follows movement, optionally learns new rooms, and answers pathfinding queries. No UI, no threads, no IO beyond what the repository does.
+- **[AutoWalkService](../src/Genie.App/Services/AutoWalkService.cs)** + **[MapperViewModel](../src/Genie.App/ViewModels/MapperViewModel.cs)** (`Genie.App`) — UI/host glue: the zone picker, the map render, click-to-goto, and the attended-mode walking state machine.
+
+This page covers the runtime behaviour. For the larger design (skill-weighted paths, cross-zone travel, the user-editable connection database), see [AUTOMAPPER_DESIGN.md](AUTOMAPPER_DESIGN.md). For cross-zone routing specifically, see [multi-zone-travel.md](multi-zone-travel.md).
+
+## Data model
+
+```
+MapZone
+├── Id (Guid)               generated on creation
+├── Name                    display name ("Crossing")
+├── Genie4Id                preserved from imported XML ("1", "60", "2d")
+└── Nodes : Dictionary<int, MapNode>
+
+MapNode
+├── Id, Title, Description, X, Y, Z
+├── Notes, Color
+├── ServerRoomId            from <nav rm="…"/>, stamped on first visit
+└── Exits : List<MapExit>
+
+MapExit
+├── Direction               Direction enum (n, ne, …, up, down, out)
+├── MoveCommand             what to send ("n", "go gate", "climb tree")
+├── DestinationId           int?; null for unmapped exits
+├── Requires                skill/class/level gate (see ExitRequirement)
+├── RtCost                  roundtime seconds (pathfinder weight)
+├── WaitMin / WaitMax       scheduled-departure wait window (boats)
+└── Notes                   community notes (rope needed, night only, …)
+```
+
+Zones load and save through [MapZoneRepository](../src/Genie.Core/Mapper/MapZoneRepository.cs). Genie 4's XML map files import via [Genie4MapImporter](../src/Genie.Core/Mapper/Genie4MapImporter.cs) and [Genie4MapExporter](../src/Genie.Core/Mapper/Genie4MapExporter.cs) round-trips back. Zone files live in the user's **Maps** directory as `Map##_*.xml`.
+
+## Wiring into the engine
+
+The engine doesn't read `GameState` directly — it reads through [IMapperGameState](../src/Genie.Core/Mapper/IMapperGameState.cs), a four-property adapter (`RoomTitle`, `RoomDescription`, `Exits`, `ServerRoomId` + a `StateChanged` event). The concrete adapter is [MapperGameStateAdapter](../src/Genie.Core/Mapper/MapperGameStateAdapter.cs), constructed in `GenieCore` over the live `GameState` and the parser's `GameEvents`. This keeps the engine testable with a fake state and decoupled from the DR-specific event shapes.
+
+```csharp
+AutoMapper     = new AutoMapperEngine(new MapZone { Name = "(unsaved)" });
+_mapperAdapter = new MapperGameStateAdapter(state, _parser.GameEvents);
+AutoMapper.Attach(_mapperAdapter);
+AutoMapper.Skills         = state.LiveSkills;   // for skill-weighted pathfinding
+AutoMapper.CharacterClass = …; AutoMapper.CharacterLevel = state.Circle;
+```
+
+`GenieCore` also forwards outgoing commands to `AutoMapper.OnCommandSent(text)` so the engine knows which movement verb the player just used — that direction is the strongest signal for resolving the next room.
+
+## Lookup-only vs. learning
+
+`AutoMapperEngine.IsEnabled` defaults to **false** — *lookup-only* mode. In lookup-only mode the engine resolves the current node against the loaded community map but never modifies the zone (no new nodes, no new arcs, no stamping). Turning it on (the **AutoMapper** config / menu toggle) enables learning: stamping `ServerRoomId` on matched nodes, adding arcs for observed movement, and creating new nodes for unrecognised rooms. The save policy follows from this — there's no point writing the zone back to disk when the engine never modifies it.
+
+## Resolving the current node
+
+On every relevant state change, [OnStateChanged](../src/Genie.Core/Mapper/AutoMapperEngine.cs#L163) re-derives the current node. It re-processes whenever **title, exits, or description** changes — all three, because DR can deliver the parts of a room transition (title, compass, description, nav) in any order, and a later-arriving description may carry the disambiguating signal an earlier title-only fire lacked.
+
+`OnRoomChanged` ([AutoMapperEngine.cs:194](../src/Genie.Core/Mapper/AutoMapperEngine.cs#L194)) tries a priority ladder:
+
+1. **(a) Server room id** — if `<nav rm="…"/>` gave us an id and a node has that `ServerRoomId`, that's definitive.
+2. **(b) Graph walk** — if we know the previous node and the movement verb used, follow that arc and confirm the destination title matches. Handles both compass directions and non-compass `MoveCommand`s (`go alley`, `climb trellis`).
+3. **(c) Fingerprint index** — [MapFingerprint](../src/Genie.Core/Mapper/MapFingerprint.cs) hashes title + cardinal exits. A single match wins; on collisions (dense cities with duplicate titles) it disambiguates by adjacency to `prevNode`, then by description, and otherwise **declines** rather than guess — a wrong lock-in cascades through every subsequent move.
+4. **(d) Reverse-arc search**, **(e) description tiebreaker**, then
+5. **(f)** create a new node (if learning is enabled) or fire `RoomNotFoundInZone` (the hook the UI uses to auto-switch zones).
+
+Once matched, `ServerRoomId` is stamped (when learning is on) so future visits resolve via (a) in O(1). An index (`RebuildIndex`) keeps fingerprint→nodes and serverRoomId→node lookups warm.
+
+## Pathfinding
+
+[FindPath(start, destination)](../src/Genie.Core/Mapper/AutoMapperEngine.cs#L547) is **Dijkstra** over the exit graph of the active zone. Edge weight is baseline 1 per room today (RT-cost weighting is wired for the cross-zone pathfinder; see below). Each exit is gated by [ExitRequirement.Parse(exit.Requires).IsMet(Skills, CharacterClass, CharacterLevel)](../src/Genie.Core/Mapper/ExitRequirement.cs) — an exit the character can't take (climb wall below the skill threshold, guild-locked door, level gate) is excluded entirely. When `Skills` is null (no character data), every exit passes and the result matches a plain BFS. It returns the ordered list of `MoveCommand` strings to send.
+
+Cross-zone routing is **not** done here — the engine only ever sees one zone. That's [MultiZonePathfinder](../src/Genie.Core/Mapper/MultiZonePathfinder.cs), documented in [multi-zone-travel.md](multi-zone-travel.md).
+
+## Walking (the UI)
+
+There is **no `#goto` command**. Walking is initiated from the Mapper panel: the user clicks a room (`GotoNodeCommand`), the view-model calls `FindPath`, and hands the plan to [AutoWalkService](../src/Genie.App/Services/AutoWalkService.cs).
+
+```
+GotoNode(target)
+  → FindPath(CurrentNode, target) → [move1, move2, …]
+  → AutoWalkService.Start(origin, destination)
+        DispatchNextStep(): ProcessInput(move) through the normal pipeline
+  → AutoMapperEngine.CurrentNodeChanged fires when the player enters a room
+  → OnRoomChanged(): if at destination → Finished
+                     else → advance step, DispatchNextStep()
+```
+
+Moves go through `Commands.ProcessInput` so the same alias/trigger/command-queue path runs as if typed — the queue handles RT gating, so the walker doesn't sleep itself. Step matching trusts `FindPath`'s ordering: if the player gets bounced off-path, the next move won't match and the walk **cancels** rather than firing arbitrary commands.
+
+### Attended-mode posture
+
+The walker is deliberately conservative, to stay within DR's allowed-software policy (see the project README and `AutoWalkService`'s class comment):
+
+- **Auto-pauses** after `UnfocusPauseSeconds` (60s) of the window being unfocused; the user must click **Resume**.
+- **Cancels** on: Esc, any typed non-meta command, disconnect, or walking off-plan.
+- **Never auto-resumes** across a disconnect — a fresh walk needs a fresh click.
+- A visible indicator strip shows progress and a Cancel/Resume control.
+
+### Cross-zone wait UI
+
+For a cross-zone hop with a known wait window (boats, ferries), `AutoWalkService` surfaces a countdown ("~4:23 left") in the indicator strip. The countdown is only a UI hint — actual arrival is driven by the destination zone fingerprinting in, so a late boat just shows "any moment now…" until the room change fires.
+
+## Zone files, import, and updates
+
+- **Import from Genie 4** — **File → Import from Genie 4…** brings `.cfg` rules across; map XML is imported via the mapper. See the [Importing Genie4 Config](../wiki/Importing-Genie4-Config.md) wiki page.
+- **Update Maps from Official Repo** — **File → Update Maps from Official Repo…** pulls fresh zone XML (and optionally helper scripts) from the community [GenieClient/Maps](https://github.com/GenieClient) repo via [MapRepoUpdater](../src/Genie.Core/Mapper/MapRepoUpdater.cs), merging upstream layout changes while preserving your stamped `ServerRoomId`s. See [Updating Maps and Scripts](../wiki/Updating-Maps-and-Scripts.md).
+- **Maps directory** — **File → Open Maps Folder** / **Change Maps Directory…**. Configurable via `#config mapdir`.
+
+## Code references
+
+- **[AutoMapperEngine.cs](../src/Genie.Core/Mapper/AutoMapperEngine.cs)** — node resolution ladder, `FindPath`, learning, `RoomNotFoundInZone`.
+- **[MapperGameStateAdapter.cs](../src/Genie.Core/Mapper/MapperGameStateAdapter.cs)** / **[IMapperGameState.cs](../src/Genie.Core/Mapper/IMapperGameState.cs)** — the state bridge.
+- **[MapZone.cs](../src/Genie.Core/Mapper/MapZone.cs)**, **[MapNode.cs](../src/Genie.Core/Mapper/MapNode.cs)**, **[MapExit.cs](../src/Genie.Core/Mapper/MapExit.cs)** — data model.
+- **[MapZoneRepository.cs](../src/Genie.Core/Mapper/MapZoneRepository.cs)**, **[Genie4MapImporter.cs](../src/Genie.Core/Mapper/Genie4MapImporter.cs)**, **[MapRepoUpdater.cs](../src/Genie.Core/Mapper/MapRepoUpdater.cs)** — persistence, import, updates.
+- **[MapFingerprint.cs](../src/Genie.Core/Mapper/MapFingerprint.cs)**, **[ExitRequirement.cs](../src/Genie.Core/Mapper/ExitRequirement.cs)** — disambiguation and skill gating.
+- **[AutoWalkService.cs](../src/Genie.App/Services/AutoWalkService.cs)**, **[AutoWalkSession.cs](../src/Genie.App/Services/AutoWalkSession.cs)**, **[MapperViewModel.cs](../src/Genie.App/ViewModels/MapperViewModel.cs)**, **[MapCanvas.cs](../src/Genie.App/Controls/MapCanvas.cs)** — UI walker + render.

--- a/docs/multi-zone-travel.md
+++ b/docs/multi-zone-travel.md
@@ -1,0 +1,82 @@
+# Multi-Zone Travel
+
+**Status:** infrastructure implemented; walker integration in progress.
+
+Unlike the single-zone walk (which [AutoMapperEngine.FindPath](../src/Genie.Core/Mapper/AutoMapperEngine.cs#L547) and [AutoWalkService](../src/Genie.App/Services/AutoWalkService.cs) already drive end-to-end — see [mapper.md](mapper.md)), travelling across zone boundaries needs a graph that spans multiple zone files plus the transit links (boats, ferries, climb-walls, portals) that connect them. Genie 5 has the pathfinder, the data model, the on-disk format, and a UI editor for that graph. What's not yet wired is the **walker consuming a multi-zone plan** — `AutoWalkService.Start` currently calls the single-zone `FindPath`. This page documents what exists and what remains.
+
+## The pieces that exist
+
+### MultiZonePathfinder
+
+[MultiZonePathfinder](../src/Genie.Core/Mapper/MultiZonePathfinder.cs) is **Dijkstra over a meta-graph of `(zoneFile, room)` tuples**. It loads zones lazily (each read at most once per search) and draws edges from two sources:
+
+- **Intra-zone** — each loaded zone's `MapNode.Exits`.
+- **Cross-zone** — [ZoneConnection](../src/Genie.Core/Mapper/ZoneConnection.cs)s from a [ZoneConnectionsRepository](../src/Genie.Core/Mapper/ZoneConnectionsRepository.cs).
+
+Both edge kinds honour [ExitRequirement](../src/Genie.Core/Mapper/ExitRequirement.cs) against the character's live `SkillStore` / class / level — an edge the character can't take is excluded from the search entirely. Weights:
+
+- intra-zone: `1 + RtCost/4`
+- cross-zone: `1 + RtCost/4 + averageWait/4`
+
+Wait time dominates, so a boat with a long schedule is only preferred when there's no overland route. The result is a [MultiZonePath](../src/Genie.Core/Mapper/MultiZonePathfinder.cs#L30): an ordered list of [WalkStep](../src/Genie.Core/Mapper/MultiZonePathfinder.cs#L12)s (each carrying its verb, and for cross-zone hops the expected wait window + target zone), plus a `HasCrossZoneHop` flag.
+
+Rooms are referenced by either integer node id or DR server-room id (`#NNNN`); `TryMatchRoom` resolves both, preferring `ServerRoomId` since it survives map regeneration.
+
+### ZoneConnection data + ZoneConnections.xml
+
+A [ZoneConnection](../src/Genie.Core/Mapper/ZoneConnection.cs) is one directed link:
+
+| Field | Meaning |
+| --- | --- |
+| `FromZone` / `ToZone` | zone-file basenames **without** `.xml` (`Map01_Crossing`) |
+| `FromRoom` / `ToRoom` | node id or `#serverRoomId` |
+| `Verb` | what the walker sends (`board boat`, `climb wall`) |
+| `TransitType` | free-form tag (`boat`, `climb`, `ride`, `portal`) |
+| `Requires` | skill/class/level gate, parsed by `ExitRequirement` |
+| `RtCost` | roundtime seconds |
+| `WaitMin` / `WaitMax` | scheduled-departure wait window |
+| `Notes` | community notes |
+
+These live in a single **`ZoneConnections.xml`** at the root of the Maps directory (next to the `Map##_*.xml` zone files), so the community Maps repo can curate transit links without editing individual zone files. The schema:
+
+```xml
+<connections>
+  <connection id="boat-cross-throne"
+              from-zone="Map01_Crossing"  from-room="#37666999"
+              to-zone="Map35_Throne_City" to-room="#37666500"
+              verb="board boat" transit-type="boat"
+              wait-min="300" wait-max="600"
+              requires="" rt="0" notes="" />
+</connections>
+```
+
+[ZoneConnectionsRepository](../src/Genie.Core/Mapper/ZoneConnectionsRepository.cs) reads and writes this file. On first launch it **seeds** an embedded baseline ([ZoneConnections.baseline.xml](../src/Genie.Core/Mapper/Resources/ZoneConnections.baseline.xml)) — a documented set of example routes with TODO room ids — so users have a starting template. A `.genie5-zone-connections-seeded` marker ensures it never re-seeds: if you delete the file after seeing it, the app respects that. Unresolvable connections (stale zone/room refs) are silently skipped by the pathfinder, so a half-filled file degrades gracefully to single-zone routing rather than breaking.
+
+### The editor UI
+
+**File → Cross-Zone Connections…** opens the [ZoneConnectionsViewModel](../src/Genie.App/ViewModels/ZoneConnectionsViewModel.cs) grid — add / remove / edit / save connections, round-tripping through the repository. This is the curation surface for the meta-graph the pathfinder consults.
+
+### Walker wait UI (ready)
+
+[AutoWalkService](../src/Genie.App/Services/AutoWalkService.cs) already understands cross-zone `WalkStep`s: `DispatchNextStep` surfaces the expected wait window and runs a countdown ("~4:23 left") in the Mapper indicator strip while waiting for the destination zone to fingerprint in. So the walker's *presentation* of a cross-zone hop is built — it just isn't being fed multi-zone plans yet.
+
+## What remains
+
+1. **Feed multi-zone plans to the walker.** `AutoWalkService.Start` (or a new entry point) needs to call `MultiZonePathfinder.FindPath` when the destination is in a different zone, and translate the resulting `WalkStep` list into the walk loop (it currently takes a `List<string>` of moves from the single-zone `FindPath`).
+2. **Cross-zone arrival detection.** On a cross-zone step, the walk advances when the destination zone's room becomes current (the same fingerprint resolution `OnRoomChanged` already does, plus the `RoomNotFoundInZone` → auto-load-zone path in the mapper).
+3. **A travel entry point.** Today the only walk trigger is clicking a room in the active zone. Cross-zone travel needs either a destination picker that spans zones or a named-destination registry.
+
+## Design alignment
+
+The broader plan — skill-weighted paths, the user-editable connection database, transit modelling, and the phased rollout — lives in [AUTOMAPPER_DESIGN.md](AUTOMAPPER_DESIGN.md). This page tracks the multi-zone slice of that work specifically.
+
+Note that Genie 5 deliberately does **not** aim to port the whole of the community `travel.cmd` into the engine. Escape recipes for un-mappable starting rooms, premium-account shortcuts, and ferry-state recovery are well-suited to scripts and stay there; the engine version targets the common land + scheduled-transit routes, with the script remaining the fallback for the long tail.
+
+## Code references
+
+- **[MultiZonePathfinder.cs](../src/Genie.Core/Mapper/MultiZonePathfinder.cs)** — lazy-loading Dijkstra, `WalkStep` / `MultiZonePath`.
+- **[ZoneConnection.cs](../src/Genie.Core/Mapper/ZoneConnection.cs)** — the cross-zone edge model.
+- **[ZoneConnectionsRepository.cs](../src/Genie.Core/Mapper/ZoneConnectionsRepository.cs)** — `ZoneConnections.xml` I/O + first-launch seeding.
+- **[ZoneConnections.baseline.xml](../src/Genie.Core/Mapper/Resources/ZoneConnections.baseline.xml)** — the embedded starter template.
+- **[ZoneConnectionsViewModel.cs](../src/Genie.App/ViewModels/ZoneConnectionsViewModel.cs)** — the editor.
+- **[AutoWalkService.cs](../src/Genie.App/Services/AutoWalkService.cs)** — the walker (with cross-zone wait UI ready).

--- a/docs/scripting-engine.md
+++ b/docs/scripting-engine.md
@@ -1,0 +1,179 @@
+# Scripting Engine
+
+This page covers [ScriptEngine](../src/Genie.Core/Scripting/ScriptEngine.cs) — the runtime that drives Genie 4 `.cmd` scripts. It's the centre of most "engine vs. script" timing questions, so the execution model below is worth internalising before changing anything in it.
+
+The script *language* (Genie 4 dialect: `put`, `gosub`, `matchwait`, `action … when …`, etc.) is documented by the original Genie 4 wiki, and Genie 5 implements it faithfully. This page focuses on **how Genie 5 executes that language**, how it's wired into the rest of the engine, and where the DragonRealms protocol shapes its timing.
+
+## Where it sits
+
+The engine is constructed and wired in [GenieCore](../src/Genie.Core/GenieCore.cs#L252):
+
+```csharp
+Scripts = new ScriptEngine(
+    scriptsDir:    Config.ScriptDir,
+    typeAhead:     _typeAhead,
+    sendCommand:   cmd => _connection.SendCommandAsync(cmd),
+    echo:          msg => { EchoLine(msg); ScriptOutputLine(msg); },
+    handleHashCmd: cmd => Commands.ProcessInput(cmd));
+
+Scripts.InRoundtime               = () => state.Combat.InRoundTime;
+Scripts.RoundTimeRemainingSeconds = () => (int)Math.Ceiling(state.Combat.RoundTimeRemaining);
+```
+
+So the engine is decoupled from the network and UI through four callbacks: send a command, echo text, run a `#cmd` (handed to [CommandEngine](../src/Genie.Core/Commanding/CommandEngine.cs)), and query roundtime from the live [GameState](../src/Genie.Core/GameState.cs). Script-readable `$variables` are mirrored separately by [ScriptGlobalsSync](../src/Genie.Core/Scripting/ScriptGlobalsSync.cs) — see [line-pipeline.md](line-pipeline.md#scriptglobalssync--genie-4-reserved-variables).
+
+The three events that drive execution are routed from the parser in `GenieCore._gameEventSub`:
+
+| Event | Engine call | Unblocks |
+| --- | --- | --- |
+| `TextEvent` | `Scripts.OnGameLine(text)` | `matchwait`, `waitfor`/`waitforre`, actions |
+| `PromptEvent` | `Scripts.OnPrompt()` | `wait`, type-ahead accounting, RT-gate recheck |
+| `NavEvent` | `Scripts.OnRoomChanged()` | `move`, `nextroom` |
+
+## Model
+
+A script is a **flat list of statements** parsed from one or more `.cmd` files into a [ScriptInstance](../src/Genie.Core/Scripting/ScriptInstance.cs). At any moment a running instance is in one of three macro-states:
+
+- **Running** — ready to execute the next statement.
+- **Blocked** — paused on a timer, prompt, match, eval, or roundtime gate.
+- **Finished** — dropped from the active list.
+
+Scripts do **not** run on their own thread. They are advanced synchronously off the events above (and a dispatcher timer for pure pauses). The engine yields between statements so a long script can't freeze the app.
+
+## Parser
+
+[ScriptParser.Parse](../src/Genie.Core/Scripting/ScriptParser.cs) turns a file into a `ScriptInstance` in four stages:
+
+1. **Include expansion** — `include foo` is recursively replaced with `foo.cmd` from the scripts directory. Cycles are detected; a missing include becomes an `echo` line rather than a crash.
+2. **Inline-conditional normalisation** — `if X then put Y` is rewritten to block form (`if X then { put Y }`) so the jump-table code handles every conditional uniformly. `begin`/`end` are translated to `{`/`}`.
+3. **Line list + label table** — every line becomes a `ScriptLine`; `label:` lines populate the label table for O(1) `goto`/`gosub`.
+4. **If/else/while jump tables** — pre-computed at parse time so each conditional executes in O(1) at runtime with no forward scanning for the matching brace.
+
+## Tick loop and blocking
+
+The engine advances scripts in a bounded loop driven by the events above plus a dispatcher timer for pure timers (`pause`/`delay`) and the roundtime wakeup. Per instance, the loop checks unblock conditions in order — user pause, `pause`/`wait`/`delay`, `matchwait` deadline, `waitfor` deadline, `waiteval` re-evaluation, the roundtime gate — before executing the next statement. The per-tick statement budget is capped so a runaway `goto` loop can't monopolise the thread; the script resumes on the next tick instead.
+
+### The roundtime gate
+
+DR's server **does not** emit a prompt when roundtime expires — it only prompts in response to commands. So once a script is RT-gated, nothing in the natural event flow will wake it. The gate schedules a one-shot timer for the remaining roundtime (read live from `GameState.Combat.RoundTimeRemaining` via the `RoundTimeRemainingSeconds` callback) and re-checks when it fires. Roundtime is computed from the absolute `<roundTime>` epoch the parser captured, so it's correct regardless of whether `<roundTime>` or `<prompt>` arrived first.
+
+### Type-ahead
+
+`put`/`send` to the game contribute to an in-flight counter decremented on each `OnPrompt`. A shared [TypeAheadSession](../src/Genie.Core/Scripting/TypeAheadSession.cs) caps how many commands may be outstanding; it auto-calibrates downward when the server replies *"Sorry, you may only type ahead N commands."* Holding the script-side cap tight means a script sees a full server response (and any embedded `<roundTime>`) before the next game-bound `put` is considered.
+
+## Statement reference
+
+Listed by category. For exact semantics, read the `case` arms in [ScriptEngine.cs](../src/Genie.Core/Scripting/ScriptEngine.cs).
+
+### Flow control
+
+| Statement | Notes |
+| --- | --- |
+| `goto label` | Jump to `label:`. Unknown labels stop the script. |
+| `gosub label [args]` | Push return PC + a fresh `$0..$9` frame (gosub args), jump. `gosub clear` wipes the stacks without jumping. |
+| `return` | Pop the gosub + `$`-frame stacks; with no caller the script ends. |
+| `exit` | Stop immediately; fires the finished event. |
+| `if X then …` / `… { } elseif … else { }` | Inline form normalised to block form at parse time; block form uses parser-built jump tables. |
+| `while X { … }` | Tests on entry; the closing `}` loops back to re-test. |
+| `shift` | Shift `%1..%9` script args left by one. |
+
+### Sending to the game
+
+| Statement | Notes |
+| --- | --- |
+| `put text` / `send text` | Send to the server. Multiple `;`-chained commands drain one per tick. |
+| `put #cmd` | Routed as a meta-command to [CommandEngine](../src/Genie.Core/Commanding/CommandEngine.cs) (`#var`, `#tvar`, `#echo`, …) — not sent to the server. |
+| `put .script args` | Launch `script.cmd` as a sub-script; does not consume type-ahead. |
+| `move text` | Send `text`, then block until a new room arrives (`NavEvent` / `OnRoomChanged`), or a movement-failure line unblocks it. |
+| `nextroom` | Block for the next room change without sending anything. |
+
+### Timers and blocking
+
+| Statement | Blocks until | RT-aware? |
+| --- | --- | --- |
+| `pause N` | N seconds elapsed | yes — the gate checks roundtime before the next statement |
+| `wait` | next `<prompt>` | yes |
+| `delay N` | N seconds elapsed | no — explicitly bypasses the RT gate (webbed/stunned sleeps) |
+| `move` / `nextroom` | new room arrives | n/a |
+
+### Pattern matching
+
+| Statement | Notes |
+| --- | --- |
+| `match label literal` / `matchre label regex` | Register a pattern; `matchwait [N]` then blocks until a line matches (first match wins), with optional N-second timeout. |
+| `waitfor text` / `waitforre regex` | Block until a line contains the substring / matches the regex (single-shot). |
+| `waiteval expr` | Block until a [ScriptExpression](../src/Genie.Core/Scripting/ScriptExpression.cs) evaluates true; re-evaluated each tick so state changes (vitals, indicators) unblock it. |
+
+Regex captures from `matchre`/`waitforre`/actions land in the current `$0..$9` frame, not in the `%N` script args.
+
+### Variables and math
+
+| Statement | Notes |
+| --- | --- |
+| `var name value` (and `setvariable`, `setvar`, …) | Set `%name`. Value is substituted before storage. |
+| `unvar name` (and synonyms) | Remove `%name`. |
+| `math var op N` | In-place `add`/`subtract`/`multiply`/`divide`/`set`. |
+| `eval var expr` / `evalmath var expr` | Evaluate via `ScriptExpression`; `evalmath` coerces to numeric. |
+| `random low high` | Uniform random into `%r`. |
+| `timer start`/`stop`/`clear` | Per-script timer baseline; `%timer` reads live elapsed seconds. |
+
+### Actions
+
+| Statement | Notes |
+| --- | --- |
+| `action body when pattern` / `whenre pattern` | Register a regex action; on a matching line, run `body` (captures in a pushed `$`-frame). |
+| `action body when eval expr` | Eval action — fires on the rising edge of `expr` becoming true. |
+| `action (label) on`/`off`/`remove`, `action on`/`off`/`clear` | Enable/disable/drop actions by label or globally. |
+
+### Other
+
+| Statement | Notes |
+| --- | --- |
+| `echo text` | Print to the echo channel (main window + Scripts panel), prefixed by the engine. |
+| `debug N` | Per-instance trace verbosity (1 = goto/gosub/return … 10 = every line). |
+| `save N value` | Genie 4 `%s` storage. |
+| `js …` / `plugin …` | Parsed for Genie 4 parity; execution is limited/stubbed (JavaScript scripting is a roadmap item). |
+
+## Variables and scope
+
+Two namespaces, by prefix:
+
+| Prefix | Namespace | Lifetime | Set by |
+| --- | --- | --- | --- |
+| `%name` | per-instance `Vars` | the script | `var`/`math`/`eval…`; `%0..%9` seeded with script args |
+| `$name` | engine-wide `Globals` | the session | [ScriptGlobalsSync](../src/Genie.Core/Scripting/ScriptGlobalsSync.cs) (live state) and `#var`/`#tvar` |
+| `$0..$9` | top `$`-frame | gosub call OR latest regex match | `gosub args`, `matchre`, `waitforre`, action firing |
+
+`%` reads `Vars` only. `$` reads the top `$`-frame (for `$0..$9`), then falls back to `Globals`. Substitution rules (right-shrinking name search for `[A-Za-z0-9_.-]` identifiers, `%%name`/`$$name` double-eval, `%name(N)` pipe-array indexing) follow Genie 4.
+
+### Engine-set globals
+
+These are mirrored by [ScriptGlobalsSync](../src/Genie.Core/Scripting/ScriptGlobalsSync.cs) at event time (not on access). A non-exhaustive list:
+
+| Global | Source |
+| --- | --- |
+| `$health`, `$mana`, `$spirit`, `$stamina`/`$fatigue`, `$concentration`, `$encumbrance` | `<progressBar>` |
+| `$roundtime`, `$casttime` | `<roundTime>`/`<castTime>` (live seconds remaining) |
+| `$righthand`/`$righthandnoun`/`$righthandid` (and `left*`) | `<right>`/`<left>` |
+| `$preparedspell`, `$stance` | `<spell>`, `pc stance` |
+| `$standing`, `$kneeling`, `$prone`, `$sitting`, `$stunned`, `$hidden`, `$invisible`, `$dead`, `$webbed`, `$joined`, `$bleeding`, `$poisoned`, `$diseased` | `<indicator>` (`"1"`/`"0"`) |
+| `$north`, `$northeast`, … `$up`, `$down`, `$out` | `<compass>` (per-exit `"1"`/`"0"`) |
+| `$roomname`, `$roomdesc`, `$roomexits`, `$roomobjs`, `$roomplayers`, `$gameroomid` | room `<component>` / `<nav>` |
+| `$charactername`, `$gamename`/`$game`, `$connected` | session |
+
+Because these are mirrored at event time, use `timer start` / `%timer` for wall-clock waits rather than diffing `$roundtime` between prompts.
+
+## Diagnostics
+
+- **Per-script** — `debug 5+` in a script traces its reactions (actions at 5, every line at 10), through the echo channel.
+- **Scripts panel** — script-originated output (`[script]`, `[dbg:N]`, in-script `#echo`) is forked to the Scripts panel via `ScriptOutputLine` so it has its own scrollback ([GenieCore.cs:252](../src/Genie.Core/GenieCore.cs#L252)).
+
+## Code references
+
+- **[ScriptEngine.cs](../src/Genie.Core/Scripting/ScriptEngine.cs)** — tick loop, dispatch table, action firing, type-ahead gate, RT gate.
+- **[ScriptInstance.cs](../src/Genie.Core/Scripting/ScriptInstance.cs)** — per-script state; the fields here are what makes a blocked script blocked.
+- **[ScriptParser.cs](../src/Genie.Core/Scripting/ScriptParser.cs)** — include expansion, inline-conditional normalisation, jump tables.
+- **[ScriptExpression.cs](../src/Genie.Core/Scripting/ScriptExpression.cs)** — evaluator for `if`/`eval`/`evalmath`/`waiteval`/`action … when eval`.
+- **[TypeAheadSession.cs](../src/Genie.Core/Scripting/TypeAheadSession.cs)** — shared, auto-calibrated type-ahead cap.
+- **[ScriptGlobalsSync.cs](../src/Genie.Core/Scripting/ScriptGlobalsSync.cs)** — live state → `$` globals.
+- **[GenieCore.cs](../src/Genie.Core/GenieCore.cs)** — construction, callbacks, event routing.

--- a/wiki/Application-Folders.md
+++ b/wiki/Application-Folders.md
@@ -1,0 +1,84 @@
+# Application Folders
+
+Genie 5 keeps all of your personal data — scripts, maps, logs, settings, per-character profiles — in a single per-user folder. Knowing where it lives is useful for backing up before an upgrade, editing scripts in your own editor, pointing the import dialog at a Genie 4 install, and syncing across machines.
+
+## Where Genie 5 lives
+
+The location is resolved by [AppPaths.Discover](../src/Genie.Core/Runtime/AppPaths.cs):
+
+### macOS
+
+```
+~/Library/Application Support/Genie5/
+```
+
+Paste that into Finder's **Go → Go to Folder…** (`⇧⌘G`). `Library` is hidden by default; the Go-to dialog reveals it.
+
+### Windows
+
+```
+%APPDATA%\Genie5\
+```
+
+…which resolves to `C:\Users\<you>\AppData\Roaming\Genie5\`. Paste `%APPDATA%\Genie5` into Explorer's address bar.
+
+### Linux
+
+```
+$XDG_DATA_HOME/Genie5/      # or, if XDG_DATA_HOME is unset:
+~/.local/share/Genie5/
+```
+
+### Portable mode
+
+If a folder named `Config` exists **next to the Genie executable**, Genie 5 runs in *portable* mode and keeps everything alongside the app instead of in the per-user location. Useful for a USB-stick or self-contained install. (This is the first thing `AppPaths.Discover` checks.)
+
+## What's inside
+
+```
+Genie5/
+├── Config/      ← settings.cfg + rule .cfg files (shared / non-character)
+├── Profiles/    ← per-character config: Profiles/<Char>-<Account>/*.cfg
+├── Scripts/     ← your .cmd files
+├── Maps/        ← zone files (Map##_*.xml) + ZoneConnections.xml
+├── Logs/        ← AutoLog output, one file per character per session
+├── Sounds/      ← sound files for #play / triggers
+├── Plugins/     ← plugin host (roadmap)
+└── Art/         ← image assets
+```
+
+| Folder | What's in it | When to touch |
+| --- | --- | --- |
+| `Config/` | `settings.cfg` (app settings) and the shared rule files: `aliases.cfg`, `triggers.cfg`, `highlights.cfg`, `substitutes.cfg`, `gags.cfg`, `macros.cfg`, `variables.cfg`, `classes.cfg`. Each is a plain-text list of the commands that recreate the rules. | Mostly managed via **Edit → Configuration…**. Hand-editable — Genie 5 reloads on next launch. |
+| `Profiles/` | One subfolder per character (`<Char>-<Account>/`) holding that character's own copy of the rule `.cfg` files. The first time a character connects, the folder is seeded from your shared `Config/` files, then diverges independently. | Created automatically. Edit the per-character files here, or via the GUI while that character is connected. |
+| `Scripts/` | Your `.cmd` script files, plus any helper scripts you pull from the community repo. | Drop any script here to run it as `.scriptname` (or `put .scriptname`). |
+| `Maps/` | Zone files in Genie 4's XML format (`Map1_Crossing.xml`, …) and `ZoneConnections.xml` (the cross-zone transit graph). | Populated via **File → Import from Genie 4…** or **File → Update Maps from Official Repo…**. Jump there via **File → Open Maps Folder**. |
+| `Logs/` | When AutoLog is on, each session writes a `<character>_<timestamp>` log of plain in/out text. | Read-only from the app's view. Safe to delete or archive. |
+
+> **Note on formats.** Genie 5 stores rule config as Genie 4-style `.cfg` files (one command per line) and zone maps as Genie 4-style XML — not JSON. This keeps round-tripping with the Genie 4 ecosystem and the community Maps repo clean.
+
+## Per-character profiles
+
+Settings split into two tiers:
+
+- **Shared** (`Config/`) — the baseline, used by sessions without a character (LIST mode, dev replay).
+- **Per-character** (`Profiles/<Char>-<Account>/`) — each character gets its own aliases/triggers/etc., seeded once from the shared baseline. So your combat triggers on one character don't follow you onto a shopping alt.
+
+The active profile directory is chosen at connect time from the character + account names.
+
+## Backups, syncing, multiple machines
+
+Everything in `Genie5/` is plain text (`.cfg` / `.cmd` / `.xml` / `.log`). Copy the whole folder to a backup drive or sync it via Dropbox / iCloud / OneDrive; Genie 5 picks it up on the destination machine next launch. To share GUI rules but keep scripts machine-local, sync only `Config/` and `Profiles/`.
+
+## Resetting to defaults
+
+1. **Quit Genie 5.**
+2. **Rename** (don't delete) the `Genie5/` folder to `Genie5-old/`.
+3. Launch — a fresh empty `Genie5/` is created.
+4. Recover specific files later by copying them back from `Genie5-old/` while the app is closed.
+
+This is also the clean way to check "does my bug reproduce on a fresh install?" before reporting it.
+
+## Why this location?
+
+`~/Library/Application Support` (macOS), `%APPDATA%` (Windows), and `$XDG_DATA_HOME` (Linux) are the standard per-user "non-document" data locations. They survive app reinstalls, get backed up by Time Machine / OneDrive, don't clutter your home directory, and aren't shared between OS users. The folder is created on first launch — nothing to set up in advance.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,37 @@
+# Genie 5
+
+Genie 5 is a cross-platform client for [DragonRealms](https://www.play.net/dr), Simutronics' text MMO. It's a from-scratch rewrite of [Genie 4](https://github.com/GenieClient) on .NET 8 and [Avalonia](https://avaloniaui.net/), preserving Genie 4's scripting / mapping / triggering features while running natively on **Windows, macOS, and Linux**.
+
+> ⚠️ **Alpha.** Genie 5 is in active development, targeting parity with the most-used 80% of Genie 4. Expect rough edges. Until pre-built downloads ship, you run it from source — see [Installation](Installation.md).
+
+## New here? Start with
+
+1. **[Installation](Installation.md)** — build and run the client on Windows, macOS, or Linux.
+2. **[Application Folders](Application-Folders.md)** — where Genie 5 keeps your scripts, maps, logs, and config.
+3. **[Importing from Genie 4](Importing-Genie4-Config.md)** — bring over your aliases, triggers, highlights, etc. from an existing Genie 4 install.
+4. **[Updating Maps and Scripts](Updating-Maps-and-Scripts.md)** — pull the latest zone maps from the community repo.
+
+## Connecting
+
+Use **File → Connect…**. Genie 5 connects three ways:
+
+- **Simutronics SGE login** — the standard "log in with your DragonRealms account" flow. Enter your account name and password, click **Fetch** to retrieve your character list, pick a character, and connect. Genie 5 handles SGE auth and finds the right game server. (See the [SGE protocol notes](../docs/SGE_PROTOCOL.md) for the wire-level detail.)
+- **Lich proxy** — point Genie at a running [Lich 5](https://github.com/elanthia-online/lich-5) on `127.0.0.1:8000`; your Ruby scripts keep working and Genie sees a clean stream.
+- **Dev replay** — replay a recorded raw-XML session through the engine (handy for development).
+
+Saved connections are stored as profiles with the password encrypted on disk (AES-256-GCM). DragonRealms is the supported game; the engine is built around DR's XML protocol.
+
+## Where this wiki fits
+
+| You want… | Look here |
+| --- | --- |
+| To install, configure, or use Genie 5 | This wiki (you're here). |
+| To understand the parser, scripting engine, or mapper internals | The [`docs/` folder](../docs/) in the repository. |
+| To file a bug or request a feature | The [Issues tab](https://github.com/GenieClient/Genie5/issues). |
+| To contribute code | [CONTRIBUTING.md](../CONTRIBUTING.md). PRs welcome. |
+
+## Community resources
+
+- **Maps repo:** [GenieClient/Maps](https://github.com/GenieClient) — community zone XML for DR, pulled on demand via **File → Update Maps from Official Repo…** (see [Updating Maps and Scripts](Updating-Maps-and-Scripts.md)).
+- **Genie 4** — the original client. Its wiki remains the authoritative reference for the scripting language (`put`, `gosub`, `matchwait`, …), since Genie 5 replicates the Genie 4 `.cmd` dialect.
+- **Policy compliance** — Genie 5 is designed to live within Simutronics' [Allowed Software policy](https://elanthipedia.play.net/DragonRealms_Policy:_Allowed_Software): no auto-reconnect, attended-mode auto-walk only, advisor-only AI. See the [project README](../README.md#dragonrealms-policy-compliance).

--- a/wiki/Importing-Genie4-Config.md
+++ b/wiki/Importing-Genie4-Config.md
@@ -1,0 +1,71 @@
+# Importing Genie 4 Config
+
+If you're coming from Genie 4, you don't have to recreate your aliases, triggers, highlights, and so on by hand. Genie 5 reads Genie 4's `.cfg` files directly and folds their contents into your Genie 5 setup.
+
+## What can be imported
+
+The **File → Import from Genie 4…** dialog imports these rule categories (each with its own checkbox so you can pick a subset):
+
+| Genie 4 file | Genie 5 destination |
+| --- | --- |
+| `aliases.cfg` | Aliases |
+| `triggers.cfg` | Triggers (pattern + command + class association) |
+| `highlights.cfg` | Highlights (fore/back colours) |
+| `substitutes.cfg` | Substitutes (text rewrite rules) |
+| `gags.cfg` | Gags (line suppression) |
+| `macros.cfg` | Macros (keyboard shortcuts) |
+| `variables.cfg` | Variables (persistent `%var` values) |
+| `classes.cfg` | Classes (boolean on/off toggles) |
+
+The importer also understands `names.cfg` (name highlights) and `presets.cfg` (colour scheme) where present.
+
+## Finding your Genie 4 install
+
+Genie 4 stores its `.cfg` files in a `Config` folder, typically:
+
+| OS | Path |
+| --- | --- |
+| Windows (default) | `%LOCALAPPDATA%\Genie\Config\` |
+| Windows (portable) | the `Config\` subfolder of wherever you extracted Genie |
+| Wine on macOS/Linux | inside the wineprefix, e.g. `~/.wine/drive_c/users/<you>/Local Settings/Application Data/Genie/Config/` |
+
+Look for a folder containing `aliases.cfg`, `triggers.cfg`, etc. — that's your source.
+
+> **Multiple Genie 4 profiles?** Each profile usually has its own `.cfg` set. Pick one character's folder first; you can re-run the import later against another folder to layer on more rules.
+
+## Running the import
+
+1. Launch Genie 5 and choose **File → Import from Genie 4…**.
+2. **Source folder** — click **Browse…** and select your Genie 4 `Config` directory. Genie 5 **probes** the folder and shows a count next to each category (e.g. "Triggers: 45"), so you can confirm it found the right place before committing.
+3. **Per-category checkboxes** — untick anything you don't want (Highlights, Triggers, Substitutes, Gags, Aliases, Macros, Variables, Classes).
+4. **Target** — choose where the rules land:
+   - **Current character's profile** — imports into the connected character's `Profiles/<Char>-<Account>/` set.
+   - **Global / shared config** — imports into the shared `Config/` baseline.
+   (See [Application Folders](Application-Folders.md) for the difference.)
+5. **Mode**:
+   - **Merge** — keep existing rules; incoming rules with a matching key overwrite. Good default.
+   - **Add only** — append everything without overwriting.
+   - **Replace** — clear that category in Genie 5 first, then import. Clean for a one-shot migration; destructive if you'd already configured Genie 5.
+6. Click **Import**.
+
+When it finishes, the result line reports per-category counts (imported / skipped). Skipped lines are usually a malformed pattern in the source — those rows are simply not added. **The import is read-only against your Genie 4 files** — the originals on disk are untouched.
+
+## What's NOT imported
+
+- **Scripts (`*.cmd`)** — these aren't `.cfg`; they're plain text in Genie 4's `Scripts` folder. Copy them straight into Genie 5's [Scripts folder](Application-Folders.md) and run them as `.scriptname`.
+- **Maps (`*.xml`)** — imported through the mapper, not this dialog. See [Updating Maps and Scripts](Updating-Maps-and-Scripts.md). (Genie 5 uses the same Genie 4 XML map format, so maps largely carry over directly.)
+- **Account passwords** — for security, Genie 5 never reads Genie 4's stored credentials. Re-enter once via **File → Connect…** and save as a Genie 5 profile (encrypted AES-256-GCM).
+- **Window layouts** — Genie 5's docking model differs from Genie 4's MDI. Re-arrange via the **Window** menu and save via **Layout → Save Layout As…**.
+
+## Re-importing
+
+You can run the import again any time. Prefer **Add only** or **Merge** for incremental top-ups and review the result counts — duplicates created by repeated imports are removed by hand via **Edit → Configuration…**.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Probe shows 0 for everything | The selected folder isn't a Genie 4 `Config` directory. Confirm it contains `aliases.cfg`. |
+| One category imports 0 | That `.cfg` is empty in your Genie 4 install. |
+| Rules use stale values | Imported `variables.cfg` carried old session state — edit via **Edit → Configuration → Variables**. |
+| Colours look slightly off | The import preserves your exact hex values; tweak via **Edit → Configuration → Highlights**. |

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,0 +1,82 @@
+# Installation
+
+Genie 5 is in **alpha**. Pre-built downloads aren't published yet, so installation currently means building from source — which is a two-command process once you have the .NET 8 SDK. This page covers all three platforms, plus what to expect from the eventual pre-built artifacts.
+
+> **Coming from Genie 4?** Install fresh first, then jump to [Importing Genie 4 Config](Importing-Genie4-Config.md) to bring your aliases, triggers, highlights, etc. across.
+
+## Prerequisites
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) — Windows, macOS, and Linux builds are all supported by Microsoft.
+- [Git](https://git-scm.com/) to clone the repository.
+
+## Build and run (all platforms)
+
+```bash
+git clone https://github.com/GenieClient/Genie5.git
+cd Genie5
+dotnet run --project src/Genie.App
+```
+
+That's it — Avalonia is a tier-1 cross-platform UI toolkit, so the same command launches the GUI on Windows, macOS, and Linux.
+
+For a faster-starting build you can compile in Release first:
+
+```bash
+dotnet build -c Release
+dotnet run -c Release --project src/Genie.App
+```
+
+## Producing a standalone executable
+
+To get a single self-contained file you can copy and double-click (no .NET install needed on the target), publish for your platform's runtime identifier:
+
+```bash
+# Windows x64
+dotnet publish src/Genie.App -c Release -r win-x64   -o publish/win-x64
+# macOS Apple Silicon
+dotnet publish src/Genie.App -c Release -r osx-arm64 -o publish/osx-arm64
+# macOS Intel
+dotnet publish src/Genie.App -c Release -r osx-x64   -o publish/osx-x64
+# Linux x64
+dotnet publish src/Genie.App -c Release -r linux-x64 -o publish/linux-x64
+```
+
+The output is a single `Genie` / `Genie.exe`. See [docs/build-and-release.md](../docs/build-and-release.md) for the full publish detail and platform packaging notes.
+
+## Platform first-launch notes
+
+Because alpha builds aren't code-signed, your OS may warn the first time you run a published executable:
+
+### macOS — Gatekeeper
+
+A published `osx-*` build is ad-hoc signed at most, so macOS may refuse the first launch ("developer cannot be verified") or report the app as "damaged":
+
+- **First launch:** in Finder, **right-click** the app → **Open** → **Open**. macOS remembers the choice.
+- **"Damaged" error:** a browser download set a quarantine attribute. Strip it:
+  ```bash
+  xattr -cr /path/to/Genie.app
+  ```
+
+(Running via `dotnet run` from source sidesteps Gatekeeper entirely.)
+
+### Windows — SmartScreen
+
+Running an unsigned `.exe` shows a blue "Windows protected your PC" panel: click **More info → Run anyway**. SmartScreen remembers it for that exact file.
+
+### Linux
+
+`dotnet run` works out of the box. A published `linux-x64` binary runs directly; mark it executable if needed (`chmod +x Genie`).
+
+## First launch
+
+On first run Genie 5 creates its per-user data folder (`~/Library/Application Support/Genie5` on macOS, `%APPDATA%\Genie5` on Windows, `~/.local/share/Genie5` on Linux) with `Config/`, `Scripts/`, `Maps/`, and `Logs/` subfolders. See [Application Folders](Application-Folders.md) for the full layout.
+
+## Pre-built artifacts (planned)
+
+Once the release pipeline lands, look for `Genie5-…-{win-x64, osx-arm64, osx-x64, linux-x64}` archives on the [Releases](https://github.com/GenieClient/Genie5/releases) page. Until then, build from source as above.
+
+## After installation
+
+- [Application Folders](Application-Folders.md) — where your data lives on disk.
+- [Importing Genie 4 Config](Importing-Genie4-Config.md) — migrate from Genie 4.
+- [Updating Maps and Scripts](Updating-Maps-and-Scripts.md) — get the latest community maps.

--- a/wiki/Updating-Maps-and-Scripts.md
+++ b/wiki/Updating-Maps-and-Scripts.md
@@ -1,0 +1,51 @@
+# Updating Maps and Scripts
+
+The DragonRealms community maintains shared zone maps (and a few helper walking scripts) in a public repository. Genie 5 can pull them directly — no separate download. This page covers updating from the official repo and importing maps from an existing Genie 4 install.
+
+## Where maps live
+
+Zone maps are XML files — one per zone — in your **Maps** folder (`Map1_Crossing.xml`, `Map60_Southern_Trade_Road.xml`, …), alongside a single `ZoneConnections.xml` that describes cross-zone transit links (boats, ferries, climb-walls). See [Application Folders](Application-Folders.md) for the path, and **File → Open Maps Folder** to jump there. Change the location with **File → Change Maps Directory…** (or `#config mapdir`).
+
+Genie 5 uses the **same Genie 4 XML map format**, so maps move between the two clients cleanly.
+
+## Updating from the official repo
+
+Choose **File → Update Maps from Official Repo…**. Genie 5 fetches the latest zone XML from the community Maps repository via [MapRepoUpdater](../src/Genie.Core/Mapper/MapRepoUpdater.cs) and reports progress in the main game window as `[mapper] …` lines.
+
+### How the merge works
+
+When an update finds a zone you already have, it doesn't blindly overwrite. It loads the upstream zone and carries your locally-collected data forward — most importantly the **`ServerRoomId`** values stamped on nodes as you played through (from `<nav rm="…"/>`). So:
+
+- **Upstream layout changes win** — new rooms, fixed exits, corrected connections come down.
+- **Your stamped room ids survive** — the work the mapper did learning your routes isn't lost.
+- **New upstream nodes** start without a server-room id and get stamped the first time you visit them.
+
+If a zone file ever gets corrupted by bad edits, delete it from the Maps folder and re-run the update to pull a fresh copy.
+
+### Auto-update on launch
+
+The `updatemapperscripts` setting (see `#config` / **Configuration…**) controls whether helper map scripts are refreshed as part of updates. Repo URLs are configurable via the `maprepo` and `scriptrepo` settings if you point Genie at a fork or mirror.
+
+## Importing maps from a Genie 4 install
+
+If you have a folder of Genie 4 `*.xml` zone files, import them once without going through the community repo:
+
+1. Use the mapper's **Import from Genie 4** path (the same migration covered for rules in [Importing Genie 4 Config](Importing-Genie4-Config.md), maps side).
+2. Point it at your Genie 4 `Maps` folder.
+3. Files are brought into your [Maps folder](Application-Folders.md).
+
+You can still run **Update Maps from Official Repo…** afterward to pull newer community versions; the merge preserves your stamped data where it can.
+
+## Cross-zone connections
+
+The transit graph the [multi-zone pathfinder](../docs/multi-zone-travel.md) uses lives in `ZoneConnections.xml` at the root of the Maps folder. On first launch Genie 5 seeds a documented starter template there. Edit it via **File → Cross-Zone Connections…** (a grid editor), or let the community Maps repo curate richer versions over time. If you delete the file deliberately, Genie 5 won't silently re-create it.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Every file shows `failed` during an update | No network, a proxy/firewall blocking the repo host, or a badly-skewed system clock (TLS handshakes fail). Local maps are never corrupted by a failed update — failed files are skipped; re-run later. |
+| Update seems to do nothing | Everything is already current — unchanged files aren't re-downloaded. |
+| A zone won't match your location | Walk through it with AutoMapper enabled so `ServerRoomId`s get stamped, or pull a fresh copy from the repo. |
+
+The updater uses the system's default network configuration, so OS-level proxy settings are honoured automatically.


### PR DESCRIPTION
# Pull Request

## Summary

Fleshes out the in-repo documentation, written against this codebase's actual
architecture (DR XML parser, GenieCore event fan-out, AutoMapperEngine +
AutoWalkService, XML maps, .cfg configs).

New developer docs (docs/): README, dr-xml-protocol, line-pipeline,
scripting-engine, mapper, multi-zone-travel, build-and-release.
New user docs (wiki/): Home, Installation, Application-Folders,
Importing-Genie4-Config, Updating-Maps-and-Scripts.

Existing docs (AUTOMAPPER_DESIGN, GENIE4_VS_GENIE5, SGE_PROTOCOL) untouched;
new pages cross-link to them rather than duplicating.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ x ] Documentation update
- [ ] Plugin update
- [ ] Map update
- [ ] Build/tooling change
- [ ] Other

## Related Issue

Closes #

## Testing

- Docs-only change — no source touched, so the `dotnet build -c Release` gate
  is unaffected (build state identical to base).
- Verified every cited source-file reference resolves on disk.
- Grounded all behavioural claims by reading the source (parser, GenieCore
  wiring, command dispatch, mapper, import) rather than porting prose — e.g.
  confirmed there is no #goto/#travel meta-command (walking is UI-driven),
  maps are XML, configs are .cfg.

## Checklist

- [ x ] I kept this pull request focused and reasonably scoped
- [ x ] I tested the change where practical
- [ x ] I updated documentation if needed
- [ x ] I understand this contribution will be distributed under the repository’s existing license
