### PR TITLE
Mapper/scripting: coalesce room placement + move-unblock to the prompt (fixes #91)

### DIFF
--- a/src/Genie.Core/GenieCore.cs
+++ b/src/Genie.Core/GenieCore.cs
@@ -147,6 +147,12 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
     private readonly ScriptGlobalsSync _globalsSync;
     private readonly Diagnostics.LiveAudit _liveAudit;
 
+    /// <summary>Set when a room-defining event arrives (NavEvent or the
+    /// room-title component); consumed on the next prompt to unblock the
+    /// script <c>move</c> command. Coalescing to the prompt lets uid-less
+    /// "(**)" rooms — which emit no NavEvent — still wake a paused move.</summary>
+    private bool _roomChangedSincePrompt;
+
     /// <summary>.cmd script runner. Includes built-in EXP and info trackers.</summary>
     public ScriptEngine Scripts { get; }
 
@@ -454,11 +460,29 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
                 case PromptEvent:
                     _typeAhead.NotifyConsumed();   // server caught up → free a type-ahead slot
                     Scripts.OnPrompt();            // advance RT-gated script execution
+                    // Unblock `move` once the room has settled. We key off the
+                    // prompt (turn boundary) rather than NavEvent directly because
+                    // DR emits NO NavEvent for "(**)" rooms (no server uid) — yet
+                    // the player IS in a new room. Without this, `move go guild`
+                    // into such a room reaches it but never unblocks. The flag is
+                    // set by NavEvent OR the room-title component below, so both
+                    // uid and uid-less rooms wake the script.
+                    if (_roomChangedSincePrompt)
+                    {
+                        _roomChangedSincePrompt = false;
+                        Scripts.OnRoomChanged();
+                    }
                     Plugins.DispatchPrompt();
                     break;
 
                 case NavEvent:
-                    Scripts.OnRoomChanged();       // unblock `move` in running scripts
+                    _roomChangedSincePrompt = true;
+                    break;
+
+                case ComponentEvent ce
+                    when ce.ComponentId.Equals("room title", StringComparison.OrdinalIgnoreCase):
+                    // Room arrival without a NavEvent (e.g. "(**)" no-uid rooms).
+                    _roomChangedSincePrompt = true;
                     break;
             }
         });

--- a/src/Genie.Core/Mapper/MapperGameStateAdapter.cs
+++ b/src/Genie.Core/Mapper/MapperGameStateAdapter.cs
@@ -62,25 +62,46 @@ public sealed class MapperGameStateAdapter : IMapperGameState, IDisposable
 
     public event Action? StateChanged;
 
+    /// <summary>
+    /// Set when a room-defining event (nav / compass / room title / room desc)
+    /// arrives; cleared when we flush on the next prompt. See the constructor
+    /// for why we coalesce rather than fire per-event.
+    /// </summary>
+    private bool _roomDirty;
+
     public MapperGameStateAdapter(Models.GameState state, IObservable<GameEvent> events)
     {
         _state = state;
 
-        // Fire StateChanged on every event that could have updated Room.*.
-        // GameStateEngine writes the fields BEFORE the next event reaches our
-        // subscriber, so by the time we read _state.Room here, the new value
-        // is already present.
+        // COALESCE room updates to the prompt that ends the server turn, rather
+        // than firing per room-component event. DR streams a room as a sequence
+        // — title → desc → objs → exits/<compass> — and the TITLE arrives before
+        // THIS room's compass. Firing on each event made the engine fingerprint
+        // the new title against the PREVIOUS room's exits (and against the
+        // transient empty-compass mid-parse), producing wrong fingerprints that
+        // miss every zone — then the one coherent (title + own compass) snapshot
+        // arrives too late, after the misses have already poisoned the auto-load
+        // dedup. DR sends a <prompt> at the end of every turn, AFTER the full
+        // room block, so by then Title / Exits / RoomId are all the new room's:
+        // a single flush there gives the engine one coherent snapshot.
+        //
+        // Idle/keepalive prompts (no preceding room change) leave _roomDirty
+        // false and are ignored, so this doesn't add spurious placements.
         _subscription = events.Subscribe(e =>
         {
             switch (e)
             {
                 case NavEvent:
                 case CompassEvent:
-                    StateChanged?.Invoke();
+                    _roomDirty = true;
                     break;
                 case ComponentEvent ce
                     when ce.ComponentId.Equals("room title", StringComparison.OrdinalIgnoreCase)
                       || ce.ComponentId.Equals("room desc",  StringComparison.OrdinalIgnoreCase):
+                    _roomDirty = true;
+                    break;
+                case PromptEvent when _roomDirty:
+                    _roomDirty = false;
                     StateChanged?.Invoke();
                     break;
             }


### PR DESCRIPTION
# Pull Request

## Summary

Fixes scripts that walk with the engine `move` command and read `$roomid` (e.g. `tradeshard.cmd`, `travel.cmd`) stalling — two related defects, both resolved by coalescing room signals to the prompt that ends the turn.

**Bug 1 — mapper couldn't place rooms.** `MapperGameStateAdapter` fingerprinted on every room component, but DR streams a room as title → desc → exits/`<compass>`, so the new title was matched against the *previous* room's compass (and the transient empty compass). Wrong fingerprints missed every zone and poisoned the auto-load dedup → `$roomid` stayed 0 → scripts hit their `if $roomid = 0` RANDOMMOVE fallback.

**Bug 2 — `move` hung in `(**)` rooms.** The engine `move` command unblocks only on `OnRoomChanged ← NavEvent`, but DR emits no `NavEvent` for uid-less `(**)` rooms (no `(NNNNN)` in the subtitle). So `move go guild` into such a room reached it but never unblocked.

**Fix.**
- `MapperGameStateAdapter`: mark the room dirty on nav/compass/title/desc and flush `StateChanged` **once on the `<prompt>`**, when title + compass + room-id are all the new room's — one coherent placement per room.
- `GenieCore`: set a room-changed flag on `NavEvent` **or** the `room title` component and flush `Scripts.OnRoomChanged()` on the prompt, so uid-less rooms wake the paused `move`.

Both *reduce* per-room work (one coalesced fire vs several partial ones), so the engine isn't slowed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Plugin update
- [ ] Map update
- [ ] Build/tooling change
- [ ] Other

## Related Issue

Closes #91

## Testing

- `dotnet build -c Release` clean (0 warnings).
- **Live (`#audit on`, tradeshard through Riverhaven):** before — `No local zone contains …`, `$roomid=0`, RANDOMMOVE; after — **0** `MISS`/`LOST`/`can't match`, every room placed, `$roomid` = 137 (Shipping Dock) / 156 (Bank Teller) / 224 (Guild Lobby), and `move go guild` into the `(**)` Guild Lobby continues instead of parking.
- **Harnesses** (real engine): coalescing fires `StateChanged` exactly once on the prompt with a coherent `title="Traders' Guild, Shipping Dock"`, `exits="out"`; `move` parks after sending then unblocks on `OnRoomChanged()` with **no `NavEvent`**.
- Behavioral note: `move` now also unblocks if a room block re-arrives from a `look` (it keys on the room-title/prompt, not a uid) — matches Genie 4's "move waits for the room window update," and `move` is only ever parked right after a movement command.
