### PR TITLE
fix(docking): repair blank tool panels from Dock content recycling

### DIFF
--- a/src/Genie.App/Views/MainWindow.axaml
+++ b/src/Genie.App/Views/MainWindow.axaml
@@ -1012,7 +1012,8 @@
     <!-- InitializeLayout="False": the VM/factory init the layout explicitly
          (BuildDefaultLayout / BuildLayout call InitLayout) so runtime layout
          swaps are deterministic and don't double-initialise. -->
-    <dockc:DockControl Layout="{Binding DockLayout}"
+    <dockc:DockControl x:Name="MainDock"
+                       Layout="{Binding DockLayout}"
                        Factory="{Binding DockFactory}"
                        InitializeLayout="False"/>
 

--- a/src/Genie.App/Views/MainWindow.axaml.cs
+++ b/src/Genie.App/Views/MainWindow.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.ReactiveUI;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Genie.App.Controls;
 using Genie.App.ViewModels;
@@ -194,6 +195,29 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
                 }
             }));
 
+            // Repair Dock.Avalonia content recycling when a tool is (re)added to
+            // a dock. Dock hosts the active dockable's view in a ContentPresenter
+            // and, on an active-tab change, can recycle the previously-shown
+            // tool's realized visual — swapping only the DataContext without
+            // re-selecting the type-matched DataTemplate. A tool whose template
+            // differs from its neighbour then renders with the wrong template and
+            // shows blank (the Experience panel came up with the Backpack
+            // ItemsControl, bound to a ViewModel.Items it doesn't have). Popping
+            // out to a window built a fresh presenter, which is why that worked.
+            // Tools present from the initial layout build are unaffected; this
+            // bites panels opened later (Experience, plugin windows) or dragged
+            // between docks. DockableAdded fires for menu-open, drag-redock, and
+            // float alike, so hooking it covers every path.
+            if (ViewModel!.DockFactory is Docking.GenieDockFactory dockFactory)
+            {
+                void OnDockableAdded(object? _, Dock.Model.Core.Events.DockableAddedEventArgs e)
+                    => RebuildRecycledDockableContent(e.Dockable);
+
+                dockFactory.DockableAdded += OnDockableAdded;
+                d(System.Reactive.Disposables.Disposable.Create(
+                    () => dockFactory.DockableAdded -= OnDockableAdded));
+            }
+
             // Command-line auto-connect (--host/--port/--profile). Fired here so
             // the dialog interaction handlers above are already registered (the
             // connect path itself doesn't need them, but anything it triggers
@@ -201,6 +225,36 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
             // activations are harmless.
             _ = ViewModel!.RunStartupConnectAsync();
         });
+    }
+
+    /// <summary>
+    /// Force the host <see cref="Avalonia.Controls.Presenters.ContentPresenter"/>
+    /// of a freshly (re)added dockable to discard any recycled child and rebuild
+    /// the type-matched DataTemplate. Dock.Avalonia recycles the previously-shown
+    /// tool's realized visual on an active-tab change and only swaps the
+    /// DataContext, so a tool whose template differs from its neighbour renders
+    /// with the wrong template and shows blank (Avalonia content-recycling, see
+    /// issues #16891 / #14863). Toggling the presenter's <c>Content</c> clears the
+    /// cached child; the rebuild then resolves the correct template for this
+    /// dockable's type. Posted at <see cref="DispatcherPriority.Loaded"/> so Dock
+    /// has finished attaching the content visual before we touch it.
+    /// </summary>
+    private void RebuildRecycledDockableContent(Dock.Model.Core.IDockable? dockable)
+    {
+        if (dockable is null) return;
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (MainDock is null) return;
+            foreach (var cp in MainDock.GetVisualDescendants()
+                                       .OfType<Avalonia.Controls.Presenters.ContentPresenter>())
+            {
+                if (!ReferenceEquals(cp.Content, dockable)) continue;
+                cp.Content = null;
+                cp.UpdateChild();
+                cp.Content = dockable;
+                cp.UpdateChild();
+            }
+        }, DispatcherPriority.Loaded);
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem
Tool panels opened after startup (Experience, plugin windows) or dragged between docks rendered blank until popped out into their own window.

## Cause
Dock.Avalonia recycles the previously-shown tool's content presenter on an active-tab change, swapping only the DataContext without re-selecting the type-matched DataTemplate. A tool whose template differs from its neighbour then renders with the wrong template — e.g. the Experience panel came up with the Backpack `ItemsControl`, bound to a `ViewModel.Items` it doesn't have, so it showed blank. A fresh float-window presenter rebuilds correctly, which is why popping out worked.

## Fix
On `DockableAdded` (which fires for menu-open, drag-redock, and float), force the host `ContentPresenter` to discard the recycled child and rebuild the correct template for the dockable's type.

## Testing
Verified in-app: Experience and plugin (Time Tracker) panels now populate immediately while docked, with no pop-out needed.