### PR TITLE
Game window: 'Script Lines' filter covers all script output (fixes #56)

### DIFF
--- a/src/Genie.App/ViewModels/GameTextViewModel.cs
+++ b/src/Genie.App/ViewModels/GameTextViewModel.cs
@@ -53,21 +53,24 @@ public class GameTextViewModel : ReactiveObject
                 AddLine(text, StreamColor.Main, links, bolds);
             });
 
-        // ── Local echoes: typed commands + #echo + script echoes ──────────
-        // EchoLine fires for two semantically-distinct kinds of line:
+        // ── Local echoes: typed commands + system diagnostics ─────────────
+        // EchoLine carries non-script lines of two kinds:
         //   (a) typed-command echoes ("> look", "> n", …) — what we call "Echo"
-        //   (b) script + system diagnostics ([script] X done, [recorder] …) — "Script"
+        //   (b) system diagnostics ([plugin] …, [layout] …, [recorder] …) — a
+        //       bracketed tag, grouped with "Script" for filtering purposes.
         // The split is detected by prefix: a line starting with [xxx] is a
-        // bracketed system tag. Both render with StreamColor.System styling
-        // (italic-gray); the filter just decides whether to render at all.
+        // bracketed system tag. Script-originated lines no longer arrive here —
+        // they come via ScriptOutputLine (below) — so there's no double render.
+        // Both render with StreamColor.System styling (italic-gray); the filter
+        // just decides whether to render at all.
         Observable.FromEvent<Action<string>, string>(
                 h => core.EchoLine += h,
                 h => core.EchoLine -= h)
             .ObserveOn(RxApp.MainThreadScheduler)
             .Subscribe(msg =>
             {
-                var isScriptTag = msg.StartsWith("[", StringComparison.Ordinal);
-                if (isScriptTag)
+                var isSystemTag = msg.StartsWith("[", StringComparison.Ordinal);
+                if (isSystemTag)
                 {
                     if (DisplaySettings?.ShowScriptText == false) return;
                 }
@@ -75,6 +78,21 @@ public class GameTextViewModel : ReactiveObject
                 {
                     if (DisplaySettings?.ShowEchoText == false) return;
                 }
+                AddLine(msg, StreamColor.System);
+            });
+
+        // ── Script-originated lines ───────────────────────────────────────
+        // Everything a script produces arrives on ScriptOutputLine: its
+        // echo output, [script]/[dbg] diagnostics, AND the game commands it
+        // issues (`put north`, …). All classified as Script lines so the
+        // "Script Lines" toggle governs the whole of a script's activity.
+        Observable.FromEvent<Action<string>, string>(
+                h => core.ScriptOutputLine += h,
+                h => core.ScriptOutputLine -= h)
+            .ObserveOn(RxApp.MainThreadScheduler)
+            .Subscribe(msg =>
+            {
+                if (DisplaySettings?.ShowScriptText == false) return;
                 AddLine(msg, StreamColor.System);
             });
 

--- a/src/Genie.Core/GenieCore.cs
+++ b/src/Genie.Core/GenieCore.cs
@@ -145,13 +145,14 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
     public event Action<string>?                   EchoLine;
 
     /// <summary>
-    /// Raised specifically for script-originated echoes — anything the
-    /// <see cref="ScriptEngine"/> emits via its echo channel: <c>[script]</c>
-    /// status lines, <c>[dbg:N]</c> traces, <c>#echo</c> output from inside
-    /// a running script, abort messages. Fired in addition to
-    /// <see cref="EchoLine"/> (which still gets the same text) so the
-    /// Scripts panel can build its own scrollback without blocking the
-    /// main game window from showing the same messages.
+    /// Raised for every script-originated line — the single "this came from a
+    /// script" signal. Covers anything the <see cref="ScriptEngine"/> emits via
+    /// its echo channel (<c>[script]</c> status lines, <c>[dbg:N]</c> traces,
+    /// <c>echo</c>/<c>#echo</c> output, abort messages) AND the game commands a
+    /// script issues. The main game window classifies these as Script lines
+    /// (governed by the "Script Lines" filter); the Scripts panel uses the same
+    /// stream for its scrollback. Distinct from <see cref="EchoLine"/>, which
+    /// carries user-typed command echoes and system diagnostics.
     /// </summary>
     public event Action<string>?                   ScriptOutputLine;
 
@@ -271,21 +272,27 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
 
         // ── Scripting ──────────────────────────────────────────────────────────
         _typeAhead = new TypeAheadSession();
-        // The script engine's echo callback fires for ALL script-originated
-        // text: "[script] X started/done", "[dbg:N]" traces, `#echo` output
-        // from running scripts, abort messages. Fork the dispatch so the
-        // main game window (via EchoLine) AND the Scripts panel (via
-        // ScriptOutputLine) both receive it. The main window already knows
-        // not to highlight echoes; the Scripts panel keeps its own scrollback.
+        // All script-originated output flows through ScriptOutputLine — the
+        // single "this came from a script" signal the UI uses to classify a
+        // line as a Script line (governed by the "Script Lines" filter):
+        //   • echo callback — "[script] X started/done", "[dbg:N]" traces,
+        //     `echo`/`#echo` output, abort messages;
+        //   • sendCommand   — the actual game commands a script issues
+        //     (`put north`, …), so they're visible/toggleable as script
+        //     activity (Genie 4 surfaces script-sent commands too).
+        // Routed to ScriptOutputLine ONLY (not EchoLine) so the game window
+        // shows each script line once; EchoLine is reserved for user-typed
+        // command echoes and system diagnostics. The Scripts panel also reads
+        // ScriptOutputLine for its own scrollback.
         Scripts    = new ScriptEngine(
             scriptsDir:    Config.ScriptDir,
             typeAhead:     _typeAhead,
-            sendCommand:   cmd => _ = _connection.SendCommandAsync(cmd),
-            echo:          msg =>
+            sendCommand:   cmd =>
                            {
-                               EchoLine?.Invoke(msg);
-                               ScriptOutputLine?.Invoke(msg);
+                               ScriptOutputLine?.Invoke(cmd);
+                               _ = _connection.SendCommandAsync(cmd);
                            },
+            echo:          msg => ScriptOutputLine?.Invoke(msg),
             handleHashCmd: cmd => Commands.ProcessInput(cmd));
 
         // Wire game-state callbacks for RT-gated script pausing


### PR DESCRIPTION
# Pull Request

## Summary

Makes the **Window → Game Window → Script Lines** toggle govern *all* of a script's output, instead of only lines that happen to start with `[`.

Previously a running script's own `echo "…"` output (no bracket) was classified as an Echo line, and the game commands a script issued (`put north`, …) weren't shown at all — so "Script Lines" didn't actually control "what my script is doing."

Reclassify by **origin** instead of by prefix, using `GenieCore.ScriptOutputLine` as the single "this came from a script" signal:
- **`GenieCore`** — route all script-originated text through `ScriptOutputLine` only (was: the script echo callback forked to both `EchoLine` and `ScriptOutputLine`). Also emit each game command a script sends on `ScriptOutputLine`, so script-sent commands are visible and toggleable (Genie 4 surfaces these too). `EchoLine` is now reserved for user-typed command echoes and system diagnostics.
- **`GameTextViewModel`** — subscribe to `ScriptOutputLine` and render those as Script lines (gated by `ShowScriptText`). `EchoLine` still feeds user echoes (`> look`) and bracketed system diagnostics. No double-render, since script output no longer fires `EchoLine`.

Net: "Script Lines" now governs a script's `echo` output, its `[script]`/`[dbg]` diagnostics, and the commands it issues to the game.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Plugin update
- [ ] Map update
- [ ] Build/tooling change
- [ ] Other

## Related Issue

Closes #56

## Testing

- `dotnet build -c Release` clean (0 warnings); app smoke-launches with no startup/binding errors.
- Drove the real `ScriptEngine` with GenieCore's new wiring: a script's `echo` output, its `[script]` diagnostics, and a `put north` command all land on the script channel (and the command still reaches the game); nothing leaks to the `EchoLine` channel (no double render).
- Possible regression surface: anything that previously relied on script echoes arriving via `EchoLine`. In-tree the only `EchoLine` consumer is the game window (handled here); the Scripts panel already used `ScriptOutputLine`.
