### PR TITLE
fix(#97): #var/#class list+set subcommands; Variables grid copy-all

### DIFF
--- a/src/Genie.App/Views/VariablesPanel.axaml
+++ b/src/Genie.App/Views/VariablesPanel.axaml
@@ -15,12 +15,18 @@
                 Grid.Row="0"
                 Margin="0,0,0,4"
                 IsReadOnly="True"
-                SelectionMode="Single"
+                SelectionMode="Extended"
                 CanUserSortColumns="True"
                 GridLinesVisibility="Horizontal"
                 HeadersVisibility="Column"
                 x:CompileBindings="False"
                 SelectionChanged="OnSelectionChanged">
+        <DataGrid.ContextMenu>
+          <ContextMenu>
+            <MenuItem Header="Copy"       Click="OnCopy"/>
+            <MenuItem Header="Select All" Click="OnSelectAll"/>
+          </ContextMenu>
+        </DataGrid.ContextMenu>
         <DataGrid.Columns>
           <DataGridTextColumn Header="Name"  Binding="{Binding Name}"  Width="Auto"/>
           <DataGridTextColumn Header="Value" Binding="{Binding Value}" Width="*"/>

--- a/src/Genie.App/Views/VariablesPanel.axaml.cs
+++ b/src/Genie.App/Views/VariablesPanel.axaml.cs
@@ -80,6 +80,27 @@ public partial class VariablesPanel : UserControl
     private void OnAdd  (object? sender, RoutedEventArgs e) => ClearForm();
     private void OnClear(object? sender, RoutedEventArgs e) => ClearForm();
 
+    private void OnSelectAll(object? sender, RoutedEventArgs e) => ItemsList.SelectAll();
+
+    /// <summary>
+    /// Copy every selected row (not just the focused one — #97) to the clipboard
+    /// as tab-separated <c>Name\tValue</c> lines, in display order.
+    /// </summary>
+    private async void OnCopy(object? sender, RoutedEventArgs e)
+    {
+        var rows = ItemsList.SelectedItems?.Cast<VariableRow>().ToList() ?? new List<VariableRow>();
+        if (rows.Count == 0 && ItemsList.SelectedItem is VariableRow one) rows.Add(one);
+        if (rows.Count == 0) return;
+
+        var text = string.Join(
+            Environment.NewLine,
+            rows.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(r => $"{r.Name}\t{r.Value}"));
+
+        if (TopLevel.GetTopLevel(this)?.Clipboard is { } clipboard)
+            await clipboard.SetTextAsync(text);
+    }
+
     private void ClearForm()
     {
         ItemsList.SelectedItem = null;

--- a/src/Genie.Core/Commanding/CommandEngine.cs
+++ b/src/Genie.Core/Commanding/CommandEngine.cs
@@ -557,6 +557,25 @@ public sealed class CommandEngine
             return;
         }
 
+        // Explicit subcommands (#97): a bare `list` / `set` used to be treated as
+        // a class-name filter / class name — `#class list` filtered by "list" and
+        // `#class set foo on` was silently ignored. Recognise them explicitly.
+        var firstLower = first.ToLowerInvariant();
+        if (firstLower == "list")
+        {
+            ListClasses(parts.Count > 2 ? parts[2] : null);
+            return;
+        }
+        if (firstLower == "set")
+        {
+            if (parts.Count < 3) { _host.Echo("Usage: #class set <name> [on|off]"); return; }
+            var setName = parts[2].ToLowerInvariant();
+            var setVal  = parts.Count > 3 ? parts[3].ToLowerInvariant() : "on";
+            if (setVal is "off" or "false" or "0") Classes.Set(setName, false);
+            else                                   Classes.Set(setName, true);
+            return;
+        }
+
         // 2-arg subcommands or single-name filter
         if (parts.Count == 2)
         {
@@ -776,6 +795,27 @@ public sealed class CommandEngine
         if (parts.Count == 1) { ListVars(null); return; }
 
         var sub = parts[1].ToLowerInvariant();
+
+        // Explicit subcommands (#97): a bare `list` / `set` used to be treated as
+        // a name filter / variable name — `#var list` filtered by the text "list"
+        // and `#var set x 1` created a variable literally named "set". Recognise
+        // them so they behave as users expect. (A variable genuinely named
+        // "list"/"set"/"save"/… must be set via `#var set <name> <value>`.)
+        if (sub == "list")
+        {
+            ListVars(parts.Count > 2 ? string.Join(" ", parts.Skip(2)) : null);
+            return;
+        }
+        if (sub == "set")
+        {
+            if (parts.Count < 4) { _host.Echo("Usage: #var set <name> <value>"); return; }
+            var setName  = parts[2];
+            var setValue = string.Join(" ", parts.Skip(3));
+            Variables.Store.Set(setName, setValue);
+            if (_processInputDepth == 1 && _interactive)
+                _host.Echo($"Variable set: {setName}={setValue}");
+            return;
+        }
 
         if (parts.Count == 2)
         {


### PR DESCRIPTION
Addresses 2 of the 3 items in #97 (the Mobs "and"-split is tracked separately, so this does not fully close it).

- **`#var`/`#class` subcommand parsing** — a bare `list`/`set` was treated as a name filter / variable name: `#var list` filtered by the text "list" and `#var set x 1` created a variable literally named "set" (and `#class set foo on` was silently ignored). `HandleVar`/`HandleClass` now recognise `list` (`[filter]`) and `set <name> <value>` explicitly.
- **Variables grid copy** — the grid was `SelectionMode=Single` with no Copy menu, so only one row could ever be copied. Switched to `Extended` selection + a Copy / Select All context menu that copies every selected row as `Name\tValue` lines in display order.

Build clean (Release).