### PR TITLE
Scripting: expose $roomid / $zoneid / $zonename from the mapper (refs #45)

### DIFF
--- a/src/Genie.Core/GenieCore.cs
+++ b/src/Genie.Core/GenieCore.cs
@@ -313,6 +313,17 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
             accountName:   cfg.AccountName,
             clientVersion: HostVersionString);
 
+        // Mirror the AutoMapper's current location into the script globals so
+        // scripts can read $roomid / $zoneid / $zonename (Genie 4 parity — the
+        // mapper-sourced reserved vars deferred from #45). $roomid is the MAPPER
+        // node id (the numbers #goto and scripts compare against, e.g.
+        // `if $roomid != 156`), distinct from the server's $gameroomid. Seeded
+        // now for scripts that start before any move; refreshed on every
+        // CurrentNodeChanged. Scripts.Globals is concurrent, so the mapper-thread
+        // write is safe against script-thread reads.
+        SyncMapperGlobals();
+        AutoMapper.CurrentNodeChanged += SyncMapperGlobals;
+
         // ── Game event routing ─────────────────────────────────────────────────
         // Note: Scripts.OnGameLine already calls Extensions.DispatchGameLine internally —
         // no need to route TextEvents to the extension manager separately.
@@ -688,8 +699,25 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
         set => _connection.AiPipeEnabled = value;
     }
 
+    /// <summary>
+    /// Push the AutoMapper's current room/zone into the script globals
+    /// (<c>$roomid</c> / <c>$zoneid</c> / <c>$zonename</c>). <c>$roomid</c> is the
+    /// mapper node id (what <c>#goto</c> and scripts compare against), not the
+    /// server's <c>$gameroomid</c>. Defaults to <c>"0"</c> / empty when there's
+    /// no current node (off-map), matching Genie 4 / Genie5.Kzin.
+    /// </summary>
+    private void SyncMapperGlobals()
+    {
+        var node = AutoMapper.CurrentNode;
+        var zone = AutoMapper.ActiveZone;
+        Scripts.Globals["roomid"]   = node?.Id.ToString() ?? "0";
+        Scripts.Globals["zoneid"]   = zone?.Genie4Id ?? string.Empty;
+        Scripts.Globals["zonename"] = zone?.Name ?? string.Empty;
+    }
+
     public async ValueTask DisposeAsync()
     {
+        AutoMapper.CurrentNodeChanged -= SyncMapperGlobals;
         _gameEventSub.Dispose();
         _pluginXmlSub.Dispose();
         Plugins.Shutdown();


### PR DESCRIPTION
# Pull Request

## Summary

Exposes the mapper-sourced reserved script variables `$roomid` / `$zoneid` / `$zonename` (Genie 4 parity) — the items deferred from #45.

Scripts could not read `$roomid`: the engine only set the server-sourced `$gameroomid`. With it unset, those conditions never matched, so `AUTOMOVE` looped.

`GenieCore` now mirrors the AutoMapper's current location into `Scripts.Globals` on every `CurrentNodeChanged` (seeded at construction):
- `$roomid`   = `AutoMapper.CurrentNode.Id` (mapper **node** id — what `#goto` and scripts compare against; distinct from the server's `$gameroomid`), `"0"` when off-map
- `$zoneid`   = `AutoMapper.ActiveZone.Genie4Id`
- `$zonename` = `AutoMapper.ActiveZone.Name`

Unsubscribes in `DisposeAsync`. Mirrors my prototype wiring.

`$roomname` is left as-is (already game-sourced via `ScriptGlobalsSync`). Remaining #45 deferrals (`$monsterlist`/`$monstercount` update, `$gamehost`/`$gameport`, spell-timer vars) are unaffected and still open.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Plugin update
- [ ] Map update
- [ ] Build/tooling change
- [ ] Other

## Related Issue

Refs #45

## Testing

- `dotnet build -c Release` clean (0 warnings).
- Validated the read logic against the real `AutoMapperEngine`: `$zoneid`/`$zonename` flow from `ActiveZone`; `$roomid` defaults to `"0"` with no current node; node-id formats as a plain integer. The positive `$roomid` path is the same `node.Id.ToString()` and is confirmed by a live walk (the map numbers scripts compare to, e.g. 156/7).
