### PR TITLE
Script engine: '#' comments + undefined vars resolve to empty (fixes #54)

### DIFF
--- a/src/Genie.Core/Scripting/ScriptEngine.cs
+++ b/src/Genie.Core/Scripting/ScriptEngine.cs
@@ -1715,22 +1715,19 @@ public sealed class ScriptEngine
             }
             if (!resolved)
             {
-                // No prefix matched anywhere. For local %vars we keep the
-                // historical "empty if undefined" behavior — scripts often
-                // lazy-init %vars and rely on `if "%foo" = ""` checks.
-                //
-                // For global $vars we record an AbortReason so the runner
-                // can stop the script at the next safe point. Without this,
-                // an unset $sheath/$pack/etc. silently truncates the line
-                // ("put open my $sheath" → "put open my") and the server
-                // rejects a malformed command. Scripts that legitimately
-                // want to check for an unset global should use the def()
-                // expression helper.
+                // Undefined variable → empty string, for BOTH local %vars and
+                // global $vars. This matches Genie 4 (Lists/Globals.cs returns
+                // the line with the token resolved to nothing) and the
+                // Genie5.Kzin engine, which both treat an unset variable as
+                // empty rather than aborting. Scripts routinely compare against
+                // optional globals — e.g. travel.cmd's
+                // `if "$charactername" = "$char1"` where $char1 may never have
+                // been created — and rely on the empty result so the branch
+                // simply doesn't match. Scripts that need to distinguish
+                // "set to empty" from "never set" use the def() helper.
                 name = text[nameStart..j];
                 value = string.Empty;
                 nameEnd = j;
-                if (c == '$' && inst.AbortReason is null)
-                    inst.AbortReason = "undefined variable $" + name;
             }
             j = nameEnd;
             if (doubleEval && !string.IsNullOrEmpty(value))

--- a/src/Genie.Core/Scripting/ScriptEngine.cs
+++ b/src/Genie.Core/Scripting/ScriptEngine.cs
@@ -650,42 +650,18 @@ public sealed class ScriptEngine
         inst.Pc++;
 
         var t = line.Trimmed;
-        // Skip blank lines and pure comments. A comment is `#` alone, `#`
-        // followed by whitespace, or `#` followed by a non-letter (e.g.
-        // `############` divider lines). Meta-commands (`#echo`, `#var`,
-        // `#tvar`, `#class`, `#mapper`, `#parse`, ...) start with `#`
-        // immediately followed by a letter and fall through to the
-        // meta-command route a few lines down — Genie 4 parity for the
-        // bare `#xxx` invocation pattern community scripts use.
+        // Skip blank lines and comments. In Genie 4 a script line whose first
+        // non-whitespace character is `#` is ALWAYS a comment — including
+        // `#debug 10`, `#include foo`, commented-out code like `#goto LABEL`,
+        // and prose (`#todo ...`). Meta-commands are never invoked as a bare
+        // `#xxx` script line; a script runs one only by sending it to the
+        // command line via put/send (`put #echo foo`, `put #goto 400`), which
+        // the `put`/`send` case handles separately. So `#` here means "ignore
+        // the rest of the line" — nothing is substituted or dispatched.
         if (t.Length == 0) return true;
-        if (t[0] == '#' && (t.Length == 1 || !char.IsLetter(t[1]))) return true;
+        if (t[0] == '#') return true;
         if ((t[0] == ':' || t[^1] == ':') && !t.Contains(' ')) return true;
 
-        // Bare meta-command (`#echo foo`, `#var x 1`, ...). Substitute
-        // $/% vars then route through HandleMetaCommand — the same target
-        // the `put #...` and PendingSends paths use. AbortReason from the
-        // substitute step is honoured exactly like the regular dispatch
-        // path below: undefined-$var stops the script with a clear reason
-        // rather than running a half-substituted meta-command.
-        if (t[0] == '#')
-        {
-            inst.AbortReason = null;
-            var metaText = SubstituteVars(t, inst);
-            if (inst.AbortReason is not null)
-            {
-                _echo($"[script] {inst.Name} stopped at line {line.LineNumber}: {inst.AbortReason}");
-                inst.Running = false;
-                ScriptFinished?.Invoke(inst.Name);
-                return false;
-            }
-            if (inst.LastDebugLine != line.LineNumber)
-            {
-                DbgEcho(inst, 10, $"{inst.Name}:{line.LineNumber} {metaText}");
-                inst.LastDebugLine = line.LineNumber;
-            }
-            HandleMetaCommand(metaText, inst);
-            return true;
-        }
         // Brace block delimiters are structural — the parser already mapped
         // jumps over them; at runtime they're no-ops.
         if (t == "{") return true;

--- a/src/Genie.Core/Scripting/ScriptParser.cs
+++ b/src/Genie.Core/Scripting/ScriptParser.cs
@@ -247,7 +247,7 @@ public static class ScriptParser
                     bodyEnd   = inst.Lines.Count;
                     for (int j = bodyStart; j < inst.Lines.Count; j++)
                     {
-                        if (inst.Lines[j].Trimmed.Length == 0) continue;
+                        if (IsSkippable(inst.Lines[j].Trimmed)) continue;
                         if (inst.Lines[j].Indent <= line.Indent) { bodyEnd = j; break; }
                     }
                 }
@@ -356,7 +356,7 @@ public static class ScriptParser
                         bodyEnd = inst.Lines.Count;
                         for (int j = cursor + 1; j < inst.Lines.Count; j++)
                         {
-                            if (inst.Lines[j].Trimmed.Length == 0) continue;
+                            if (IsSkippable(inst.Lines[j].Trimmed)) continue;
                             if (inst.Lines[j].Indent <= inst.Lines[cursor].Indent) { bodyEnd = j; break; }
                         }
                     }
@@ -384,7 +384,7 @@ public static class ScriptParser
                     elseEnd = inst.Lines.Count;
                     for (int j = cursor + 1; j < inst.Lines.Count; j++)
                     {
-                        if (inst.Lines[j].Trimmed.Length == 0) continue;
+                        if (IsSkippable(inst.Lines[j].Trimmed)) continue;
                         if (inst.Lines[j].Indent <= inst.Lines[cursor].Indent) { elseEnd = j; break; }
                     }
                     return elseEnd;
@@ -413,10 +413,17 @@ public static class ScriptParser
         return t[6] == ' ' || t[6] == '\t';
     }
 
+    /// <summary>True for lines the block/jump mapper must look past: blank
+    /// lines and `#` comments. A `#` comment is semantically "not there" (Genie
+    /// 4), so it must not separate an `if … then` from its `{`, or an if-block
+    /// from its `else`/`elseif`, when building jump maps.</summary>
+    private static bool IsSkippable(string trimmed)
+        => trimmed.Length == 0 || trimmed[0] == '#';
+
     private static int NextNonEmpty(ScriptInstance inst, int from)
     {
         for (int j = from; j < inst.Lines.Count; j++)
-            if (inst.Lines[j].Trimmed.Length > 0) return j;
+            if (!IsSkippable(inst.Lines[j].Trimmed)) return j;
         return -1;
     }
 


### PR DESCRIPTION
# Pull Request

## Summary

Two related script-engine correctness fixes (bundled because both touch `ScriptEngine.cs` and would otherwise conflict).

### 1. `#` is a comment (Closes #54)

In Genie 4 any script line whose first non-whitespace char is `#` is a comment. The engine only skipped `#`+non-letter (`#%`, `####`); a `#`+letter line was parsed as a bare meta-command and dispatched to the command pipeline. Real Genie 4 scripts use `#` for comments and commented-out code, so this spammed the game window with `Unknown command: …` and, worse, **silently executed commented-out lines** whose verb happened to be a meta-command (`#var`, `#echo`, `#mapper`, `#parse`). `tradeshard.cmd` alone has 128 such lines.

- **`ScriptEngine`** — any line whose first non-whitespace char is `#` is now skipped as a comment. Removed the bare-`#`-meta dispatch path. A script runs a meta-command only by sending it to the command line via `put`/`send` (`put #echo foo`, `put #goto 400`); that interception is unchanged.
- **`ScriptParser`** — the if/while/goto block mapper now looks past `#` comments wherever it looks past blank lines (`NextNonEmpty` + the indent-based body scans), via a shared `IsSkippable` helper. Without this, a comment between an `if … then` and its `{`, or between an if-block and its `else`, would misparse the conditional.

### 2. Undefined variables resolve to empty, not abort

An unset `$global` aborted the running script (`[script] travel stopped at line 74: undefined variable $char1`). Genie 4 (`Lists/Globals.cs`) and the Genie5.Kzin engine both resolve an undefined variable — local `%var` or global `$var` — to an empty string and keep running. Scripts depend on this: `travel.cmd` compares `$charactername` against optional `$char1..$charN` globals the user may never have created, expecting the branch to simply not match.

- **`ScriptEngine`** — undefined `$globals` now resolve to empty, same as `%locals` (removed the `AbortReason`). Scripts that need to distinguish "set to empty" from "never set" still use the `def()` helper.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Plugin update
- [ ] Map update
- [ ] Build/tooling change
- [ ] Other

## Related Issue

Closes #54

## Testing

- `dotnet build -c Release` clean (0 warnings).
- Drove the real `ScriptEngine`:
  - `#` comments: bare `#echo`/`#var`/`#goto` neither execute nor leak to the command engine; an `if`/`else` with comments interspersed branches correctly; `put #echo …` still works.
  - Undefined vars: with `$char1` unset, `if "$charactername" = "$char1" then …` evaluates false, `$char1` expands to empty, and the script runs to completion with no stop/abort.
