### PR TITLE
docs: add issue templates + PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: A crash, wrong behaviour, or other defect in Genie 5
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+<!--
+Thanks for filing a bug. Please don't use this for security issues
+(credential leaks, code execution, etc.) — those go through SECURITY.md
+privately. Wrong parser output / untyped XML has its own template
+("Parser gap report") and is easier for us to act on there.
+-->
+
+## What happened
+
+<!-- A clear, concise description of the bug. -->
+
+## What you expected
+
+<!-- What you thought would happen instead. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- **OS + version:** <!-- e.g. Windows 11 23H2 / macOS 14.5 Apple Silicon / Ubuntu 24.04 -->
+- **Genie 5 version:** <!-- Help → About, or the release filename you downloaded -->
+- **Install type:** <!-- Setup.exe / .pkg / AppImage / Portable .zip / built from source -->
+- **.NET version (source builds only):** <!-- `dotnet --version` -->
+- **Connection mode:** <!-- Direct SGE / Lich Proxy / Dev-replay -->
+
+## Logs / session capture
+
+<!--
+If it's reproducible, a raw-XML capture helps a lot: File → Record Session…,
+reproduce, then attach the resulting file (it stays local until you upload it).
+Strip anything you don't want public — captures can contain account/character
+names and other players' speech. Paste relevant log lines below.
+-->
+
+```
+(paste here)
+```
+
+## Anything else
+
+<!-- Workarounds you found, how often it happens, whether it's a regression from a prior build, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🔒 Security vulnerability
+    url: https://github.com/GenieClient/Genie5/blob/main/SECURITY.md
+    about: Credential leaks, code execution, or anything that could harm another user — please report privately, not as a public issue.
+  - name: 💬 Discord community
+    url: https://discord.gg/MtmzE2w
+    about: Scripting help, mapper questions, alpha-tester chat, or sanity-checking an idea before opening an issue.
+  - name: 💡 Discussions
+    url: https://github.com/GenieClient/Genie5/discussions
+    about: Open-ended Q&A, ideas, and show-and-tell that aren't bug reports or feature requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,48 @@
+---
+name: Feature request
+about: Suggest a capability or improvement for Genie 5
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+<!--
+Before writing a large feature, it's worth opening this issue (or asking in
+Discord) first — it saves a round-trip if the idea needs reshaping for policy
+or architecture reasons. Lead with the use case, not the implementation.
+-->
+
+## The use case
+
+<!--
+What are you trying to do? Start from the player's situation —
+"when I'm hunting and …", "while travelling across zones …" — rather than
+jumping straight to a proposed setting or button.
+-->
+
+## Proposed solution
+
+<!-- What you'd like Genie 5 to do. UI sketches / mockups welcome but not required. -->
+
+## How others handle it
+
+<!--
+Bonus points: how do Genie 4, Lich 5, Wrayth/StormFront, or Mudlet handle the
+same thing? Prior art helps us stay compatible and design something familiar.
+-->
+
+## Policy check
+
+<!--
+Genie holds a few hard lines (see docs/POLICY.md): no auto-reconnect, no
+agentive AI driving commands, no headless mode, no shipping other players'
+speech off-machine without consent. Anything that constrains how a player runs
+the client must be opt-in and off by default.
+
+Does any step of this feature happen while the user is NOT at the keyboard?
+If you're unsure, say so — we'll work it out in the thread.
+-->
+
+## Alternatives considered
+
+<!-- Other approaches you thought about, and why this one is better. -->

--- a/.github/ISSUE_TEMPLATE/parser_gap_report.md
+++ b/.github/ISSUE_TEMPLATE/parser_gap_report.md
@@ -1,0 +1,48 @@
+---
+name: Parser gap report
+about: Wrong game-text output, untyped XML, or a tag Genie 5 doesn't understand
+title: "[Parser] "
+labels: parser-gap
+assignees: ''
+---
+
+<!--
+Parser-gap reports are some of the most valuable contributions to Genie 5 —
+they're how the XML parser learns DragonRealms' full tag vocabulary. The single
+most useful thing you can attach is a raw-XML capture of the moment it went
+wrong: File → Record Session…, reproduce, then find the relevant section.
+-->
+
+## What you saw
+
+<!--
+What did Genie 5 display, and what was wrong about it? e.g. "the held-item name
+leaked into the room description", "whisper text was split across two lines",
+"this verb's output showed raw <tag> markup".
+-->
+
+## What it should have shown
+
+<!-- The correct text / behaviour, as best you can describe it. -->
+
+## Raw XML snippet
+
+<!--
+Paste the relevant lines from a File → Record Session… capture. Include a little
+context before and after the problem. Captures can contain account/character
+names and other players' speech — trim anything you don't want public.
+-->
+
+```xml
+(paste the raw XML here)
+```
+
+## Game context
+
+- **Verb / action that produced it:** <!-- e.g. `look`, `inventory`, a whisper received, entering a room -->
+- **Connection mode:** <!-- Direct SGE / Lich Proxy / Dev-replay -->
+- **Genie 5 version:** <!-- Help → About, or release filename -->
+
+## Anything else
+
+<!-- Is it consistent or intermittent? Tied to a specific room / item / NPC? Did it work in Genie 4? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for contributing to Genie 5! Keep PRs focused — one feature or one fix.
+For anything beyond a trivial change, please open an issue first (see CONTRIBUTING.md).
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? Link the issue it closes: "Closes #123". -->
+
+## Test plan
+
+<!--
+What did you do to verify this works, and what could it have broken? Be specific.
+For parser / scripting / mapper changes, a REPLAY smoke-test against a real
+recording is the easiest path:
+  dotnet run --project src/Genie.Core -- REPLAY <file>
+-->
+
+## Checklist
+
+- [ ] `dotnet build -c Release` succeeds cleanly (warnings OK, errors not)
+- [ ] Tests / relevant test-harness modes pass for the subsystems I touched
+- [ ] **No machine-specific paths** committed (no `C:\Users\…`, no hard-coded home dirs, no local absolute paths — use `AppPaths` / config)
+- [ ] **No AI brand references** in tracked files (the public repo stays vendor-neutral)
+- [ ] Docs updated if user-visible behaviour changed (README / CONTRIBUTING / `docs/`)
+- [ ] This is a focused PR — one feature or one fix
+
+## Compatibility & policy
+
+<!-- Tick the lines that apply; delete the ones that don't. -->
+
+- [ ] **Script parity** — if I touched the `.cmd` engine, existing Genie 4 scripts still work (tested against DR-Genie-Scripts where relevant)
+- [ ] **Map format** — if I touched map I/O, Genie 4 `.xml` zone files still round-trip without loss
+- [ ] **SGE protocol** — if I touched the handshake, I verified against the Genie 4 source / `docs/SGE_PROTOCOL.md`
+- [ ] **DR policy acknowledged** — this change introduces no auto-reconnect, no agentive AI driving commands, no headless mode, and ships no other-player speech off-machine without consent. Anything that constrains how a player runs the client is opt-in and off by default. (See `docs/POLICY.md`.)


### PR DESCRIPTION
Adds the GitHub community files for the repo:

- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`
- `.github/ISSUE_TEMPLATE/parser_gap_report.md`
- `.github/ISSUE_TEMPLATE/config.yml` (routes Security / Discord / Discussions)
- `.github/PULL_REQUEST_TEMPLATE.md`

**Fixes currently-broken links:** `CONTRIBUTING.md` already points at `?template=bug_report.md` and `?template=feature_request.md`, but those template files did not exist in the repo yet — those links 404 today. This adds the matching files.

All `config.yml` URLs target this repo (Security policy, Discussions) plus the community Discord; `SECURITY.md` link target exists.