### PR TITLE
feat(scripting): expose Genie 4 reserved variables to scripts (#45)

### DIFF
--- a/src/Genie.Core/GenieCore.cs
+++ b/src/Genie.Core/GenieCore.cs
@@ -302,7 +302,9 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
         _globalsSync = new ScriptGlobalsSync(
             state, Scripts.Globals, _parser.GameEvents,
             gameCode:      cfg.GameCode,
-            characterName: cfg.CharacterName);
+            characterName: cfg.CharacterName,
+            accountName:   cfg.AccountName,
+            clientVersion: HostVersionString);
 
         // ── Game event routing ─────────────────────────────────────────────────
         // Note: Scripts.OnGameLine already calls Extensions.DispatchGameLine internally —
@@ -417,6 +419,9 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
         // directions ("n", "go bridge", etc.) so it can correlate the
         // subsequent room change with the direction we just moved.
         AutoMapper.OnCommandSent(text);
+
+        // Genie 4 reserved $lastcommand — the last line sent to the game.
+        Scripts.Globals["lastcommand"] = text;
 
         _ = _connection.SendCommandAsync(text);
     }

--- a/src/Genie.Core/Scripting/ScriptEngine.cs
+++ b/src/Genie.Core/Scripting/ScriptEngine.cs
@@ -1837,6 +1837,15 @@ public sealed class ScriptEngine
             { value = sv; return true; }
             if (Globals.TryGetValue(name, out var gv))
             { value = gv ?? string.Empty; return true; }
+            // $scriptlist — '|'-separated names of running scripts, or "none"
+            // (Genie 4 parity). Computed on read so it's always current.
+            if (name.Equals("scriptlist", StringComparison.OrdinalIgnoreCase))
+            { value = BuildScriptList(); return true; }
+            // Genie 4 reserved clock variables ($date/$time/$unixtime/...).
+            // Computed on read so they're always current, and resolved as a
+            // final fallback so a user var of the same name can still shadow.
+            if (TryClockVar(name, out var clock))
+            { value = clock; return true; }
             return false;
         }
 
@@ -1844,6 +1853,47 @@ public sealed class ScriptEngine
         if (inst.Vars.TryGetValue(name, out var lv))
         { value = lv ?? string.Empty; return true; }
         return false;
+    }
+
+    /// <summary>
+    /// Builds the <c>$scriptlist</c> value: the names of all currently running
+    /// script instances joined with <c>'|'</c>, or the literal <c>"none"</c>
+    /// when nothing is running (Genie 4 parity).
+    /// </summary>
+    private string BuildScriptList()
+    {
+        // Snapshot to a local array first: the same unlocked access pattern the
+        // engine uses for Instances/AnyRunning, but the copy avoids enumerating
+        // the live list if a start/stop mutates it mid-read.
+        var names = _instances.ToArray().Where(i => i.Running).Select(i => i.Name);
+        var joined = string.Join("|", names);
+        return joined.Length == 0 ? "none" : joined;
+    }
+
+    /// <summary>
+    /// Resolves the Genie 4 "reserved" date/time variables, computed fresh on
+    /// each read. Formats are copied verbatim from Genie 4
+    /// (<c>Lists/Globals.cs</c>) for script parity — including the quirk that
+    /// <c>$time24</c> still appends the AM/PM designator. Returns false for any
+    /// name that isn't one of these so normal resolution can continue.
+    /// </summary>
+    private static bool TryClockVar(string name, out string value)
+    {
+        var now = DateTime.Now;
+        value = name.ToLowerInvariant() switch
+        {
+            "time"         => now.ToString("hh:mm:ss tt", CultureInfo.InvariantCulture).Trim(),
+            "time24"       => now.ToString("HH:mm:ss tt", CultureInfo.InvariantCulture).Trim(),
+            "date"         => now.ToString("M/d/yyyy",     CultureInfo.InvariantCulture).Trim(),
+            "datetime"     => now.ToString("M/d/yyyy hh:mm:ss tt", CultureInfo.InvariantCulture).Trim(),
+            "datetime24"   => now.ToString("M/d/yyyy HH:mm:ss tt", CultureInfo.InvariantCulture).Trim(),
+            "militarytime" => now.ToString("HHmm",         CultureInfo.InvariantCulture).Trim(),
+            "dayofmonth"   => now.ToString("dd",           CultureInfo.InvariantCulture).Trim(),
+            "dayofyear"    => now.DayOfYear.ToString(CultureInfo.InvariantCulture),
+            "unixtime"     => DateTimeOffset.Now.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture),
+            _              => string.Empty,
+        };
+        return value.Length > 0;
     }
 
     // Bounded LRU cache of compiled regexes, shared across all TryMatch

--- a/src/Genie.Core/Scripting/ScriptGlobalsSync.cs
+++ b/src/Genie.Core/Scripting/ScriptGlobalsSync.cs
@@ -42,20 +42,32 @@ public sealed class ScriptGlobalsSync : IDisposable
     private readonly IDisposable                 _subscription;
     private readonly string                      _gameCode;
     private readonly string                      _characterName;
+    private readonly string                      _accountName;
+    private readonly string                      _clientName;
+    private readonly string                      _clientVersion;
 
     /// <param name="gameCode">e.g. "DR" for DragonRealms. Surfaced as <c>$game</c> and <c>$gamename</c>.</param>
     /// <param name="characterName">Seeds <c>$charactername</c> until the server's component event arrives.</param>
+    /// <param name="accountName">SGE account, surfaced as <c>$account</c>.</param>
+    /// <param name="clientName">Product name, surfaced as <c>$client</c> (Genie 4 used "Genie Client 4").</param>
+    /// <param name="clientVersion">App version string, surfaced as <c>$version</c>.</param>
     public ScriptGlobalsSync(
         Models.GameState            state,
         IDictionary<string, string> globals,
         IObservable<GameEvent>      events,
         string                      gameCode      = "DR",
-        string                      characterName = "")
+        string                      characterName = "",
+        string                      accountName   = "",
+        string                      clientName    = "Genie Client 5",
+        string                      clientVersion = "")
     {
         _state         = state;
         _globals       = globals;
         _gameCode      = gameCode;
         _characterName = characterName;
+        _accountName   = accountName;
+        _clientName    = clientName;
+        _clientVersion = clientVersion;
 
         SeedInitial();
         _subscription  = events.Subscribe(OnEvent);
@@ -76,6 +88,11 @@ public sealed class ScriptGlobalsSync : IDisposable
         Set("gamename",      _gameCode);
         Set("game",          _gameCode);    // common alias used by some scripts
         Set("connected",     "1");
+
+        // Session statics — known at construction, never change for this session.
+        Set("account",       _accountName);
+        Set("client",        _clientName);
+        Set("version",       _clientVersion);
 
         // Vitals — match GameState defaults (100%).
         Set("health",        _state.Vitals.Health.ToString(CultureInfo.InvariantCulture));


### PR DESCRIPTION
# Pull Request

## Summary
Fills gaps in the reserved-variable vocabulary that scripts read as $name, so community scripts ported from Genie 4 resolve them instead of aborting on an undefined $var.

- Computed clock vars in ScriptEngine.TryResolveVar: $date, $time, $time24, $datetime, $datetime24, $militarytime, $dayofmonth, $dayofyear, $unixtime. Formats copied verbatim from Genie 4 (Lists/Globals.cs), including the $time24 "tt" quirk, for parity. Resolved as a final fallback so a user var of the same name can shadow.
- $scriptlist: '|'-separated running script names, or "none" (G4 parity), computed on read from the live instance list.
- Session statics seeded in ScriptGlobalsSync: $account, $client ("Genie Client 5"), $version (host version string).
- $lastcommand: set on every line sent to the game (ICommandHost.SendToGame).
Describe what this pull request changes.

## Type of Change

- [ ] Bug fix
- [ x ] New feature
- [ ] Documentation update
- [ ] Plugin update
- [ ] Map update
- [ ] Build/tooling change
- [ ] Other

## Related Issue

Doesn't close, but addresses some of #45 

## Testing

Verified via a throwaway harness driving the real ScriptEngine: all 11 variables round-trip through the substitution path (clock vars, scriptlist showing the running script, lastcommand, and the statics).

## Checklist

- [ x ] I kept this pull request focused and reasonably scoped
- [ x ] I tested the change where practical
- [ x ] I updated documentation if needed
- [ x ] I understand this contribution will be distributed under the repository’s existing license

## Follow-up
Follow-ups (dependency-heavy, left on the issue): $zoneid/$zonename and $roomnote (mapper state), $monstercount/$monsterlist (creature parsing), $gamehost/$gameport (resolved connection plumbing), spell-timer vars.