### PR TITLE
feat(typeahead): account-tier limit, server-cap calibration, command-bar counter

### DIFF
--- a/src/Genie.App/Controls/TypeAheadCounterConverters.cs
+++ b/src/Genie.App/Controls/TypeAheadCounterConverters.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace Genie.App.Controls;
+
+/// <summary>
+/// Renders the command-bar type-ahead counter as a keyboard glyph followed by
+/// one pip per available slot: filled (●) for in-flight commands, hollow (○)
+/// for free slots — e.g. "⌨ ●●○" for 2 of 3 used. Bind multi: [InFlight, Limit].
+/// Reference from XAML via <c>{x:Static controls:TypeAheadPipsConverter.Instance}</c>.
+/// </summary>
+public sealed class TypeAheadPipsConverter : IMultiValueConverter
+{
+    public static readonly TypeAheadPipsConverter Instance = new();
+
+    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        int inFlight = values.Count > 0 && values[0] is int a ? a : 0;
+        int limit    = values.Count > 1 && values[1] is int b ? b : 0;
+        if (limit < 1)    limit = 1;
+        if (inFlight < 0) inFlight = 0;
+        if (inFlight > limit) inFlight = limit;
+
+        var sb = new StringBuilder("⌨ ");
+        for (int i = 0; i < limit; i++)
+            sb.Append(i < inFlight ? '●' : '○');
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// Colours the type-ahead counter by state: dim grey when idle (nothing typed
+/// ahead), normal when partially full, amber at the cap. Bind multi:
+/// [InFlight, Limit]. Reference via <c>{x:Static controls:TypeAheadBrushConverter.Instance}</c>.
+/// </summary>
+public sealed class TypeAheadBrushConverter : IMultiValueConverter
+{
+    public static readonly TypeAheadBrushConverter Instance = new();
+
+    private static readonly IBrush Idle    = new SolidColorBrush(Color.Parse("#5a5a5a"));
+    private static readonly IBrush Partial = new SolidColorBrush(Color.Parse("#cfcfcf"));
+    private static readonly IBrush Full     = new SolidColorBrush(Color.Parse("#ffc107"));
+
+    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        int inFlight = values.Count > 0 && values[0] is int a ? a : 0;
+        int limit    = values.Count > 1 && values[1] is int b ? b : 0;
+        if (limit < 1) limit = 1;
+
+        if (inFlight <= 0)      return Idle;
+        if (inFlight >= limit)  return Full;
+        return Partial;
+    }
+}

--- a/src/Genie.App/ViewModels/VitalsViewModel.cs
+++ b/src/Genie.App/ViewModels/VitalsViewModel.cs
@@ -18,6 +18,14 @@ public class VitalsViewModel : ReactiveObject
     [Reactive] public double RoundTimeSeconds { get; private set; }
     [Reactive] public bool   InRoundTime      { get; private set; }
 
+    /// <summary>Commands currently typed ahead of the game (sent, awaiting a
+    /// prompt). Drives the filled pips in the command-bar type-ahead counter.</summary>
+    [Reactive] public int    TypeAheadInFlight { get; private set; }
+
+    /// <summary>The type-ahead cap (1 free / 2 premium / 3 +LTB, or the
+    /// server-calibrated value). Number of pips drawn by the counter.</summary>
+    [Reactive] public int    TypeAheadLimit    { get; private set; } = 2;
+
     /// <summary>Bare prepared-spell name from <c>&lt;spell&gt;X&lt;/spell&gt;</c>.
     /// Empty or "None" means no spell held. This is what scripts see as
     /// <c>$preparedspell</c>; the UI binds to <see cref="PreparedSpellLabel"/>.</summary>
@@ -130,6 +138,23 @@ public class VitalsViewModel : ReactiveObject
     {
         // ShowSpellTimer (Genie 4): gate the prepared-spell timer display.
         IsSpellTimerVisible = core.Config?.ShowSpellTimer ?? true;
+
+        // ── Type-ahead counter ──────────────────────────────────────────────
+        // Mirror the Core type-ahead state into reactive props. The Changed
+        // event can fire off the UI thread (send happens on the script/UI
+        // thread, the prompt decrement on the parser thread), so marshal.
+        void SyncTypeAhead()
+        {
+            void apply()
+            {
+                TypeAheadInFlight = core.TypeAheadInFlight;
+                TypeAheadLimit    = core.TypeAheadLimit;
+            }
+            if (Dispatcher.UIThread.CheckAccess()) apply();
+            else Dispatcher.UIThread.Post(apply);
+        }
+        core.TypeAheadChanged += SyncTypeAhead;
+        SyncTypeAhead(); // seed initial values
 
         core.GameEvents.OfType<ProgressBarEvent>()
             .ObserveOn(RxApp.MainThreadScheduler)

--- a/src/Genie.App/Views/MainWindow.axaml
+++ b/src/Genie.App/Views/MainWindow.axaml
@@ -1108,10 +1108,11 @@
     </Border>
 
     <!-- ── Command bar (above status bar) ────────────────────────────────── -->
-    <!-- Three columns: RT badge | input box | Send. The RT badge is only
-         visible while a roundtime is active; it ticks down live courtesy of
-         the VitalsViewModel timer. -->
-    <Grid DockPanel.Dock="Bottom" ColumnDefinitions="Auto,*,Auto" Margin="4,2">
+    <!-- Four columns: RT badge | type-ahead counter | input box | Send. The RT
+         badge is only visible while a roundtime is active; it ticks down live
+         courtesy of the VitalsViewModel timer. The type-ahead counter sits
+         between RT and the input and is always visible (dim when idle). -->
+    <Grid DockPanel.Dock="Bottom" ColumnDefinitions="Auto,Auto,*,Auto" Margin="4,2">
 
       <Border Grid.Column="0"
               IsVisible="{Binding ShowRtInCommandBar}"
@@ -1127,7 +1128,35 @@
         </TextBlock>
       </Border>
 
-      <TextBox Grid.Column="1"
+      <!-- ── Type-ahead counter ──────────────────────────────────────────
+           Pips show the type-ahead buffer: filled = commands queued ahead of
+           the game, hollow = free slots, up to the per-account cap (1 free /
+           2 premium / 3 +LTB, auto-calibrated from the server). Dim when idle,
+           amber at the cap. -->
+      <Border Grid.Column="1"
+              Background="#2a2a2a" BorderBrush="#444" BorderThickness="1"
+              CornerRadius="3" Padding="6,2" Margin="0,0,4,0"
+              VerticalAlignment="Stretch"
+              ToolTip.Tip="Type-ahead buffer — commands queued ahead of the game (filled = used, hollow = free). DR caps this per account: free 1, premium 2, +1 with the LTB line. Amber means the buffer is full.">
+        <TextBlock FontWeight="SemiBold"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   FontFamily="Consolas,Courier New,monospace" FontSize="12">
+          <TextBlock.Text>
+            <MultiBinding Converter="{x:Static controls:TypeAheadPipsConverter.Instance}">
+              <Binding Path="Vitals.TypeAheadInFlight"/>
+              <Binding Path="Vitals.TypeAheadLimit"/>
+            </MultiBinding>
+          </TextBlock.Text>
+          <TextBlock.Foreground>
+            <MultiBinding Converter="{x:Static controls:TypeAheadBrushConverter.Instance}">
+              <Binding Path="Vitals.TypeAheadInFlight"/>
+              <Binding Path="Vitals.TypeAheadLimit"/>
+            </MultiBinding>
+          </TextBlock.Foreground>
+        </TextBlock>
+      </Border>
+
+      <TextBox Grid.Column="2"
                Text="{Binding Command.CommandText}"
                Watermark="Enter command..."
                FontFamily="Consolas,Courier New,monospace"
@@ -1136,7 +1165,7 @@
           <KeyBinding Gesture="Return" Command="{Binding Command.SubmitCommand}"/>
         </TextBox.KeyBindings>
       </TextBox>
-      <Button Grid.Column="2" Content="Send" Margin="4,0,0,0"
+      <Button Grid.Column="3" Content="Send" Margin="4,0,0,0"
               Command="{Binding Command.SubmitCommand}"/>
     </Grid>
 

--- a/src/Genie.Core/GameConnection.cs
+++ b/src/Genie.Core/GameConnection.cs
@@ -96,6 +96,14 @@ public sealed class GameConnection : IAsyncDisposable
     /// </summary>
     public string ResolvedGameHost { get; private set; } = string.Empty;
 
+    /// <summary>
+    /// True when the last DirectSGE login reported a PREMIUM account. Used to
+    /// seed the DR type-ahead limit (premium accounts get an extra type-ahead
+    /// line). Stays false for Lich / DevReplay (no SGE handshake), where the
+    /// limit instead self-calibrates from the server's cap message.
+    /// </summary>
+    public bool AccountPremium { get; private set; }
+
     /// <summary>The port paired with <see cref="ResolvedGameHost"/>; surfaced as
     /// <c>$gameport</c>. 0 until first connect.</summary>
     public int ResolvedGamePort { get; private set; }
@@ -268,6 +276,7 @@ public sealed class GameConnection : IAsyncDisposable
         // Remember which transport the login actually used so the UI can show a
         // TLS / plaintext indicator (the TLS attempt auto-falls-back to plain).
         _authTransport = sgeResult.UsedTls ? "TLS" : "plaintext";
+        AccountPremium = sgeResult.IsPremium;
 
         _log.LogInformation("SGE OK → connecting to game {Host}:{Port}",
             sgeResult.GameHost, sgeResult.GamePort);

--- a/src/Genie.Core/GenieCore.cs
+++ b/src/Genie.Core/GenieCore.cs
@@ -161,6 +161,21 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
     /// <summary>Connection lifecycle events.</summary>
     public IObservable<ConnectionEvent> ConnectionState => _connection.StateStream;
 
+    // ── Type-ahead (UI counter) ─────────────────────────────────────────────
+    /// <summary>Commands sent to the game awaiting a prompt — the live
+    /// type-ahead buffer occupancy shown by the command-bar counter.</summary>
+    public int TypeAheadInFlight => _typeAhead.InFlight;
+    /// <summary>The current type-ahead cap (1 free / 2 premium / 3 +LTB, or the
+    /// server-calibrated value).</summary>
+    public int TypeAheadLimit    => _typeAhead.Limit;
+    /// <summary>Raised when <see cref="TypeAheadInFlight"/> or
+    /// <see cref="TypeAheadLimit"/> changes. May fire off the UI thread.</summary>
+    public event Action? TypeAheadChanged
+    {
+        add    => _typeAhead.Changed += value;
+        remove => _typeAhead.Changed -= value;
+    }
+
     /// <summary>Timed connect-progress sink (TLS attempt, per-step SGE timings,
     /// fallback, game-server connect) surfaced to the game window so a stall can
     /// be isolated to an exact step. Set by the host before connecting.</summary>
@@ -352,6 +367,7 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
             sendCommand:   cmd =>
                            {
                                ScriptOutputLine?.Invoke(cmd);
+                               _typeAhead.NotifySent();
                                _ = _connection.SendCommandAsync(cmd);
                            },
             echo:          msg => ScriptOutputLine?.Invoke(msg),
@@ -411,6 +427,12 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
             switch (evt)
             {
                 case TextEvent te:
+                    // Self-calibrate the type-ahead limit from the server's own cap
+                    // report ("(Sorry,) you may only type ahead N line(s).") so a
+                    // wrong seed (e.g. a Lich/DevReplay default, or premium+LTB) is
+                    // corrected by the authority. Cheap guard before any parsing.
+                    if (te.Text.IndexOf("type ahead", StringComparison.OrdinalIgnoreCase) >= 0)
+                        CalibrateTypeAhead(te.Text);
                     // Each per-line consumer is timed into its own stage so the
                     // overlay shows which feature is eating the frame. The Time
                     // wrapper is a zero-overhead passthrough while disabled.
@@ -430,6 +452,7 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
                     break;
 
                 case PromptEvent:
+                    _typeAhead.NotifyConsumed();   // server caught up → free a type-ahead slot
                     Scripts.OnPrompt();            // advance RT-gated script execution
                     Plugins.DispatchPrompt();
                     break;
@@ -476,6 +499,19 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
                 Scripts.Globals["gameport"] = _connection.ResolvedGamePort > 0
                     ? _connection.ResolvedGamePort.ToString(System.Globalization.CultureInfo.InvariantCulture)
                     : "0";
+
+                // Seed the DR type-ahead limit from the account tier reported by
+                // the SGE login: free/basic = 1 line, premium = 2 (premium grants
+                // an extra type-ahead line). A premium+LTB account (3 lines) self-
+                // calibrates up via the server cap message if it ever overruns.
+                // Only DirectSGE knows the tier; Lich/DevReplay keep the default
+                // and rely on cap-message calibration. Refreshes each (re)connect.
+                if (cfg.Mode == ConnectionMode.DirectSGE)
+                    _typeAhead.Limit = _connection.AccountPremium ? 2 : 1;
+
+                // Fresh session → clear any stale type-ahead count so the UI
+                // counter starts empty.
+                _typeAhead.ResetInFlight();
             });
 
         // ── Per-character profile directory ────────────────────────────────────
@@ -546,6 +582,7 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
         // Genie 4 reserved $lastcommand — the last line sent to the game.
         Scripts.Globals["lastcommand"] = text;
 
+        _typeAhead.NotifySent();
         _ = _connection.SendCommandAsync(text);
     }
 
@@ -563,6 +600,35 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
     /// if one is configured (Genie 4 parity). A bad/missing connect-script name
     /// must never break the connect, so failures are swallowed.
     /// </summary>
+    /// <summary>
+    /// Parse the server's type-ahead cap report — "(Sorry,) you may only type
+    /// ahead N line(s)." — and set the shared <see cref="TypeAheadSession.Limit"/>
+    /// to N. DR phrases the single-line case as the word "one"; multi-line as a
+    /// digit. This is the authoritative correction for a mis-seeded limit.
+    /// </summary>
+    private void CalibrateTypeAhead(string line)
+    {
+        const string marker = "type ahead ";
+        int i = line.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (i < 0) return;
+        var rest = line[(i + marker.Length)..].TrimStart();
+        // Grab the token after the marker (a digit run or a number word).
+        int end = 0;
+        while (end < rest.Length && !char.IsWhiteSpace(rest[end]) && rest[end] != '.') end++;
+        var token = rest[..end];
+
+        int cap = token.ToLowerInvariant() switch
+        {
+            "one"   => 1,
+            "two"   => 2,
+            "three" => 3,
+            "four"  => 4,
+            _ => int.TryParse(token, out var n) ? n : 0,
+        };
+        if (cap >= 1 && cap != _typeAhead.Limit)
+            _typeAhead.Limit = cap;
+    }
+
     private void OnConnectReady()
     {
         var __ = _connection.SendCommandAsync("look");

--- a/src/Genie.Core/Scripting/TypeAheadSession.cs
+++ b/src/Genie.Core/Scripting/TypeAheadSession.cs
@@ -1,10 +1,61 @@
 namespace Genie.Core.Scripting;
 
 /// <summary>
-/// Session-wide type-ahead limit, shared by the mapper and the script engine.
-/// Auto-calibrated downward when the server reports its cap.
+/// Session-wide DR type-ahead limit, shared by the mapper and the script engine
+/// (how many commands may be pipelined before the server rejects with "you may
+/// only type ahead N lines"). DR caps this per account: free/basic = 1, premium
+/// = 2, premium+LTB = 3.
+///
+/// Lifecycle:
+/// <list type="bullet">
+/// <item>On a DirectSGE connect, <see cref="GenieCore"/> seeds it from the
+///   account tier reported by the SGE login (1 free / 2 premium).</item>
+/// <item>It then self-calibrates to the authoritative value if the server ever
+///   reports its cap ("(Sorry,) you may only type ahead N line(s).") — see
+///   <c>GenieCore.CalibrateTypeAhead</c>. This corrects a mis-seed in either
+///   direction (e.g. premium+LTB up to 3, or a too-high Lich/DevReplay default).</item>
+/// </list>
+/// The default below is the pre-connect / non-SGE (Lich, DevReplay) fallback;
+/// those paths don't know the tier and rely on cap-message calibration.
 /// </summary>
 public sealed class TypeAheadSession
 {
-    public int Limit { get; set; } = 3;
+    private int _limit = 3;
+    private int _inFlight;
+
+    /// <summary>Raised whenever <see cref="Limit"/> or <see cref="InFlight"/>
+    /// changes, so a UI counter can refresh. May fire on any thread — handlers
+    /// must marshal to the UI thread themselves.</summary>
+    public event Action? Changed;
+
+    /// <summary>Max commands that may be pipelined ahead of the game (see class
+    /// summary). Seeded from the account tier and calibrated from the server cap.</summary>
+    public int Limit
+    {
+        get => _limit;
+        set { if (value != _limit) { _limit = value; Changed?.Invoke(); } }
+    }
+
+    /// <summary>Commands sent to the game that the server hasn't acknowledged
+    /// yet (incremented on send, decremented on each game prompt). Clamped to
+    /// ≥ 0. This is the live "type-ahead buffer occupancy" the UI counter shows.</summary>
+    public int InFlight
+    {
+        get => _inFlight;
+        private set
+        {
+            var v = value < 0 ? 0 : value;
+            if (v != _inFlight) { _inFlight = v; Changed?.Invoke(); }
+        }
+    }
+
+    /// <summary>A command was sent to the game — one type-ahead slot consumed.</summary>
+    public void NotifySent() => InFlight = _inFlight + 1;
+
+    /// <summary>The game emitted a prompt — the server processed input, so one
+    /// slot frees. No-op when already empty (floored at 0).</summary>
+    public void NotifyConsumed() => InFlight = _inFlight - 1;
+
+    /// <summary>Clear the in-flight count (e.g. on (re)connect).</summary>
+    public void ResetInFlight() => InFlight = 0;
 }

--- a/src/Genie.Core/SgeAuthClient.cs
+++ b/src/Genie.Core/SgeAuthClient.cs
@@ -42,7 +42,7 @@ public sealed class SgeAuthClient(ILogger<SgeAuthClient> logger)
     /// hitting a connection stall can capture a full trace on demand without
     /// every normal login spamming the game window.</summary>
     public bool VerboseDiag { get; set; }
-    public sealed record SgeResult(string GameHost, int GamePort, string GameKey, bool UsedTls = false);
+    public sealed record SgeResult(string GameHost, int GamePort, string GameKey, bool UsedTls = false, bool IsPremium = false);
     public sealed record SgeCharacter(string Code, string Name);
 
     /// <summary>
@@ -195,6 +195,13 @@ public sealed class SgeAuthClient(ILogger<SgeAuthClient> logger)
         await StreamWriteAsync(stream, $"G\t{cfg.GameCode}\n", ct);
         var gameResponse = await ReadLineAsync(stream, useTls, ct);
         logger.LogDebug("Game select: {GameResponse}", gameResponse);
+        // The game-select response carries the account's subscription type as one
+        // of its tab fields (PREMIUM / NORMAL / FREE_TO_PLAY / TRIAL / …). We keep
+        // only whether it's PREMIUM — used to seed the DR type-ahead limit (premium
+        // accounts get an extra type-ahead line; see TypeAheadSession). Scan ALL
+        // fields rather than a fixed index, same defensive approach as PROBLEM codes.
+        bool isPremium = gameResponse.Split('\t')
+            .Any(f => f.Equals("PREMIUM", StringComparison.OrdinalIgnoreCase));
         mark("→M/G  ←game selected");
 
         // ── Step 6: Character list ───────────────────────────────────────────
@@ -224,7 +231,7 @@ public sealed class SgeAuthClient(ILogger<SgeAuthClient> logger)
         logger.LogWarning("SGE login response: {LoginResponse}", loginResponse);
         mark("→L  ←login token");
 
-        return ParseLoginResponse(loginResponse) with { UsedTls = useTls };
+        return ParseLoginResponse(loginResponse) with { UsedTls = useTls, IsPremium = isPremium };
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds DR type-ahead awareness and a visual counter.

## Type-ahead limit (correctness)
DR caps type-ahead per account — free/basic = 1 line, premium = 2, premium+LTB = 3.
- Seed the limit from the account tier reported by the SGE login (`SgeResult.IsPremium`, parsed from the game-select response; surfaced as `GameConnection.AccountPremium`).
- Self-calibrate to the server's authoritative cap when it reports "(Sorry,) you may only type ahead N line(s)", correcting any mis-seed in either direction (e.g. premium+LTB, or a non-SGE default).

## Command-bar counter (UI)
A pip indicator between the roundtime badge and the input box:
```
⌨ ●○   1 of 2 used
⌨ ●●○  2 of 3 used
⌨ ●●●  full (amber)
```
Filled = commands queued ahead of the game, hollow = free slots. Dim when idle, amber at the cap, always visible. Live-updates as commands are sent and drains one per game prompt.

## Implementation
- `TypeAheadSession` tracks live in-flight count with a change event.
- `VitalsViewModel` mirrors the state (UI-thread-marshalled).
- Two multi-value converters render the pips and the state colour.

Builds clean (Core + App).