### PR TITLE
fix(#84): support #echo mono + colour on the main window

### DIFF
--- a/src/Genie.App/ViewModels/GameTextViewModel.cs
+++ b/src/Genie.App/ViewModels/GameTextViewModel.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Documents;
+using Avalonia.Media;
 using Genie.App.Highlighting;
 using Genie.App.Settings;
 using Genie.Core;
@@ -202,6 +203,22 @@ public class GameTextViewModel : ReactiveObject
                 AddLine(msg, StreamColor.System);
             });
 
+        // ── Styled #echo (colour / mono, no >window) ──────────────────────
+        // `#echo Yellow foo` / `#echo mono foo` from the command bar or a
+        // script: a main-window line carrying an explicit colour and/or a
+        // monospaced font. Governed by the same Echo-text filter as a plain
+        // #echo; rendered via the explicit-style path on TextLine.
+        Observable.FromEvent<Action<string, string?, bool>, (string Msg, string? Color, bool Mono)>(
+                rx => (t, c, m) => rx((t, c, m)),
+                h => core.EchoStyledLine += h,
+                h => core.EchoStyledLine -= h)
+            .ObserveOn(RxApp.MainThreadScheduler)
+            .Subscribe(t =>
+            {
+                if (DisplaySettings?.ShowEchoText == false) return;
+                AddEcho(t.Msg, t.Color, t.Mono);
+            });
+
         // ── Script-originated lines ───────────────────────────────────────
         // Everything a script produces arrives on ScriptOutputLine: its
         // echo output, [script]/[dbg] diagnostics, AND the game commands it
@@ -295,6 +312,20 @@ public class GameTextViewModel : ReactiveObject
     /// </summary>
     public void AddSystemLine(string text)
         => AddLine(text, StreamColor.System);
+
+    /// <summary>
+    /// Add a styled <c>#echo</c> line to the main window — an explicit colour
+    /// (named or <c>#rrggbb</c>) and/or a monospaced font (Genie 4 <c>#echo</c>
+    /// colour / <c>mono</c> options). Renders as a single plain run carrying the
+    /// requested style; unparseable colours fall back to the default echo colour.
+    /// </summary>
+    public void AddEcho(string text, string? color, bool mono)
+    {
+        Lines.Add(new TextLine(text, StreamColor.System, EchoColor: color, Mono: mono));
+        while (Lines.Count > _maxLines)
+            Lines.RemoveAt(0);
+        _lastLineWasPrompt = false;
+    }
 }
 
 /// <summary>
@@ -306,19 +337,50 @@ public class GameTextViewModel : ReactiveObject
 public record TextLine(string Text, StreamColor Color,
                        IReadOnlyList<LinkSpan>? Links = null,
                        IReadOnlyList<BoldSpan>? BoldSpans = null,
-                       IReadOnlyList<PresetSpan>? PresetSpans = null)
+                       IReadOnlyList<PresetSpan>? PresetSpans = null,
+                       string? EchoColor = null,
+                       bool Mono = false)
 {
     public bool IsEcho => Color == StreamColor.System;
+
+    /// <summary>Monospaced font for <c>#echo mono</c> lines — falls back through
+    /// the chain if the first family is unavailable.</summary>
+    private static readonly FontFamily MonoFont = new("Consolas,Courier New,monospace");
 
     /// <summary>
     /// The line broken into styled <see cref="Inline"/> segments by
     /// <see cref="DefaultHighlights"/>. Echo lines bypass highlighting and
     /// render as a single plain run (the AXAML class selector handles their
-    /// italic + colour). Each access produces a fresh list — Avalonia
+    /// italic + colour). A styled <c>#echo</c> (<see cref="EchoColor"/> /
+    /// <see cref="Mono"/>) sets the run's foreground/font directly so it
+    /// overrides the class styling. Each access produces a fresh list — Avalonia
     /// <see cref="Inline"/>s can only belong to one parent, so we don't cache.
     /// </summary>
-    public IReadOnlyList<Inline> Inlines =>
-        IsEcho ? [new Run(Text)] : DefaultHighlights.Tokenize(Text, Links, BoldSpans, PresetSpans);
+    public IReadOnlyList<Inline> Inlines
+    {
+        get
+        {
+            if (EchoColor is not null || Mono)
+            {
+                var run = new Run(Text);
+                if (Mono) run.FontFamily = MonoFont;
+                if (EchoColor is not null && TryParseColor(EchoColor, out var c))
+                    run.Foreground = new SolidColorBrush(c);
+                return [run];
+            }
+            return IsEcho ? [new Run(Text)]
+                          : DefaultHighlights.Tokenize(Text, Links, BoldSpans, PresetSpans);
+        }
+    }
+
+    /// <summary>Parse a Genie 4 echo colour — a named colour (Yellow, DodgerBlue)
+    /// or <c>#rrggbb</c> hex. Returns false (caller keeps the default colour) on
+    /// anything Avalonia can't parse.</summary>
+    private static bool TryParseColor(string token, out Avalonia.Media.Color color)
+    {
+        try { color = Avalonia.Media.Color.Parse(token); return true; }
+        catch { color = default; return false; }
+    }
 }
 
 public enum StreamColor { Main, Logons, Talk, Whisper, Thought, Combat, Familiar, System }

--- a/src/Genie.Core/Commanding/CommandEngine.cs
+++ b/src/Genie.Core/Commanding/CommandEngine.cs
@@ -177,9 +177,10 @@ public sealed class CommandEngine
             case "echo":
                 if (parts.Count > 1)
                 {
-                    EchoArgs.Parse(parts, 1, out var window, out var color, out var msg);
-                    if (window != null || color != null) _host.EchoTo(msg, window, color);
-                    else _host.Echo(msg);
+                    EchoArgs.Parse(parts, 1, out var window, out var color, out var mono, out var msg);
+                    if (window != null)         _host.EchoTo(msg, window, color);
+                    else if (color != null || mono) _host.EchoMain(msg, color, mono);
+                    else                        _host.Echo(msg);
                 }
                 break;
             case "send":

--- a/src/Genie.Core/Commanding/EchoArgs.cs
+++ b/src/Genie.Core/Commanding/EchoArgs.cs
@@ -5,13 +5,26 @@ public static class EchoArgs
     public static void Parse(
         IReadOnlyList<string> tokens, int startIndex,
         out string? window, out string? color, out string message)
+        => Parse(tokens, startIndex, out window, out color, out _, out message);
+
+    /// <summary>
+    /// Parse the leading <c>#echo</c> option tokens (Genie 4 parity): an optional
+    /// <c>&gt;window</c> redirect, an optional colour (named or <c>#rrggbb</c>),
+    /// and an optional <c>mono</c> flag (render the line in a monospaced font).
+    /// Options may appear in any order before the message; the first token that
+    /// isn't an option begins the message.
+    /// </summary>
+    public static void Parse(
+        IReadOnlyList<string> tokens, int startIndex,
+        out string? window, out string? color, out bool mono, out string message)
     {
-        window = null; color = null;
+        window = null; color = null; mono = false;
         int idx = startIndex;
         while (idx < tokens.Count)
         {
             var tok = tokens[idx];
             if (tok.Length > 0 && tok[0] == '>') { window = tok[1..]; idx++; continue; }
+            if (string.Equals(tok, "mono", StringComparison.OrdinalIgnoreCase)) { mono = true; idx++; continue; }
             if (IsEchoColor(tok)) { color = tok; idx++; continue; }
             break;
         }

--- a/src/Genie.Core/Commanding/ICommandHost.cs
+++ b/src/Genie.Core/Commanding/ICommandHost.cs
@@ -4,6 +4,16 @@ public interface ICommandHost
 {
     void Echo(string text);
     void EchoTo(string text, string? window, string? color);
+
+    /// <summary>
+    /// Echo a styled line into the <em>main</em> game window (Genie 4
+    /// <c>#echo</c> with a colour and/or the <c>mono</c> flag but no
+    /// <c>&gt;window</c> redirect). <paramref name="color"/> is a named colour
+    /// or <c>#rrggbb</c> hex (null = default echo colour); <paramref name="mono"/>
+    /// renders the line in a monospaced font. Distinct from
+    /// <see cref="EchoTo"/>, which targets a named side/plugin window.
+    /// </summary>
+    void EchoMain(string text, string? color, bool mono);
     /// <summary>
     /// Send a command line to the game socket.
     /// </summary>

--- a/src/Genie.Core/GenieCore.cs
+++ b/src/Genie.Core/GenieCore.cs
@@ -282,6 +282,14 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
     /// </summary>
     public event Action<string, string?, string?>? EchoToWindow;
 
+    /// <summary>
+    /// Raised by <c>#echo</c> with a colour and/or <c>mono</c> flag but no
+    /// <c>&gt;window</c> redirect — a styled line for the <em>main</em> game
+    /// window. Args: (text, colour?, mono). Colour is a named colour or
+    /// <c>#rrggbb</c> (null = default echo colour); mono = monospaced font.
+    /// </summary>
+    public event Action<string, string?, bool>? EchoStyledLine;
+
     // ── Constructor ────────────────────────────────────────────────────────────
 
     public GenieCore(
@@ -422,6 +430,7 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
         // $spelltime — seconds since the current spell was prepared (Genie 4).
         Scripts.SpellTimeSeconds          = () => (int)_state.Combat.SpellTimeSeconds;
         Scripts.EchoTo                   = (msg, win, color) => EchoToWindow?.Invoke(msg, win, color);
+        Scripts.EchoStyled               = (msg, color, mono) => EchoStyledLine?.Invoke(msg, color, mono);
         // Named-window seam for the built-in trackers (Spell Timer / Experience /
         // Time Tracker), which re-render a whole dock panel each prompt. Same event
         // the App's ExperienceViewModel + generic PluginWindowViewModel consume.
@@ -736,6 +745,9 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
 
     void ICommandHost.EchoTo(string text, string? window, string? color)
         => EchoToWindow?.Invoke(text, window, color);
+
+    void ICommandHost.EchoMain(string text, string? color, bool mono)
+        => EchoStyledLine?.Invoke(text, color, mono);
 
     void ICommandHost.SendToGame(string text, bool userInput, string origin, string? echoOverride)
     {

--- a/src/Genie.Core/Scripting/ScriptEngine.cs
+++ b/src/Genie.Core/Scripting/ScriptEngine.cs
@@ -42,6 +42,14 @@ public sealed class ScriptEngine
     public Action<string, string?, string?>? EchoTo { get; set; }
 
     /// <summary>
+    /// Styled main-window echo: (message, color, mono). For <c>#echo</c> with a
+    /// colour and/or the <c>mono</c> flag but no <c>&gt;window</c> redirect —
+    /// routes to the main game window (not a side window). Falls back to a plain
+    /// <see cref="_echo"/> when unset (headless tests).
+    /// </summary>
+    public Action<string, string?, bool>? EchoStyled { get; set; }
+
+    /// <summary>
     /// Echoes a command sent by a script to the game window. Args: (scriptName, command).
     /// Set by the UI layer to render with the "scriptecho" preset colour.
     /// </summary>
@@ -1546,18 +1554,23 @@ public sealed class ScriptEngine
                 // (e.g. Crimson, DodgerBlue) — the downstream Brush.Parse handles both.
                 string? window = null;
                 string? color  = null;
+                bool    mono   = false;
                 var msg = rest;
                 while (msg.Length > 0)
                 {
                     var (tok, after) = SplitCmd(msg);
                     if (tok.Length > 0 && tok[0] == '>')
                     { window = tok[1..]; msg = after; continue; }
+                    if (string.Equals(tok, "mono", StringComparison.OrdinalIgnoreCase))
+                    { mono = true; msg = after; continue; }
                     if (IsEchoColor(tok))
                     { color = tok; msg = after; continue; }
                     break;
                 }
-                if ((window != null || color != null) && EchoTo != null)
+                if (window != null && EchoTo != null)
                     EchoTo(msg, window, color);
+                else if ((color != null || mono) && EchoStyled != null)
+                    EchoStyled(msg, color, mono);
                 else
                     _echo(msg);
                 return;


### PR DESCRIPTION
Closes #84.

`#echo mono <text>` and `#echo <Colour> <text>` (named or `#rrggbb`) were not honoured from the command bar or scripts:
- `mono` was unrecognised and leaked into the message ("mono Test").
- A window-less coloured echo (`#echo Yellow Test`) was routed through the `EchoToWindow` seam with a null window, which the App handler dropped via `IsReservedWindow(null)` — so it printed nothing.

Adds a `mono` flag to `EchoArgs.Parse` and a dedicated main-window styled-echo channel (`ICommandHost.EchoMain` → `GenieCore.EchoStyledLine`, plus the parallel `ScriptEngine.EchoStyled` seam). `TextLine` carries an optional `EchoColor` + `Mono` and renders a single `Run` with the parsed `Foreground`/monospaced `FontFamily`. Unparseable colours fall back to the default echo colour. Named-window `#echo >win` is unchanged.

Build clean (Release).