### PR TITLE
Config: per-profile loads fall back to global; profile overrides when present (fixes #59)

### DIFF
--- a/src/Genie.App/ViewModels/ConfigurationViewModel.cs
+++ b/src/Genie.App/ViewModels/ConfigurationViewModel.cs
@@ -211,6 +211,24 @@ public class ConfigurationViewModel : ReactiveObject
         return Path.Combine(dir, fileName);
     }
 
+    /// <summary>
+    /// Read path with profile-over-global precedence: the selected profile's
+    /// own copy when present, otherwise the shared global Config file (so a
+    /// profile that hasn't customised a rule type still shows the global set,
+    /// including legacy / earlier-prototype configs). Saves always go to the
+    /// profile dir via <see cref="PathFor"/>, so the first edit promotes a
+    /// global config into a per-profile override. Returns the profile path
+    /// (which may not exist) when neither location has the file, so callers'
+    /// existing <c>File.Exists</c> guards still work.
+    /// </summary>
+    private string ReadPathFor(string fileName)
+    {
+        var profilePath = PathFor(fileName);
+        if (File.Exists(profilePath)) return profilePath;
+        var globalPath = Path.Combine(_configRoot, fileName);
+        return File.Exists(globalPath) ? globalPath : profilePath;
+    }
+
     // ── Draft engines (cleared whenever SelectedProfile changes) ─────────────
 
     private HighlightEngine?     _draftHighlights;
@@ -253,7 +271,7 @@ public class ConfigurationViewModel : ReactiveObject
     {
         if (_draftHighlights is not null) return _draftHighlights;
         _draftHighlights = new HighlightEngine();
-        var path = PathFor("highlights.json");
+        var path = ReadPathFor("highlights.json");
         if (!File.Exists(path)) return _draftHighlights;
         try
         {
@@ -274,7 +292,7 @@ public class ConfigurationViewModel : ReactiveObject
     {
         if (_draftTriggers is not null) return _draftTriggers;
         _draftTriggers = new TriggerEngineFinal();
-        var path = PathFor("triggers.json");
+        var path = ReadPathFor("triggers.json");
         if (!File.Exists(path)) return _draftTriggers;
         try
         {
@@ -289,7 +307,7 @@ public class ConfigurationViewModel : ReactiveObject
     {
         if (_draftSubstitutes is not null) return _draftSubstitutes;
         _draftSubstitutes = new SubstituteEngine();
-        var path = PathFor("substitutes.json");
+        var path = ReadPathFor("substitutes.json");
         if (!File.Exists(path)) return _draftSubstitutes;
         try
         {
@@ -304,7 +322,7 @@ public class ConfigurationViewModel : ReactiveObject
     {
         if (_draftGags is not null) return _draftGags;
         _draftGags = new GagEngine();
-        var path = PathFor("gags.json");
+        var path = ReadPathFor("gags.json");
         if (!File.Exists(path)) return _draftGags;
         try
         {
@@ -319,7 +337,7 @@ public class ConfigurationViewModel : ReactiveObject
     {
         if (_draftAliases is not null) return _draftAliases;
         _draftAliases = new AliasEngine();
-        var path = PathFor("aliases.json");
+        var path = ReadPathFor("aliases.json");
         if (!File.Exists(path)) return _draftAliases;
         try
         {
@@ -334,7 +352,7 @@ public class ConfigurationViewModel : ReactiveObject
     {
         if (_draftMacros is not null) return _draftMacros;
         _draftMacros = new MacroEngine();
-        var path = PathFor("macros.json");
+        var path = ReadPathFor("macros.json");
         if (!File.Exists(path)) return _draftMacros;
         try
         {
@@ -345,13 +363,26 @@ public class ConfigurationViewModel : ReactiveObject
         return _draftMacros;
     }
 
-    private ClassEngine GetDraftClasses() => _draftClasses ??= new ClassEngine();
+    private ClassEngine GetDraftClasses()
+    {
+        if (_draftClasses is not null) return _draftClasses;
+        _draftClasses = new ClassEngine();
+        var path = ReadPathFor("classes.json");
+        if (!File.Exists(path)) return _draftClasses;
+        try
+        {
+            foreach (var m in _persistence.LoadClasses(path))
+                _draftClasses.Set(m.Name, m.IsActive);
+        }
+        catch { }
+        return _draftClasses;
+    }
 
     private VariableStore GetDraftVariables()
     {
         if (_draftVariables is not null) return _draftVariables;
         _draftVariables = new VariableStore();
-        var path = PathFor("variables.json");
+        var path = ReadPathFor("variables.json");
         if (!File.Exists(path)) return _draftVariables;
         try
         {

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -1680,10 +1680,35 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// </summary>
     private void LoadSavedConfiguration(GenieCore core)
     {
-        var p   = new PersistenceService();
-        var dir = GetProfileConfigDir(ConnectedProfile);
+        var p          = new PersistenceService();
+        var profileDir = GetProfileConfigDir(ConnectedProfile);
+        var globalDir  = _configDir;
 
-        SafeLoad(dir, "highlights.json", path =>
+        // Resolve a rule file with profile-over-global precedence: the connected
+        // profile's own copy wins when present, otherwise fall back to the shared
+        // global Config dir. This lets per-profile configs override the shared
+        // set while legacy / pre-per-profile configs (e.g. imported Genie 4 or
+        // earlier-prototype files that live in the global Config dir) still load
+        // for a profile that hasn't customised that rule type yet. Returns null
+        // when neither location has the file. For a profile-less (ad-hoc)
+        // connection profileDir == globalDir, so this is a plain "load if present".
+        string? Pick(string fileName)
+        {
+            var profilePath = Path.Combine(profileDir, fileName);
+            if (File.Exists(profilePath)) return profilePath;
+            var globalPath = Path.Combine(globalDir, fileName);
+            return File.Exists(globalPath) ? globalPath : null;
+        }
+
+        // Classes first so Ensure() calls from the rule loaders below don't
+        // clobber persisted active/inactive state (matches Genie5.Kzin ordering).
+        SafeLoad(Pick("classes.json"), path =>
+        {
+            foreach (var m in p.LoadClasses(path))
+                core.Classes.Set(m.Name, m.IsActive);
+        });
+
+        SafeLoad(Pick("highlights.json"), path =>
         {
             foreach (var m in p.LoadHighlights(path))
             {
@@ -1695,7 +1720,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             }
         });
 
-        SafeLoad(dir, "triggers.json", path =>
+        SafeLoad(Pick("triggers.json"), path =>
         {
             foreach (var m in p.LoadTriggers(path))
             {
@@ -1704,7 +1729,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             }
         });
 
-        SafeLoad(dir, "substitutes.json", path =>
+        SafeLoad(Pick("substitutes.json"), path =>
         {
             foreach (var m in p.LoadSubstitutes(path))
             {
@@ -1713,7 +1738,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             }
         });
 
-        SafeLoad(dir, "gags.json", path =>
+        SafeLoad(Pick("gags.json"), path =>
         {
             foreach (var m in p.LoadGags(path))
             {
@@ -1722,7 +1747,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             }
         });
 
-        SafeLoad(dir, "aliases.json", path =>
+        SafeLoad(Pick("aliases.json"), path =>
         {
             foreach (var m in p.LoadAliases(path))
             {
@@ -1731,10 +1756,10 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             }
         });
 
-        var macrosPath = Path.Combine(dir, "macros.json");
-        if (File.Exists(macrosPath))
+        var macrosPath = Pick("macros.json");
+        if (macrosPath is not null)
         {
-            SafeLoad(dir, "macros.json", path =>
+            SafeLoad(macrosPath, path =>
             {
                 foreach (var m in p.LoadMacros(path))
                     core.Macros.Add(m.Key, m.Action);
@@ -1742,32 +1767,33 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         }
         else
         {
-            // First run for this profile: seed Genie 4's classic numpad
-            // movement pad so 10-key travel works out of the box. Persisted
-            // so it appears in the Macros panel and the user can edit/remove
-            // any of it freely.
+            // First run for this profile (and no global macros either): seed
+            // Genie 4's classic numpad movement pad so 10-key travel works out
+            // of the box. Persisted to the profile dir so it appears in the
+            // Macros panel and the user can edit/remove any of it freely.
             SeedDefaultMovementMacros(core.Macros);
-            try { p.SaveMacros(macrosPath, core.Macros.Rules); } catch { /* best-effort seed */ }
+            try { p.SaveMacros(Path.Combine(profileDir, "macros.json"), core.Macros.Rules); } catch { /* best-effort seed */ }
         }
 
-        SafeLoad(dir, "variables.json", path =>
+        SafeLoad(Pick("variables.json"), path =>
         {
             foreach (var m in p.LoadVariables(path))
                 core.Variables.Store.Set(m.Name, m.Value);
         });
 
-        SafeLoad(dir, "windows.json", path =>
+        SafeLoad(Pick("windows.json"), path =>
         {
             foreach (var m in p.LoadWindowSettings(path))
                 WindowSettings.Apply(m);
         });
     }
 
-    /// <summary>Run a load callback against <c>{dir}/{name}</c> if it exists, swallowing exceptions.</summary>
-    private static void SafeLoad(string dir, string fileName, Action<string> load)
+    /// <summary>Run a load callback against <paramref name="path"/> when it's
+    /// non-null and present, swallowing exceptions (corrupt JSON shouldn't block
+    /// connect). Pair with the profile-over-global path resolver in the caller.</summary>
+    private static void SafeLoad(string? path, Action<string> load)
     {
-        var path = Path.Combine(dir, fileName);
-        if (!File.Exists(path)) return;
+        if (path is null || !File.Exists(path)) return;
         try { load(path); } catch { /* corrupt JSON shouldn't block connect */ }
     }
 


### PR DESCRIPTION
# Pull Request

## Summary

Fixes the Configuration dialog showing **empty** Variables / Aliases / Classes / Gags / Substitutes / Triggers / Highlights for a connected profile when those configs exist only in the shared global `Config/` dir.

Config loading moved from a single flat global dir to **per-profile** dirs (`Config/Profiles/<id>/`). A profile that hadn't customised a rule type loaded nothing for it, and global `Config/` files (earlier-prototype configs, imported Genie 4 rules) were never consulted. (`Classes` was additionally dropped from the connect-time load vs Genie5.Kzin, so it was always blank.)

Resolve each rule file with **profile-over-global precedence on read**; the connected profile's own copy wins when present, otherwise fall back to the shared global file. **Writes still go to the profile dir**, so the first edit promotes a global config into a per-profile override — the profile "overrules" the global thereafter, exactly as requested.

- `MainWindowViewModel.LoadSavedConfiguration`: per-file `Pick()` resolver; `SafeLoad` is now path-based. Restores loading `classes.json` on connect (loaded first so rule loaders' `Ensure()` can't clobber persisted active state).
- `ConfigurationViewModel`: `ReadPathFor()` applies the same precedence to the draft engines used when editing a non-connected profile; `GetDraftClasses` now actually loads `classes.json`. `PathFor` (writes) unchanged.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Plugin update
- [ ] Map update
- [ ] Build/tooling change
- [ ] Other

## Related Issue

Closes #59

## Testing

- `dotnet build -c Release` clean (0 warnings); app smoke-launches.
- Verified the live `PersistenceService` parses the real global files (356 aliases, 916 variables, 26 classes, 745 substitutes, 48 triggers, 267 highlights), so the fallback populates the engines.
- Unit-checked the resolver: profile copy overrides global; falls back to global when the profile lacks the file; null when neither exists.
