### PR TITLE
feat(scripting): expose Genie 4 reserved $gametime to scripts (#45)

### DIFF
--- a/src/Genie.Core/Scripting/ScriptGlobalsSync.cs
+++ b/src/Genie.Core/Scripting/ScriptGlobalsSync.cs
@@ -134,6 +134,7 @@ public sealed class ScriptGlobalsSync : IDisposable
 
         // Misc
         Set("prompt",        "");
+        Set("gametime",      "0");
         Set("monstercount",  "0");
         Set("monsterlist",   "");
     }
@@ -152,8 +153,20 @@ public sealed class ScriptGlobalsSync : IDisposable
             case RoundTimeEvent rt:    Set("roundtime", SecondsRemaining(rt.ExpiresAt)); break;
             case CastTimeEvent ct:     Set("casttime",  SecondsRemaining(ct.ExpiresAt)); break;
             case SpellEvent sp:        Set("preparedspell", sp.SpellName ?? string.Empty); break;
-            case PromptEvent p:        Set("prompt", p.Indicator);                            break;
+            case PromptEvent p:        OnPrompt(p);                                           break;
         }
+    }
+
+    private void OnPrompt(PromptEvent p)
+    {
+        Set("prompt", p.Indicator);
+
+        // Genie 4 reserved $gametime — the server's clock (Unix seconds) carried
+        // on each <prompt time='...'> tag. The parser leaves ServerTime at its
+        // default when a prompt arrives without a time attribute; guard against
+        // that so we never publish a bogus negative epoch.
+        if (p.ServerTime > DateTimeOffset.UnixEpoch)
+            Set("gametime", p.ServerTime.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture));
     }
 
     private void OnProgressBar(ProgressBarEvent bar)


### PR DESCRIPTION
## Summary
Follow-up to #50, addressing one more reserved variable from #45.

`$gametime` is the server's clock (Unix seconds) carried on each `<prompt time='...'>` tag — distinct from `$unixtime` (local wall clock). The parser already captures it as `PromptEvent.ServerTime`; this surfaces it to the script-readable globals.

- Routes `PromptEvent` through a new `OnPrompt` handler that sets `$gametime` from `ServerTime.ToUnixTimeSeconds()`.
- Guarded by `> UnixEpoch` so a prompt without a `time` attribute never publishes a bogus negative epoch.
- Seeded to `"0"` in `SeedInitial` for scripts that read it before the first prompt arrives.

## Type of Change
- [x] New feature

## Related Issue
Addresses another item from #45 (does not close it — remaining vars tracked there).

## Testing
`Genie.Core` builds clean (0 warnings / 0 errors). Change is isolated to `ScriptGlobalsSync` event routing.