### PR TITLE
feat(#85): add an Atmospherics (Atmo) stream window

### DIFF
--- a/src/Genie.App/Docking/GenieDockFactory.cs
+++ b/src/Genie.App/Docking/GenieDockFactory.cs
@@ -182,6 +182,7 @@ public class GenieDockFactory : Factory
         var familiar = new StreamTool      (_vm.StreamTabs.Familiar, ws.Get("familiar"));
         var death    = new StreamTool      (_vm.StreamTabs.Death,    ws.Get("death"));
         var assess   = new StreamTool      (_vm.StreamTabs.Assess,   ws.Get("assess"));
+        var atmospherics = new StreamTool  (_vm.StreamTabs.Atmospherics, ws.Get("atmospherics"));
         var log      = new StreamTool      (_vm.StreamTabs.Log,      ws.Get("log"));
         var itemlog  = new StreamTool      (_vm.StreamTabs.ItemLog,  ws.Get("itemlog"));
         var experience = new ExperienceTool(_vm.Experience,          ws.Get("experience"));
@@ -329,6 +330,9 @@ public class GenieDockFactory : Factory
         _tools[familiar.Id] = (familiar, streamDock.Id);
         _tools[death.Id]    = (death,    streamDock.Id);
         _tools[assess.Id]   = (assess,   streamDock.Id);
+        // Atmospherics: ambient/weather feed — hidden by default (opt-in, #85);
+        // re-open via Window → Atmospherics. Homes in the stream dock.
+        _tools[atmospherics.Id] = (atmospherics, streamDock.Id);
         _tools[log.Id]      = (log,      streamDock.Id);
         _tools[itemlog.Id]  = (itemlog,  streamDock.Id);
         // Experience: registered but hidden by default (like Vitals) — re-opens
@@ -405,6 +409,7 @@ public class GenieDockFactory : Factory
         var familiar   = new StreamTool      (_vm.StreamTabs.Familiar, ws.Get("familiar"));
         var death      = new StreamTool      (_vm.StreamTabs.Death,    ws.Get("death"));
         var assess     = new StreamTool      (_vm.StreamTabs.Assess,   ws.Get("assess"));
+        var atmospherics = new StreamTool    (_vm.StreamTabs.Atmospherics, ws.Get("atmospherics"));
         var log        = new StreamTool      (_vm.StreamTabs.Log,      ws.Get("log"));
         var itemlog    = new StreamTool      (_vm.StreamTabs.ItemLog,  ws.Get("itemlog"));
         var experience = new ExperienceTool  (_vm.Experience,          ws.Get("experience"));
@@ -418,7 +423,7 @@ public class GenieDockFactory : Factory
             ("game-text", gameText), ("room", room), ("mapper", mapper), ("backpack", backpack),
             ("logons", logons), ("talk", talk), ("whispers", whispers), ("thoughts", thoughts),
             ("combat", combat), ("familiar", familiar), ("death", death), ("assess", assess),
-            ("log", log), ("itemlog", itemlog),
+            ("atmospherics", atmospherics), ("log", log), ("itemlog", itemlog),
             ("vitals", vitals), ("experience", experience), ("scene", scene),
             ("mobs", mobs), ("players", players),
         };

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -337,6 +337,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     [Reactive] public bool FamiliarVisible { get; private set; } = true;
     [Reactive] public bool DeathVisible    { get; private set; } = true;
     [Reactive] public bool AssessVisible   { get; private set; } = true;
+    [Reactive] public bool AtmosphericsVisible { get; private set; }   // hidden by default (opt-in, #85)
     [Reactive] public bool LogVisible      { get; private set; } = true;
     [Reactive] public bool ItemLogVisible  { get; private set; } = true;
     [Reactive] public bool ScriptsVisible  { get; private set; }   // hidden by default (opt-in)
@@ -359,6 +360,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     public ReactiveCommand<Unit, Unit> ToggleFamiliarCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleDeathCommand    { get; }
     public ReactiveCommand<Unit, Unit> ToggleAssessCommand   { get; }
+    public ReactiveCommand<Unit, Unit> ToggleAtmosphericsCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleLogCommand      { get; }
     public ReactiveCommand<Unit, Unit> ToggleItemLogCommand  { get; }
     public ReactiveCommand<Unit, Unit> ToggleScriptsCommand  { get; }
@@ -701,6 +703,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         WindowSettings.Register("familiar",  "Familiar");
         WindowSettings.Register("death",     "Deaths");
         WindowSettings.Register("assess",    "Assess");
+        WindowSettings.Register("atmospherics", "Atmospherics");
         WindowSettings.Register("log",       "Log");
         WindowSettings.Register("itemlog",   "ItemLog");
         WindowSettings.Register("mapper",    "Mapper");
@@ -1230,6 +1233,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         ToggleFamiliarCommand = MakeToggleCommand("familiar",  v => FamiliarVisible = v);
         ToggleDeathCommand    = MakeToggleCommand("death",     v => DeathVisible    = v);
         ToggleAssessCommand   = MakeToggleCommand("assess",    v => AssessVisible   = v);
+        ToggleAtmosphericsCommand = MakeToggleCommand("atmospherics", v => AtmosphericsVisible = v);
         ToggleLogCommand      = MakeToggleCommand("log",       v => LogVisible      = v);
         ToggleItemLogCommand  = MakeToggleCommand("itemlog",   v => ItemLogVisible  = v);
         ToggleScriptsCommand  = MakeToggleCommand("scripts",   v => ScriptsVisible  = v);
@@ -2071,6 +2075,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         SetVisibilityBool("familiar",  factory.IsToolVisible("familiar"));
         SetVisibilityBool("death",     factory.IsToolVisible("death"));
         SetVisibilityBool("assess",    factory.IsToolVisible("assess"));
+        SetVisibilityBool("atmospherics", factory.IsToolVisible("atmospherics"));
         SetVisibilityBool("log",       factory.IsToolVisible("log"));
         SetVisibilityBool("itemlog",   factory.IsToolVisible("itemlog"));
         SetVisibilityBool("scripts",   factory.IsToolVisible("scripts"));
@@ -2396,6 +2401,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             case "familiar":  ForceSet(visible, v => FamiliarVisible = v, () => FamiliarVisible); break;
             case "death":     ForceSet(visible, v => DeathVisible    = v, () => DeathVisible);    break;
             case "assess":    ForceSet(visible, v => AssessVisible   = v, () => AssessVisible);   break;
+            case "atmospherics": ForceSet(visible, v => AtmosphericsVisible = v, () => AtmosphericsVisible); break;
             case "log":       ForceSet(visible, v => LogVisible      = v, () => LogVisible);      break;
             case "itemlog":   ForceSet(visible, v => ItemLogVisible  = v, () => ItemLogVisible);  break;
             case "scripts":   ForceSet(visible, v => ScriptsVisible  = v, () => ScriptsVisible);  break;

--- a/src/Genie.App/ViewModels/StreamTabsViewModel.cs
+++ b/src/Genie.App/ViewModels/StreamTabsViewModel.cs
@@ -28,6 +28,11 @@ public class StreamTabsViewModel : ReactiveObject
     /// (declared <c>ifClosed="main"</c>).</summary>
     public StreamBuffer Assess   { get; } = new("Assess");
 
+    /// <summary>Atmospherics / ambient feed — the server's <c>atmospherics</c>
+    /// stream (weather + ambient room flavour). Genie 4 "Atmo window" parity
+    /// (#85); hidden by default, re-open via Window → Atmospherics.</summary>
+    public StreamBuffer Atmospherics { get; } = new("Atmospherics");
+
     /// <summary>Consolidated conversation log — mirrors the speech streams
     /// (talk / whispers), Genie 4 "Log" window parity. Also an <c>#echo &gt;log</c>
     /// target (wired in MainWindowViewModel).</summary>
@@ -38,7 +43,7 @@ public class StreamTabsViewModel : ReactiveObject
     public StreamBuffer ItemLog  { get; } = new("ItemLog");
 
     public IReadOnlyList<StreamBuffer> All =>
-        [Logons, Talk, Whispers, Thoughts, Combat, Familiar, Death, Assess, Log, ItemLog];
+        [Logons, Talk, Whispers, Thoughts, Combat, Familiar, Death, Assess, Atmospherics, Log, ItemLog];
 
     public void Attach(GenieCore core)
     {
@@ -57,6 +62,7 @@ public class StreamTabsViewModel : ReactiveObject
                     "familiar"             => Familiar,
                     "death"                => Death,
                     "assess"               => Assess,
+                    "atmospherics"         => Atmospherics,
                     "itemlog" or "itemLog" => ItemLog,
                     _                      => null
                 };

--- a/src/Genie.App/Views/MainWindow.axaml
+++ b/src/Genie.App/Views/MainWindow.axaml
@@ -239,6 +239,11 @@
                   IsChecked="{Binding AssessVisible, Mode=OneWay}"
                   Command="{Binding ToggleAssessCommand}"
                   ToolTip.Tip="Assess feed — the server `assess` stream."/>
+        <MenuItem Header="At_mospherics"
+                  ToggleType="CheckBox"
+                  IsChecked="{Binding AtmosphericsVisible, Mode=OneWay}"
+                  Command="{Binding ToggleAtmosphericsCommand}"
+                  ToolTip.Tip="Atmospherics / ambient feed — the server `atmospherics` stream (weather + room flavour)."/>
         <MenuItem Header="Lo_g"
                   ToggleType="CheckBox"
                   IsChecked="{Binding LogVisible, Mode=OneWay}"


### PR DESCRIPTION
Closes #85.

Adds a dockable **Atmospherics** panel that captures the server's `atmospherics` stream (weather + ambient room flavour), mirroring the Familiar/Death/Assess stream-tab pattern:
- `StreamTabsViewModel` — new `Atmospherics` buffer + routes the `atmospherics` stream id to it.
- `GenieDockFactory` — registers the stream tool in both the tabbed and MDI layouts; **hidden by default** (opt-in), homes in the stream dock.
- `MainWindowViewModel` — `AtmosphericsVisible` + `ToggleAtmosphericsCommand` + `WindowSettings.Register` + the toggle/visibility-sync/force-set wire-ups.
- `MainWindow.axaml` — Window → Atmospherics check-box menu item.

Hidden by default; open via **Window → Atmospherics**. Verified live (build clean, Release).