### PR TITLE
fix(maps): strip UTF-8 BOM so BOM-prefixed maps import (Update Maps drops files)

### DIFF
--- a/src/Genie.Core/Mapper/Genie4MapImporter.cs
+++ b/src/Genie.Core/Mapper/Genie4MapImporter.cs
@@ -31,6 +31,18 @@ public static class Genie4MapImporter
     /// </summary>
     public static MapZone ImportFromContent(string xmlContent, string fallbackName)
     {
+        // Strip a leading UTF-8 BOM (U+FEFF). When the source is a byte[] decoded
+        // via Encoding.UTF8.GetString — e.g. the Maps updater's download path — the
+        // BOM survives as a leading character and XmlDocument.LoadXml rejects it
+        // ("data at the root level is invalid"). File.ReadAllText already strips it,
+        // so file-load callers never hit this; the byte-array path did. This silently
+        // dropped every BOM-prefixed upstream map (Map30_Riverhaven, Map4_Crossing_
+        // West_Gate, Map69_Shard_West_Gate, … — 13 of the 90 GenieClient/Maps files),
+        // since the importer threw and MapsUpdater swallowed it as a per-file error.
+        const char Bom = (char)0xFEFF;   // U+FEFF — UTF-8 BOM, decoded as one leading char
+        if (xmlContent.Length > 0 && xmlContent[0] == Bom)
+            xmlContent = xmlContent[1..];
+
         var doc = new XmlDocument();
         doc.LoadXml(xmlContent);
 


### PR DESCRIPTION
**Root cause of "Update Maps downloads OK but some files are still missing."**

13 of the upstream map files are saved with a UTF-8 BOM. The Maps updater downloads the bytes → `Encoding.UTF8.GetString` (which preserves a leading `U+FEFF`) → `Genie4MapImporter.ImportFromContent` → `XmlDocument.LoadXml`, which **throws** on a leading BOM (`Data at the root level is invalid. Line 1, position 1.`). `MapsUpdater` catches it as a per-file error and never writes the file — so those files silently fail **every** update (Map30_Riverhaven, Map4_Crossing_West_Gate, Map69_Shard_West_Gate, the Southern Trade Routes, M'Riss, Hibarnhvidar, Fang Cove, …).

`File.ReadAllText` strips BOMs, so local-load paths never hit this — only the byte-array download path did.

**Fix:** strip a leading `U+FEFF` in `Genie4MapImporter.ImportFromContent` (the single parse choke point) before `LoadXml`.

**Verified end-to-end:** reproduced the exact throw against the real `Map30_Riverhaven.xml` (BOM present) and confirmed it imports cleanly (568 nodes) after the strip. Build clean (Release).

Likely also fixes the missing-Shard half of #76 (`Map69_Shard_West_Gate` is BOM-prefixed).