### PR TITLE
Scripting: wire ScheduleTick so pause/delay advance on their own timer (fixes #61)

### DIFF
--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -1966,6 +1966,21 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         // toggles (Window → Game Window) — supply Display so it can read
         // ShowGameText / ShowEchoText / ShowScriptText at subscription time.
         GameText.DisplaySettings = Display;
+
+        // Timer-driven script tick so `pause`/`delay` (and the RT gate) unblock
+        // on their own schedule instead of waiting for the next server event.
+        // Without this, a paused script only resumes when game text/a prompt
+        // arrives — so a `pause 0.5` between idle commands stalls until DR's
+        // periodic keepalive prompt (~10s), crawling any pause-heavy script.
+        // One-shot DispatcherTimer per scheduled wake (UI thread, where Tick
+        // already marshals its echo/send callbacks).
+        _core.Scripts.ScheduleTick = delay =>
+        {
+            var timer = new Avalonia.Threading.DispatcherTimer { Interval = delay };
+            timer.Tick += (_, _) => { timer.Stop(); _core.Scripts.Tick(); };
+            timer.Start();
+        };
+
         GameText.Attach(_core);
         Vitals.Attach(_core);
         Room.Attach(_core);


### PR DESCRIPTION
# Pull Request

## Summary

Fixes scripts stalling on `pause`/`delay` (#61). Each short pause could take ~10s — e.g. `tradeshard.cmd`'s non-existent-contract loop took ~10s per line.

`ScriptEngine` delegates timed wake-ups to the host hook `ScheduleTick`; `pause`, `delay`, and the roundtime gate call it to re-`Tick()` after a delay. **The app never wired it**, so `ScheduleTick` was null and `ScheduleTick?.Invoke(...)` was a no-op. A paused script could then only resume on the next game event — and while idle, that's DR's periodic keepalive `<prompt>` (~10s), so any pause-heavy script crawled.

Wire `Scripts.ScheduleTick` in `MainWindowViewModel` (where the engines are attached) to a one-shot `DispatcherTimer` that re-`Tick()`s after the delay — the same approach Genie5.Kzin uses (`MainWindow.Engine.cs:353`). `InRoundtime`/`RoundTimeRemainingSeconds` were already wired in `GenieCore`; only this timer hook was missing.

Not involved (ruled out while diagnosing): fractional `pause` parsing (handled), `match`/`matchwait` (substring match fires instantly; no timeout), `gosub`.

Note this was somehow overwritten or not pushed properly last time.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Plugin update
- [ ] Map update
- [ ] Build/tooling change
- [ ] Other

## Related Issue

Closes #61

## Testing

- `dotnet build -c Release` clean (0 warnings); app smoke-launches.
- Drove the real `ScriptEngine` with the hook wired: `pause 0.5` advances in ~0.56s with **no** game events; with the hook unwired the script never advances (reproduces the stall).
- Confirmed in-game: my trade script runs at full speed instead of ~10s per line.
