### PR TITLE
feat(mapper): in-app AutoMapper editor + pan + smarter labels

### DIFF
--- a/src/Genie.App/App.axaml
+++ b/src/Genie.App/App.axaml
@@ -166,6 +166,7 @@
         <!-- cluster put it next to "zoom in" which made it easy to click  -->
         <!-- by accident while intending a zoom action.                    -->
         <Border Grid.Row="0" Background="#252525" BorderBrush="#333" BorderThickness="0,0,0,1" Padding="4,3">
+          <StackPanel Spacing="3">
           <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="4">
             <!-- Pop out (window-level action, separated from data-level cluster) -->
             <Button Grid.Column="0" Content="⬈" Padding="6,1" FontSize="11"
@@ -196,6 +197,55 @@
                     Command="{Binding ViewModel.ZoomInCommand}"
                     ToolTip.Tip="Zoom in (or mouse-wheel up over the map)"/>
           </Grid>
+
+          <!-- Editor toolbar (Genie 4 AutoMapper edit tools). Edit + Record + -->
+          <!-- New + Save are always available; the node-edit cluster (Remove / -->
+          <!-- Reset IDs / Snap / Lock / Dup) only shows in Edit mode.          -->
+          <WrapPanel Orientation="Horizontal">
+            <ToggleButton Content="✎ Edit" IsChecked="{Binding ViewModel.EditMode}"
+                          Margin="0,0,4,0" Padding="6,1" FontSize="11"
+                          ToolTip.Tip="Edit mode: click a room to select it, drag to move it. Turn off to navigate (click = nothing, right-click = Go Here)."/>
+            <ToggleButton Content="⏺ Record" IsChecked="{Binding ViewModel.AutoCreateEnabled}"
+                          Margin="0,0,4,0" Padding="6,1" FontSize="11"
+                          ToolTip.Tip="Record mode: add new rooms to the active zone as you walk into them (Genie 4 Record Mode)."/>
+            <Button Content="New" Command="{Binding ViewModel.NewZoneCommand}"
+                    Margin="0,0,4,0" Padding="6,1" FontSize="11"
+                    ToolTip.Tip="Start a new, empty zone. Save writes it to the Maps directory."/>
+            <Button Command="{Binding ViewModel.SaveMapCommand}"
+                    Margin="0,0,8,0" Padding="6,1" FontSize="11"
+                    ToolTip.Tip="Save the active zone to its XML file (Genie 4 compatible).">
+              <StackPanel Orientation="Horizontal" Spacing="3">
+                <TextBlock Text="Save"/>
+                <TextBlock Text="●" Foreground="#e0a060"
+                           IsVisible="{Binding ViewModel.IsZoneDirty}"
+                           ToolTip.Tip="Unsaved edits"/>
+              </StackPanel>
+            </Button>
+            <ToggleButton Content="Labels" IsChecked="{Binding ViewModel.FullLabels}"
+                          Margin="8,0,0,0" Padding="6,1" FontSize="11"
+                          ToolTip.Tip="OFF: show only each room's primary name. ON: show the full |-separated label list. Labels auto-place around rooms and skip when crowded; the full set is always in the hover tooltip."/>
+
+            <!-- Edit-only cluster -->
+            <StackPanel Orientation="Horizontal" Spacing="4"
+                        IsVisible="{Binding ViewModel.EditMode}">
+              <Button Content="Remove" Command="{Binding ViewModel.RemoveSelectedCommand}"
+                      Padding="6,1" FontSize="11" Background="#3a2424" Foreground="#ffcccc"
+                      ToolTip.Tip="Delete the selected room (or press Delete on the map)."/>
+              <Button Content="Reset IDs" Command="{Binding ViewModel.ResetMapIdsCommand}"
+                      Padding="6,1" FontSize="11"
+                      ToolTip.Tip="Renumber all room IDs to a dense 1..N sequence (fixes sparse ids after lots of add/remove)."/>
+              <ToggleButton Content="Snap" IsChecked="{Binding ViewModel.SnapToGrid}"
+                            Padding="6,1" FontSize="11"
+                            ToolTip.Tip="Snap dragged rooms to the grid. Genie 5 maps are grid-based, so positions always align."/>
+              <ToggleButton Content="Lock" IsChecked="{Binding ViewModel.LockPositions}"
+                            Padding="6,1" FontSize="11"
+                            ToolTip.Tip="Lock positions: rooms can be selected but not dragged."/>
+              <ToggleButton Content="Dup" IsChecked="{Binding ViewModel.AllowDuplicate}"
+                            Padding="6,1" FontSize="11"
+                            ToolTip.Tip="Allow duplicate rooms while recording — don't merge a new room into an existing one that merely looks the same."/>
+            </StackPanel>
+          </WrapPanel>
+          </StackPanel>
         </Border>
 
         <!-- ── ROW 1: map (left) + Details panel (right) ─────────────── -->
@@ -312,7 +362,14 @@
                                     Zoom="{Binding ViewModel.ZoomLevel}"
                                     MapBackgroundBrush="{Binding ViewModel.MapBackgroundBrush}"
                                     NodeClickedCommand="{Binding ViewModel.GotoNodeCommand}"
-                                    EditExitCommand="{Binding ViewModel.EditExitCommand}"/>
+                                    EditExitCommand="{Binding ViewModel.EditExitCommand}"
+                                    EditMode="{Binding ViewModel.EditMode}"
+                                    SnapToGrid="{Binding ViewModel.SnapToGrid}"
+                                    LockPositions="{Binding ViewModel.LockPositions}"
+                                    FullLabels="{Binding ViewModel.FullLabels}"
+                                    SelectedNode="{Binding ViewModel.SelectedNode, Mode=TwoWay}"
+                                    NodeMovedCommand="{Binding ViewModel.NodeMovedCommand}"
+                                    RemoveNodeCommand="{Binding ViewModel.RemoveNodeCommand}"/>
               </ScrollViewer>
             </Border>
           </Grid>
@@ -358,6 +415,36 @@
                           HorizontalAlignment="Right"
                           Command="{Binding ViewModel.SaveNotesCommand}"
                           ToolTip.Tip="Save the edited Notes back to the zone XML file. Updates immediately on disk and on the map."/>
+                </StackPanel>
+
+                <!-- ── Edit Room (edit mode only) ───────────────────── -->
+                <!-- Genie 4 AutoMapper "Edit Panel": properties of the      -->
+                <!-- selected node. Title/server-id feed the lookup index,   -->
+                <!-- so Apply rebuilds it; Color is a hex like #FFAA00.      -->
+                <StackPanel Spacing="3" IsVisible="{Binding ViewModel.EditMode}">
+                  <TextBlock Text="EDIT ROOM" Foreground="#7a92a8" FontSize="9"
+                             FontWeight="SemiBold" Margin="0,0,0,2"/>
+                  <TextBlock Text="Click a room on the map to select it."
+                             Foreground="#888" FontSize="11" TextWrapping="Wrap"
+                             IsVisible="{Binding ViewModel.SelectedNode, Converter={x:Static ObjectConverters.IsNull}}"/>
+                  <StackPanel Spacing="3"
+                              IsVisible="{Binding ViewModel.SelectedNode, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    <TextBlock Text="Title" Foreground="#888" FontSize="11"/>
+                    <TextBox Text="{Binding ViewModel.SelNodeTitle}" FontSize="11"/>
+                    <TextBlock Text="Notes / label" Foreground="#888" FontSize="11"/>
+                    <TextBox Text="{Binding ViewModel.SelNodeNotes}" FontSize="11"
+                             Watermark="e.g. Bank|Teller (| separates #goto labels)"/>
+                    <TextBlock Text="Color (hex)" Foreground="#888" FontSize="11"/>
+                    <TextBox Text="{Binding ViewModel.SelNodeColor}" FontSize="11"
+                             FontFamily="Consolas,monospace" Watermark="#FFAA00"/>
+                    <TextBlock Text="Server id" Foreground="#888" FontSize="11"/>
+                    <TextBox Text="{Binding ViewModel.SelNodeServerId}" FontSize="11"
+                             FontFamily="Consolas,monospace"/>
+                    <Button Content="Apply" Padding="8,2" FontSize="11"
+                            HorizontalAlignment="Right"
+                            Command="{Binding ViewModel.ApplyNodePropsCommand}"
+                            ToolTip.Tip="Write these fields back into the room. Save the zone to persist to disk."/>
+                  </StackPanel>
                 </StackPanel>
 
                 <!-- ── Zone ─────────────────────────────────────────── -->

--- a/src/Genie.App/Controls/MapCanvas.cs
+++ b/src/Genie.App/Controls/MapCanvas.cs
@@ -48,6 +48,10 @@ public class MapCanvas : Control
     private static readonly IBrush  CurrentStroke   = new SolidColorBrush(Color.FromRgb(0xff, 0x40, 0x40));
     private static readonly Pen     NodePen         = new(NodeStroke, 1.0);
     private static readonly Pen     CurrentPen      = new(CurrentStroke, 2.5);
+    // Selection outline (edit mode) — bright yellow dashed so it's distinct
+    // from the red "you are here" current-room outline.
+    private static readonly Pen     SelectedPen     = new(new SolidColorBrush(Color.FromRgb(0xff, 0xe0, 0x40)), 2.0)
+                                                      { DashStyle = new DashStyle(new double[] { 2, 2 }, 0) };
     private static readonly IBrush  EmptyMessageBrush = new SolidColorBrush(Color.FromRgb(0x66, 0x66, 0x66));
 
     // Edge pens — colour-coded by exit type so the player can see at a glance
@@ -65,6 +69,9 @@ public class MapCanvas : Control
     // (e.g. "Spell Library", "Pawnshop"). The Genie 4 AutoMapper uses these
     // labels as the primary way to orient the player in dense city zones.
     private static readonly IBrush  RoomLabelBrush  = new SolidColorBrush(Color.FromRgb(0xc8, 0xc8, 0xc8));
+    // Dotted leader line tying a displaced label back to its node.
+    private static readonly Pen     LabelLeaderPen  = new(new SolidColorBrush(Color.FromRgb(0x77, 0x77, 0x77)), 1.0)
+                                                      { DashStyle = new DashStyle(new double[] { 1, 2 }, 0) };
 
     // Hover badge — translucent panel + bright text drawn near the cursor.
     private static readonly IBrush  HoverBackgroundBrush = new SolidColorBrush(Color.FromArgb(0xee, 0x22, 0x22, 0x22));
@@ -135,6 +142,61 @@ public class MapCanvas : Control
     public static readonly StyledProperty<IBrush?> MapBackgroundBrushProperty =
         AvaloniaProperty.Register<MapCanvas, IBrush?>(nameof(MapBackgroundBrush));
 
+    // ── Editor styled properties (Genie 4 AutoMapper edit toolbar) ─────────
+
+    /// <summary>When true, left-click selects a node and drag moves it
+    /// (edit mode). When false the canvas is a read-only navigator and
+    /// left-click does nothing (Go Here lives on the right-click menu).</summary>
+    public static readonly StyledProperty<bool> EditModeProperty =
+        AvaloniaProperty.Register<MapCanvas, bool>(nameof(EditMode));
+
+    /// <summary>Snap dragged nodes to the integer grid (always on in practice —
+    /// the Genie 4 map format stores positions as 20px multiples, so off-grid
+    /// placement can't round-trip; the toggle biases rounding vs floor).</summary>
+    public static readonly StyledProperty<bool> SnapToGridProperty =
+        AvaloniaProperty.Register<MapCanvas, bool>(nameof(SnapToGrid), defaultValue: true);
+
+    /// <summary>When true, nodes can be selected but not dragged (Genie 4
+    /// "Lock Positions") — guards against accidentally nudging a clean map.</summary>
+    public static readonly StyledProperty<bool> LockPositionsProperty =
+        AvaloniaProperty.Register<MapCanvas, bool>(nameof(LockPositions));
+
+    /// <summary>When true, room labels show the full <c>|</c>-separated Notes
+    /// string (all #goto labels). When false (default) only the primary label
+    /// (first segment) is drawn — much cleaner in dense zones. The full set is
+    /// always available in the hover badge.</summary>
+    public static readonly StyledProperty<bool> FullLabelsProperty =
+        AvaloniaProperty.Register<MapCanvas, bool>(nameof(FullLabels));
+
+    /// <summary>The currently selected node (edit mode). Outlined in yellow.</summary>
+    public static readonly StyledProperty<MapNode?> SelectedNodeProperty =
+        AvaloniaProperty.Register<MapCanvas, MapNode?>(nameof(SelectedNode),
+            defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
+
+    /// <summary>Invoked with the moved <see cref="MapNode"/> after a drag
+    /// completes, so the VM can mark the zone dirty + repaint.</summary>
+    public static readonly StyledProperty<ICommand?> NodeMovedCommandProperty =
+        AvaloniaProperty.Register<MapCanvas, ICommand?>(nameof(NodeMovedCommand));
+
+    /// <summary>Invoked with the selected <see cref="MapNode"/> (or null) when
+    /// the selection changes in edit mode.</summary>
+    public static readonly StyledProperty<ICommand?> SelectNodeCommandProperty =
+        AvaloniaProperty.Register<MapCanvas, ICommand?>(nameof(SelectNodeCommand));
+
+    /// <summary>Invoked with a <see cref="MapNode"/> to delete it (Remove Room
+    /// context-menu item / Delete key in edit mode).</summary>
+    public static readonly StyledProperty<ICommand?> RemoveNodeCommandProperty =
+        AvaloniaProperty.Register<MapCanvas, ICommand?>(nameof(RemoveNodeCommand));
+
+    public bool      EditMode          { get => GetValue(EditModeProperty);          set => SetValue(EditModeProperty, value); }
+    public bool      SnapToGrid        { get => GetValue(SnapToGridProperty);        set => SetValue(SnapToGridProperty, value); }
+    public bool      LockPositions     { get => GetValue(LockPositionsProperty);     set => SetValue(LockPositionsProperty, value); }
+    public bool      FullLabels        { get => GetValue(FullLabelsProperty);        set => SetValue(FullLabelsProperty, value); }
+    public MapNode?  SelectedNode      { get => GetValue(SelectedNodeProperty);      set => SetValue(SelectedNodeProperty, value); }
+    public ICommand? NodeMovedCommand  { get => GetValue(NodeMovedCommandProperty);  set => SetValue(NodeMovedCommandProperty, value); }
+    public ICommand? SelectNodeCommand { get => GetValue(SelectNodeCommandProperty); set => SetValue(SelectNodeCommandProperty, value); }
+    public ICommand? RemoveNodeCommand { get => GetValue(RemoveNodeCommandProperty); set => SetValue(RemoveNodeCommandProperty, value); }
+
     public MapZone?  Zone               { get => GetValue(ZoneProperty);               set => SetValue(ZoneProperty, value); }
     public MapNode?  CurrentNode        { get => GetValue(CurrentNodeProperty);        set => SetValue(CurrentNodeProperty, value); }
     public int       Level              { get => GetValue(LevelProperty);              set => SetValue(LevelProperty, value); }
@@ -149,11 +211,31 @@ public class MapCanvas : Control
     private MapNode? _hoveredNode;
     private Point    _cursor;
 
+    // ── Drag state (edit mode) ────────────────────────────────────────────
+    private bool _dragging;
+    private int  _dragMinX;   // bounds origin cached at drag start (stable while dragging)
+    private int  _dragMinY;
+    private int  _dragOrigX;  // selected node's grid position at drag start —
+    private int  _dragOrigY;  // used to skip the move/dirty when it didn't change
+
+    // ── Pan state (grab-scroll the view) ──────────────────────────────────
+    private bool          _panning;
+    private Point         _panLast;    // last pointer pos in ScrollViewer coords
+    private ScrollViewer? _scroller;   // cached parent scroll viewer
+
+    public MapCanvas()
+    {
+        // Focusable so the Delete key reaches OnKeyDown when the canvas has
+        // focus (we Focus() on pointer-press in edit mode).
+        Focusable = true;
+    }
+
     static MapCanvas()
     {
         // Any of these changing means we need to repaint AND recompute size.
         AffectsRender<MapCanvas>(ZoneProperty, CurrentNodeProperty, LevelProperty, RenderTickProperty,
-                                 ZoomProperty, CurrentRoomBrushProperty, MapBackgroundBrushProperty);
+                                 ZoomProperty, CurrentRoomBrushProperty, MapBackgroundBrushProperty,
+                                 EditModeProperty, SelectedNodeProperty, FullLabelsProperty);
         AffectsMeasure<MapCanvas>(ZoneProperty, LevelProperty, RenderTickProperty, ZoomProperty);
 
         // Auto-center on the active room whenever it changes. Walking into a
@@ -314,7 +396,14 @@ public class MapCanvas : Control
         {
             if (node.Z != Level) continue;
 
-            var rect = NodeRect(node, minX, minY);
+            var isSelected = SelectedNode is not null && node.Id == SelectedNode.Id;
+
+            // While dragging the selected node, draw it under the cursor (a
+            // visual-only offset) — its stored X/Y don't change until release,
+            // so the bounds origin stays stable and nothing else jumps.
+            var rect = (_dragging && isSelected)
+                ? new Rect(_cursor.X - NodeSize / 2, _cursor.Y - NodeSize / 2, NodeSize, NodeSize)
+                : NodeRect(node, minX, minY);
             var fill = ParseColor(node.Color) ?? DefaultNodeFill;
 
             context.FillRectangle(fill, rect);
@@ -330,34 +419,83 @@ public class MapCanvas : Control
                     : new Pen(CurrentRoomBrush, 2.5);
                 context.DrawRectangle(pen, hi);
             }
+
+            // Edit-mode selection outline (drawn outset further than the
+            // current-room ring so both are visible on the active room).
+            if (isSelected)
+                context.DrawRectangle(SelectedPen, rect.Inflate(4.0));
         }
 
-        // ── Pass 3: room labels (Notes attribute) ────────────────────────
-        // Genie 4's AutoMapper draws the "note" attribute as text next to the
-        // node rectangle — that's how Spell Library / Bank / Pawnshop etc.
-        // are tagged on the canvas. We render the same thing here. Multi-line
-        // notes (rare; usually a single short phrase) wrap naturally via
-        // FormattedText. Overlap with adjacent labels is accepted for MVP —
-        // a smarter placement pass can come later.
+        // ── Pass 3: room labels (Notes) with collision-aware placement ──────
+        // Genie 4 draws the "note" attribute next to each node (Spell Library /
+        // Bank / Pawnshop). We do the same, but place each label in the first
+        // free slot around the node (right → left → above → below) so labels
+        // don't pile up in dense zones. When a label can't sit directly to the
+        // right, a dotted leader line ties it back to its node. Important rooms
+        // (current / selected / hovered) always get drawn even when crowded;
+        // other labels are skipped rather than overlap.
         var labelTypeface = Typeface.Default;
         var labelSize     = Math.Max(9.0, 10.0 * Zoom);   // grows slightly with zoom
-        foreach (var node in Zone.Nodes.Values)
+
+        // Occupied rects seed with every visible node (labels avoid covering
+        // rooms) and grow as labels are placed.
+        var occupied = new List<Rect>();
+        foreach (var n in Zone.Nodes.Values)
+            if (n.Z == Level) occupied.Add(NodeRect(n, minX, minY));
+
+        int LabelPriority(MapNode n) =>
+            (CurrentNode  is not null && n.Id == CurrentNode.Id)  ? 0 :
+            (SelectedNode is not null && n.Id == SelectedNode.Id) ? 1 :
+            (_hoveredNode is not null && n.Id == _hoveredNode.Id) ? 2 : 3;
+
+        // Important labels first (best slots), then by id for stable placement.
+        var labelled = Zone.Nodes.Values
+            .Where(n => n.Z == Level && !string.IsNullOrEmpty(n.Notes))
+            .OrderBy(LabelPriority).ThenBy(n => n.Id);
+
+        const double gap = 4.0;
+        foreach (var node in labelled)
         {
-            if (node.Z != Level) continue;
-            if (string.IsNullOrEmpty(node.Notes)) continue;
+            var text = FullLabels ? node.Notes : node.Notes.Split('|')[0].Trim();
+            if (string.IsNullOrEmpty(text)) continue;
 
             var ft = new FormattedText(
-                node.Notes,
-                System.Globalization.CultureInfo.CurrentCulture,
-                FlowDirection.LeftToRight,
-                labelTypeface,
-                labelSize,
-                RoomLabelBrush);
+                text, System.Globalization.CultureInfo.CurrentCulture,
+                FlowDirection.LeftToRight, labelTypeface, labelSize, RoomLabelBrush);
 
             var rect = NodeRect(node, minX, minY);
-            // Position to the right of the node, vertically centered.
-            var pos  = new Point(rect.Right + 4, rect.Top + (NodeSize - ft.Height) / 2);
-            context.DrawText(ft, pos);
+            double cx = rect.Center.X, cy = rect.Center.Y, w = ft.Width, h = ft.Height;
+
+            // Candidate slots in preference order; the first (right) is the
+            // historical default and needs no leader line.
+            var cands = new (Rect r, bool leader)[]
+            {
+                (new Rect(rect.Right + gap,     cy - h / 2,         w, h), false), // right
+                (new Rect(rect.Left  - gap - w, cy - h / 2,         w, h), true),  // left
+                (new Rect(cx - w / 2,           rect.Top - gap - h, w, h), true),  // above
+                (new Rect(cx - w / 2,           rect.Bottom + gap,  w, h), true),  // below
+            };
+
+            Rect chosen = cands[0].r; bool leader = false; bool placed = false;
+            foreach (var (r, needsLeader) in cands)
+            {
+                bool clash = false;
+                foreach (var o in occupied) if (r.Intersects(o)) { clash = true; break; }
+                if (!clash) { chosen = r; leader = needsLeader; placed = true; break; }
+            }
+
+            if (!placed)
+            {
+                // Crowded. Only force-draw the important rooms; skip the rest.
+                if (LabelPriority(node) == 3) continue;
+                chosen = cands[0].r; leader = false;
+            }
+
+            if (leader)
+                context.DrawLine(LabelLeaderPen, new Point(cx, cy), chosen.Center);
+
+            context.DrawText(ft, chosen.Position);
+            occupied.Add(chosen);
         }
 
         // ── Pass 4: hover badge ───────────────────────────────────────────
@@ -370,6 +508,8 @@ public class MapCanvas : Control
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);
+        var props = e.GetCurrentPoint(this).Properties;
+
         // Right-click on a node = open a context menu with Go Here / Copy
         // Room ID / Show Details. We previously walked-immediately on right
         // click which made it too easy to start a long auto-walk by mis-
@@ -379,7 +519,7 @@ public class MapCanvas : Control
         // Building the menu per-click rather than via a static ContextMenu
         // property because the items depend on which node was hit — the
         // menu needs the MapNode reference captured at click time.
-        if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
+        if (props.IsRightButtonPressed)
         {
             var pt   = e.GetPosition(this);
             var node = HitTest(pt);
@@ -387,7 +527,148 @@ public class MapCanvas : Control
 
             ShowNodeContextMenu(node);
             e.Handled = true;
+            return;
         }
+
+        // Middle-button drag pans the view in any mode (universal grab-scroll).
+        if (props.IsMiddleButtonPressed)
+        {
+            BeginPan(e);
+            e.Handled = true;
+            return;
+        }
+
+        if (props.IsLeftButtonPressed && EditMode)
+        {
+            // Edit mode: left-click selects the hit node (or clears selection on
+            // empty space) and, unless locked, begins a drag-to-move. Pressing
+            // on empty space instead pans the view.
+            Focus();   // so the Delete key reaches OnKeyDown
+            _cursor   = e.GetPosition(this);
+            var node  = HitTest(_cursor);
+
+            SelectedNode = node;
+            if (SelectNodeCommand?.CanExecute(node) == true)
+                SelectNodeCommand.Execute(node);
+
+            if (node is not null && !LockPositions)
+            {
+                // Cache the bounds origin now so the grid math stays stable
+                // for the whole drag even as the visual node tracks the cursor.
+                ComputeOrigin(out _dragMinX, out _dragMinY);
+                _dragOrigX = node.X;
+                _dragOrigY = node.Y;
+                _dragging = true;
+                e.Pointer.Capture(this);
+            }
+            else
+            {
+                // Empty space (or positions locked) → pan instead of move.
+                BeginPan(e);
+            }
+
+            InvalidateVisual();
+            e.Handled = true;
+        }
+        else if (props.IsLeftButtonPressed)
+        {
+            // Navigate mode: left-drag grab-scrolls the map. (Go Here stays on
+            // the right-click menu, so a plain left-drag is free to pan.)
+            BeginPan(e);
+            e.Handled = true;
+        }
+    }
+
+    /// <summary>Start a grab-scroll pan: cache the parent ScrollViewer and the
+    /// pointer's position within it, capture the pointer, show the move cursor.</summary>
+    private void BeginPan(PointerPressedEventArgs e)
+    {
+        _scroller = this.FindAncestorOfType<ScrollViewer>();
+        if (_scroller is null) return;   // nothing to scroll (e.g. designer)
+        _panLast  = e.GetPosition(_scroller);
+        _panning  = true;
+        e.Pointer.Capture(this);
+        Cursor = new Cursor(StandardCursorType.SizeAll);
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+
+        if (_panning)
+        {
+            _panning = false;
+            e.Pointer.Capture(null);
+            Cursor = Cursor.Default;
+            e.Handled = true;
+            return;
+        }
+
+        if (!_dragging) return;
+
+        _dragging = false;
+        e.Pointer.Capture(null);
+
+        if (SelectedNode is { } node)
+        {
+            // Convert the release point to a grid cell using the origin cached
+            // at drag start. SnapToGrid rounds to the nearest cell; with it off
+            // we floor — both produce integer coords (the only values the
+            // Genie 4 XML format can round-trip, since export writes X*20).
+            var rawX = (_cursor.X - Padding - GridSize / 2) / GridSize + _dragMinX;
+            var rawY = (_cursor.Y - Padding - GridSize / 2) / GridSize + _dragMinY;
+            var newX = SnapToGrid ? (int)Math.Round(rawX) : (int)Math.Floor(rawX);
+            var newY = SnapToGrid ? (int)Math.Round(rawY) : (int)Math.Floor(rawY);
+
+            // Only commit + mark dirty when the room actually moved to a new
+            // grid cell. A plain click (press+release with no drag) lands back
+            // on the same cell and must not dirty the zone.
+            if (newX != _dragOrigX || newY != _dragOrigY)
+            {
+                node.X = newX;
+                node.Y = newY;
+                if (NodeMovedCommand?.CanExecute(node) == true)
+                    NodeMovedCommand.Execute(node);
+            }
+        }
+
+        InvalidateVisual();
+        e.Handled = true;
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        // Delete removes the selected room in edit mode (Genie 4 "Remove
+        // Selected Nodes/Labels"). Gated on EditMode so the key is inert in
+        // the read-only navigator.
+        if (EditMode && e.Key == Key.Delete && SelectedNode is { } node)
+        {
+            if (RemoveNodeCommand?.CanExecute(node) == true)
+            {
+                RemoveNodeCommand.Execute(node);
+                SelectedNode = null;
+                e.Handled = true;
+            }
+        }
+    }
+
+    /// <summary>Compute the current-level bounds origin (min X/Y across visible
+    /// nodes) — the same calculation Render/HitTest use to map grid → pixels.</summary>
+    private void ComputeOrigin(out int minX, out int minY)
+    {
+        minX = 0; minY = 0;
+        if (Zone is null) return;
+        int mx = int.MaxValue, my = int.MaxValue;
+        bool any = false;
+        foreach (var n in Zone.Nodes.Values)
+        {
+            if (n.Z != Level) continue;
+            if (n.X < mx) mx = n.X;
+            if (n.Y < my) my = n.Y;
+            any = true;
+        }
+        if (any) { minX = mx; minY = my; }
     }
 
     /// <summary>
@@ -452,6 +733,23 @@ public class MapCanvas : Control
         };
         if (editExitMenu is not null) items.Add(editExitMenu);
 
+        // Edit-mode-only: Remove Room. Mirrors the Delete key + the toolbar
+        // Remove button; the menu item makes it discoverable on right-click.
+        if (EditMode && RemoveNodeCommand is not null)
+        {
+            items.Add(new Separator());
+            var remove = new MenuItem { Header = "Remove Room", Foreground = new SolidColorBrush(Color.FromRgb(0xff, 0x99, 0x99)) };
+            remove.Click += (_, _) =>
+            {
+                if (RemoveNodeCommand?.CanExecute(node) == true)
+                {
+                    RemoveNodeCommand.Execute(node);
+                    if (SelectedNode?.Id == node.Id) SelectedNode = null;
+                }
+            };
+            items.Add(remove);
+        }
+
         var menu = new ContextMenu { ItemsSource = items };
 
         // Show the menu programmatically. Avalonia's ContextMenu.Open()
@@ -509,6 +807,28 @@ public class MapCanvas : Control
     {
         base.OnPointerMoved(e);
         _cursor = e.GetPosition(this);
+
+        // Grab-scroll panning: shift the ScrollViewer offset by the pointer
+        // delta (measured in the viewer's own coords so changing the offset
+        // doesn't feed back into the next reading).
+        if (_panning && _scroller is not null)
+        {
+            var p     = e.GetPosition(_scroller);
+            var delta = p - _panLast;
+            _scroller.Offset -= delta;
+            _panLast = p;
+            return;
+        }
+
+        // While dragging a node, just track the cursor and repaint — the node
+        // is drawn under the cursor and committed to a grid cell on release.
+        if (_dragging)
+        {
+            _hoveredNode = null;   // suppress the hover badge mid-drag
+            InvalidateVisual();
+            return;
+        }
+
         var hit = HitTest(_cursor);
         if (!ReferenceEquals(hit, _hoveredNode))
         {

--- a/src/Genie.App/ViewModels/MapperViewModel.cs
+++ b/src/Genie.App/ViewModels/MapperViewModel.cs
@@ -138,6 +138,59 @@ public class MapperViewModel : ReactiveObject
     /// </summary>
     [Reactive] public bool   AutoCreateEnabled { get; set; }
 
+    // ── Editor state (Genie 4 AutoMapper edit toolbar parity) ─────────────
+    /// <summary>Master toggle: when on, the canvas selects/drags nodes and the
+    /// edit toolbar + node-properties panel appear.</summary>
+    [Reactive] public bool   EditMode      { get; set; }
+
+    /// <summary>Snap dragged nodes to the grid (always effectively on — the
+    /// Genie 4 format stores 20px multiples; see MapCanvas).</summary>
+    [Reactive] public bool   SnapToGrid    { get; set; } = true;
+
+    /// <summary>Lock node positions so a drag can't nudge a clean map.</summary>
+    [Reactive] public bool   LockPositions { get; set; }
+
+    /// <summary>Genie 4 "Allow Duplicate" — mirror to
+    /// <see cref="AutoMapperEngine.AllowDuplicateRooms"/>.</summary>
+    [Reactive] public bool   AllowDuplicate { get; set; }
+
+    /// <summary>Show full <c>|</c>-separated room labels vs. only the primary
+    /// name (default). Bound to <see cref="Controls.MapCanvas.FullLabels"/>.</summary>
+    [Reactive] public bool   FullLabels    { get; set; }
+
+    /// <summary>The node selected in the canvas (edit mode). Two-way bound.</summary>
+    [Reactive] public MapNode? SelectedNode { get; set; }
+
+    /// <summary>True when the active zone has unsaved edits. Drives the Save
+    /// button's enabled state + a "● unsaved" hint.</summary>
+    [Reactive] public bool   IsZoneDirty   { get; private set; }
+
+    // Editable mirrors of the selected node's fields (Edit Panel). The user
+    // types here, then Apply pushes them back into the live node.
+    [Reactive] public string SelNodeTitle    { get; set; } = "";
+    [Reactive] public string SelNodeNotes    { get; set; } = "";
+    [Reactive] public string SelNodeColor    { get; set; } = "";
+    [Reactive] public string SelNodeServerId { get; set; } = "";
+
+    // ── Editor commands ───────────────────────────────────────────────────
+    /// <summary>Create a fresh empty zone in the engine (Genie 4 "New").</summary>
+    public ReactiveCommand<Unit, Unit> NewZoneCommand        { get; }
+    /// <summary>Save the active zone XML (Genie 4 "Save"). Derives a filename
+    /// from the zone name for brand-new zones.</summary>
+    public ReactiveCommand<Unit, Unit> SaveMapCommand        { get; }
+    /// <summary>Delete the selected node (Genie 4 "Remove Selected").</summary>
+    public ReactiveCommand<Unit, Unit> RemoveSelectedCommand { get; }
+    /// <summary>Renumber node ids to a dense 1..N (Genie 4 "Reset Map IDs").</summary>
+    public ReactiveCommand<Unit, Unit> ResetMapIdsCommand    { get; }
+    /// <summary>Push the Edit-Panel fields back into the selected node.</summary>
+    public ReactiveCommand<Unit, Unit> ApplyNodePropsCommand { get; }
+    /// <summary>Invoked by the canvas after a node drag completes — mark dirty
+    /// and repaint.</summary>
+    public ReactiveCommand<MapNode, Unit> NodeMovedCommand   { get; }
+    /// <summary>Delete a specific node — invoked by the canvas (Remove Room
+    /// context item / Delete key) with the target node.</summary>
+    public ReactiveCommand<MapNode, Unit> RemoveNodeCommand  { get; }
+
     // ── Zone selection ────────────────────────────────────────────────────
     /// <summary>Zone filenames (no extension) found in <see cref="MapsDirectory"/>.</summary>
     public ObservableCollection<string> AvailableZones { get; } = new();
@@ -427,6 +480,25 @@ public class MapperViewModel : ReactiveObject
         ZoomOutCommand   = ReactiveCommand.Create(() => { ZoomLevel /= 1.2; });
         ZoomResetCommand = ReactiveCommand.Create(() => { ZoomLevel  = 1.0; });
 
+        // ── Editor commands ───────────────────────────────────────────────
+        NewZoneCommand        = ReactiveCommand.Create(NewZone);
+        SaveMapCommand        = ReactiveCommand.Create(SaveMap);
+        RemoveSelectedCommand = ReactiveCommand.Create(RemoveSelected);
+        ResetMapIdsCommand    = ReactiveCommand.Create(ResetMapIds);
+        ApplyNodePropsCommand = ReactiveCommand.Create(ApplyNodeProps);
+        NodeMovedCommand      = ReactiveCommand.Create<MapNode>(_ => { IsZoneDirty = true; RenderTick++; });
+        RemoveNodeCommand     = ReactiveCommand.Create<MapNode>(RemoveNodeById);
+
+        foreach (var c in new IReactiveCommand[]
+                 { NewZoneCommand, SaveMapCommand, RemoveSelectedCommand,
+                   ResetMapIdsCommand, ApplyNodePropsCommand, NodeMovedCommand, RemoveNodeCommand })
+            c.ThrownExceptions.Subscribe(ex => LoadStatus = $"Editor error: {ex.Message}");
+
+        // Mirror the selected node's fields into the editable Edit-Panel
+        // properties whenever the selection changes (canvas sets SelectedNode
+        // via its two-way binding).
+        this.WhenAnyValue(x => x.SelectedNode).Subscribe(_ => MirrorSelectedNode());
+
         RefreshZonesCommand = ReactiveCommand.Create(RefreshAvailableZones);
         RefreshZonesCommand.ThrownExceptions.Subscribe(ex =>
             LoadStatus = $"Refresh failed: {ex.Message}");
@@ -593,6 +665,12 @@ public class MapperViewModel : ReactiveObject
         this.WhenAnyValue(x => x.AutoCreateEnabled)
             .Skip(1)   // ignore the initial emission; engine already matches
             .Subscribe(v => { if (_engine is not null) _engine.IsEnabled = v; });
+
+        // Allow-duplicate mirror (Genie 4 parity) — same pattern.
+        AllowDuplicate = _engine.AllowDuplicateRooms;
+        this.WhenAnyValue(x => x.AllowDuplicate)
+            .Skip(1)
+            .Subscribe(v => { if (_engine is not null) _engine.AllowDuplicateRooms = v; });
 
         RefreshAvailableZones();
 
@@ -873,6 +951,122 @@ public class MapperViewModel : ReactiveObject
         {
             LoadStatus = $"Save failed: {ex.Message}";
         }
+    }
+
+    // ── Editor operations (Genie 4 AutoMapper toolbar) ────────────────────
+    private void NewZone()
+    {
+        if (_engine is null) { LoadStatus = "Mapper not ready."; return; }
+        _engine.NewZone("New Zone");
+        // Don't trigger LoadSelectedZone — there's no file yet.
+        _suppressAutoLoad = true;
+        try { SelectedZoneFile = null; } finally { _suppressAutoLoad = false; }
+        SelectedNode      = null;
+        ZoneLastWriteTime = null;
+        ZoneAgeDisplay    = "";
+        IsZoneStale       = false;
+        IsZoneDirty       = true;     // unsaved
+        EditMode          = true;     // drop straight into editing a blank map
+        Refresh();
+        LoadStatus = "New zone created — turn on Record (or add rooms), then Save.";
+    }
+
+    private void SaveMap()
+    {
+        if (_engine is null || _zoneRepo is null) { LoadStatus = "Mapper not ready."; return; }
+        if (string.IsNullOrWhiteSpace(MapsDirectory)) { LoadStatus = "No Maps directory set."; return; }
+
+        var file = SelectedZoneFile;
+        if (string.IsNullOrEmpty(file))
+        {
+            // Brand-new zone with no backing file — derive a filename from the
+            // zone name (sanitised) so New → Save works without a Save-As dialog.
+            var zname = _engine.ActiveZone.Name;
+            file = SanitizeFileName(string.IsNullOrWhiteSpace(zname) ? "new_zone" : zname);
+        }
+
+        var path = Path.Combine(MapsDirectory, file + ".xml");
+        try
+        {
+            _zoneRepo.Save(path, _engine.ActiveZone);
+            ZoneLastWriteTime = File.GetLastWriteTime(path);
+            RefreshZoneAge();
+            IsZoneDirty = false;
+            RenderTick++;
+
+            // Make sure the dropdown reflects a newly-created file and keep it
+            // selected WITHOUT re-loading (which would reset CurrentNode).
+            if (!AvailableZones.Contains(file))
+            {
+                _suppressAutoLoad = true;
+                try { AvailableZones.Add(file); SelectedZoneFile = file; }
+                finally { _suppressAutoLoad = false; }
+            }
+            LoadStatus = $"Saved {file}.xml ({_engine.ActiveZone.Nodes.Count} rooms).";
+        }
+        catch (Exception ex)
+        {
+            LoadStatus = $"Save failed: {ex.Message}";
+        }
+    }
+
+    private void RemoveSelected()
+    {
+        if (SelectedNode is null) { LoadStatus = "No room selected."; return; }
+        RemoveNodeById(SelectedNode);
+    }
+
+    private void RemoveNodeById(MapNode node)
+    {
+        if (_engine is null || node is null) return;
+        var id = node.Id;
+        if (_engine.RemoveNode(id))
+        {
+            if (SelectedNode?.Id == id) SelectedNode = null;
+            IsZoneDirty = true;
+            Refresh();
+            LoadStatus = $"Removed room {id}. Save to persist.";
+        }
+    }
+
+    private void ResetMapIds()
+    {
+        if (_engine is null) { LoadStatus = "Mapper not ready."; return; }
+        _engine.ResetMapIds();
+        SelectedNode = null;   // ids changed; clear selection to avoid a stale ref
+        IsZoneDirty  = true;
+        Refresh();
+        LoadStatus = "Renumbered room IDs to 1..N. Save to persist.";
+    }
+
+    private void ApplyNodeProps()
+    {
+        if (_engine is null || SelectedNode is null) { LoadStatus = "No room selected."; return; }
+        SelectedNode.Title        = SelNodeTitle    ?? "";
+        SelectedNode.Notes        = SelNodeNotes    ?? "";
+        SelectedNode.Color        = SelNodeColor    ?? "";
+        SelectedNode.ServerRoomId = SelNodeServerId ?? "";
+        // Title + ServerRoomId feed the lookup indexes — rebuild them.
+        _engine.NotifyStructureChanged();
+        IsZoneDirty = true;
+        RenderTick++;
+        LoadStatus = $"Updated room {SelectedNode.Id}. Save to persist.";
+    }
+
+    private void MirrorSelectedNode()
+    {
+        var n = SelectedNode;
+        SelNodeTitle    = n?.Title        ?? "";
+        SelNodeNotes    = n?.Notes        ?? "";
+        SelNodeColor    = n?.Color        ?? "";
+        SelNodeServerId = n?.ServerRoomId ?? "";
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var clean   = new string(name.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray()).Trim();
+        return string.IsNullOrEmpty(clean) ? "new_zone" : clean;
     }
 
     // ── Zone selector ─────────────────────────────────────────────────────

--- a/src/Genie.Core/Mapper/AutoMapperEngine.cs
+++ b/src/Genie.Core/Mapper/AutoMapperEngine.cs
@@ -57,6 +57,18 @@ public sealed class AutoMapperEngine
     public MapZone   ActiveZone   => _zone;
     public bool      IsEnabled    { get; set; } = false;
 
+    /// <summary>
+    /// Genie 4 "Allow Duplicate" parity. When true AND <see cref="IsEnabled"/>
+    /// (record mode), the fuzzy fingerprint/title match tiers (c)/(e)/(f) are
+    /// skipped so a freshly-entered room that merely shares a title+exit
+    /// fingerprint with an existing node gets its OWN node instead of being
+    /// folded into the existing one. Definitive tiers — server room id (a) and
+    /// graph-arc walk (b)/(d) — still match, so genuinely revisiting a known
+    /// room via a linked exit does not spawn a duplicate. Off by default
+    /// (de-duplication is the right behaviour for almost every zone).
+    /// </summary>
+    public bool      AllowDuplicateRooms { get; set; } = false;
+
     public event Action? MapChanged;
     public event Action? CurrentNodeChanged;
     /// <summary>
@@ -158,6 +170,78 @@ public sealed class AutoMapperEngine
         return zone;
     }
 
+    // ── Manual editor operations (Genie 4 AutoMapper toolbar parity) ──────────
+    // These mutate the active zone directly from the UI editor rather than from
+    // the live game stream. Each keeps the fingerprint / server-id indexes
+    // consistent (via RebuildIndex) and fires MapChanged so the canvas repaints.
+
+    /// <summary>
+    /// Delete a node and scrub every arc that pointed at it (Genie 4
+    /// "Remove Selected Nodes/Labels"). If the deleted node was the current
+    /// room, CurrentNode is cleared. No-op when the id isn't present.
+    /// </summary>
+    public bool RemoveNode(int id)
+    {
+        if (!_zone.Nodes.Remove(id)) return false;
+
+        // Drop any dangling arcs that referenced the removed node so the
+        // exported XML stays self-consistent (Genie 4 leaves dead arcs; we
+        // prefer a clean graph for the weighted pathfinder).
+        foreach (var n in _zone.Nodes.Values)
+            n.Exits.RemoveAll(e => e.DestinationId == id);
+
+        if (CurrentNode?.Id == id)
+        {
+            CurrentNode = null;
+            CurrentNodeChanged?.Invoke();
+        }
+
+        RebuildIndex();
+        MapChanged?.Invoke();
+        return true;
+    }
+
+    /// <summary>
+    /// Renumber every node to a dense 1..N sequence in ascending current-id
+    /// order, remapping all arc destinations to match (Genie 4 "Reset Map IDs").
+    /// Preserves the current-room selection across the renumber. Useful after a
+    /// lot of add/remove churn leaves the id space sparse.
+    /// </summary>
+    public void ResetMapIds()
+    {
+        var ordered = _zone.Nodes.Values.OrderBy(n => n.Id).ToList();
+        var remap   = new Dictionary<int, int>(ordered.Count);
+        for (int i = 0; i < ordered.Count; i++)
+            remap[ordered[i].Id] = i + 1;
+
+        var rebuilt = new Dictionary<int, MapNode>(ordered.Count);
+        foreach (var node in ordered)
+        {
+            node.Id = remap[node.Id];
+            foreach (var exit in node.Exits)
+                if (exit.DestinationId is { } dest && remap.TryGetValue(dest, out var newDest))
+                    exit.DestinationId = newDest;
+            rebuilt[node.Id] = node;
+        }
+
+        _zone.Nodes = rebuilt;
+        RebuildIndex();
+        MapChanged?.Invoke();
+        CurrentNodeChanged?.Invoke();   // CurrentNode object is unchanged; its Id moved
+    }
+
+    /// <summary>
+    /// Signal that node fields affecting the lookup indexes (Title, Exits,
+    /// ServerRoomId) were edited in the UI, so the fingerprint / server-id
+    /// indexes must be rebuilt and the canvas repainted. Position/Notes/Color
+    /// edits don't need this — callers can just bump the render tick.
+    /// </summary>
+    public void NotifyStructureChanged()
+    {
+        RebuildIndex();
+        MapChanged?.Invoke();
+    }
+
     // ── Internal ────────────────────────────────────────────────────────────
 
     private void OnStateChanged()
@@ -204,6 +288,12 @@ public sealed class AutoMapperEngine
         _pendingMoveCommand = string.Empty;
 
         bool zoneChanged = false;
+
+        // "Allow Duplicate" gate: when the user has opted into duplicates while
+        // recording, skip the fuzzy fingerprint/title tiers (c)/(e)/(f) so a
+        // new room sharing a fingerprint creates its own node. Definitive tiers
+        // (server-id, graph-arc) below are unaffected.
+        bool allowFuzzy = !(IsEnabled && AllowDuplicateRooms);
 
         // ── 1. Find the node ─────────────────────────────────────────────────
         // Priority:
@@ -271,7 +361,7 @@ public sealed class AutoMapperEngine
         //          would lock in a wrong match that then cascades — once
         //          CurrentNode is wrong, every subsequent move's tier (b)
         //          graph walk runs from the wrong room and stays wrong.
-        if (node is null && _fingerprintIndex.TryGetValue(fingerprint, out var candidateIds))
+        if (node is null && allowFuzzy && _fingerprintIndex.TryGetValue(fingerprint, out var candidateIds))
         {
             if (candidateIds.Count == 1)
             {
@@ -334,7 +424,7 @@ public sealed class AutoMapperEngine
 
         // (e) Description tiebreaker: scan all nodes with matching title and
         //     pick the one whose description matches (handles duplicate titles).
-        if (node is null && !string.IsNullOrEmpty(description))
+        if (node is null && allowFuzzy && !string.IsNullOrEmpty(description))
         {
             foreach (var candidate in _zone.Nodes.Values)
             {
@@ -358,7 +448,7 @@ public sealed class AutoMapperEngine
         //     currently closed in-game so the visible exit set is a subset
         //     of the persisted node's exits). Without this fallback the
         //     fingerprint check (c) would miss every such room.
-        if (node is null && !string.IsNullOrEmpty(title))
+        if (node is null && allowFuzzy && !string.IsNullOrEmpty(title))
         {
             var liveDirs = exits
                 .Select(DirectionHelper.Parse)


### PR DESCRIPTION
## Summary
Brings the Genie 4 AutoMapper window's editing & navigation tools into the Genie 5 mapper. Addresses part of #44 (AutoMapper toolbar parity).

### Editor (Edit mode)
- Select a room (yellow outline), **drag to move** it (snaps to the grid; only marks the zone dirty when the cell actually changes).
- **Remove** a room (button, Delete key, or right-click → Remove Room) and **Reset IDs** (renumber 1..N, remap arc destinations).
- **Edit Room** properties panel: Title / Notes / Color / Server-id → Apply.
- Toggles: **Snap**, **Lock** (positions), **Dup** (allow duplicate rooms while recording).
- **New** (blank zone) + **Save** (unsaved ● indicator). **Record** = auto-create rooms as you walk.

### Navigation
- **Grab-to-pan**: left-drag (navigate mode / empty space) or middle-drag (any mode) — you can now reposition the map when zoomed in.

### Labels
- **Collision-aware placement**: each label takes the first free slot (right/left/above/below), is skipped when crowded (current/selected/hovered always shown), with a dotted **leader line** when displaced.
- **Labels** toggle: primary name only (default) vs. the full `|`-separated list. Full set is always in the hover tooltip.

## Map format
Saves round-trip through the existing Genie 4 XML exporter, so edited zones stay compatible with Genie 4 / Lich / the Maps repo.

## Type of Change
- [x] New feature

## Related Issue
Addresses part of #44.

## Testing
Built clean on all targets locally; smoke-tested in the running app: toolbar + edit cluster, select/drag/move, dirty tracking, remove, pan-when-zoomed, and the label declutter + toggle.