### PR TITLE
feat(#66): optional zone/room location line on the status bar

### DIFF
--- a/src/Genie.App/Settings/DisplaySettings.cs
+++ b/src/Genie.App/Settings/DisplaySettings.cs
@@ -51,6 +51,23 @@ public sealed class DisplaySettings : ReactiveObject
     [Reactive] public bool   ShowStatusBar { get; set; } = true;
 
     /// <summary>
+    /// Whether the optional zone/room location line (the mapper's current zone
+    /// + <c>$roomid</c>) is shown at the bottom of the window (#66). Opt-in (off
+    /// by default) — handy for travel/scripting so you can always see where you
+    /// are without opening the Mapper.
+    /// </summary>
+    [Reactive] public bool   ShowZoneRoomId { get; set; }
+
+    /// <summary>
+    /// For the zone/room location line (#66): when <c>true</c> the Zone field
+    /// shows the numeric <c>$zoneid</c> (e.g. "33"); when <c>false</c> (default)
+    /// it shows the zone name (e.g. "Riverhaven West Gate"). The Room field is
+    /// always <c>$roomid</c>. Only meaningful when <see cref="ShowZoneRoomId"/>
+    /// is on.
+    /// </summary>
+    [Reactive] public bool   ZoneRoomShowNumber { get; set; }
+
+    /// <summary>
     /// Windowed (MDI) document mode — every panel becomes a free-floating
     /// child window inside the main window, à la Genie 4, instead of the
     /// tabbed/docked layout.

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -202,6 +202,8 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
 
     public Interaction<LayoutSavePrompt, LayoutSaveResult?> ShowLayoutSavePrompt   { get; } = new();
     public ReactiveCommand<Unit, Unit>                    ToggleStatusBarCommand   { get; }
+    public ReactiveCommand<Unit, Unit>                    ToggleZoneRoomIdCommand  { get; }
+    public ReactiveCommand<Unit, Unit>                    ToggleZoneRoomNumberCommand { get; }
     public ReactiveCommand<Unit, Unit>                    ToggleWindowedModeCommand{ get; }
     public ReactiveCommand<Unit, Unit>                    ToggleGuildInTitleCommand{ get; }
     public ReactiveCommand<Unit, Unit>                    ToggleHandsBarCommand    { get; }
@@ -1047,6 +1049,18 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         ToggleStatusBarCommand = ReactiveCommand.Create(() =>
         {
             Display.ShowStatusBar = !Display.ShowStatusBar;
+            Display.Save(_displayPath);
+        });
+
+        ToggleZoneRoomIdCommand = ReactiveCommand.Create(() =>
+        {
+            Display.ShowZoneRoomId = !Display.ShowZoneRoomId;
+            Display.Save(_displayPath);
+        });
+
+        ToggleZoneRoomNumberCommand = ReactiveCommand.Create(() =>
+        {
+            Display.ZoneRoomShowNumber = !Display.ZoneRoomShowNumber;
             Display.Save(_displayPath);
         });
 

--- a/src/Genie.App/ViewModels/MapperViewModel.cs
+++ b/src/Genie.App/ViewModels/MapperViewModel.cs
@@ -34,6 +34,22 @@ public class MapperViewModel : ReactiveObject
     [Reactive] public string CurrentServerId { get; private set; } = "";
     [Reactive] public int    RoomCount       { get; private set; }
 
+    /// <summary>The mapper <c>$roomid</c> — the current map node's id, matching the
+    /// script variable scripts/<c>#goto</c> compare against (NOT the server's
+    /// <c>$gameroomid</c>, e.g. 1010002). Defaults to "0" off-map, like
+    /// <c>$roomid</c> itself. Used by the status-bar location line (#66).</summary>
+    [Reactive] public string CurrentRoomId { get; private set; } = "0";
+
+    /// <summary>The mapper <c>$zoneid</c> — the active zone's Genie 4 numeric id
+    /// (e.g. "33"). Defaults to "0" off-map, like <c>$zoneid</c>. Shown on the
+    /// status-bar location line when the user picks "Zone Number" mode (#66).</summary>
+    [Reactive] public string CurrentZoneId { get; private set; } = "0";
+
+    private ObservableAsPropertyHelper<string>? _locationDisplay;
+    /// <summary>Compact "Zone: … · Room: …" readout for the optional status-bar
+    /// location line (#66). Zone name + DR's live server room id, live-updating.</summary>
+    public string LocationDisplay => _locationDisplay?.Value ?? "";
+
     /// <summary>
     /// Compass exits from the current room — "north", "northeast", "down",
     /// "up", etc. Rendered as clickable buttons in the Mapper status strip
@@ -557,6 +573,10 @@ public class MapperViewModel : ReactiveObject
             .Skip(1)
             .Subscribe(LoadSelectedZone);
 
+        // The status-bar location line OAPH (#66) is wired in AttachDisplay,
+        // where the DisplaySettings are available — its Zone-name-vs-number mode
+        // is a user setting (Display.ZoneRoomShowNumber).
+
         // Whenever the Maps directory changes, recompute the "git-managed"
         // hint. This is purely informational — Genie never runs git itself,
         // but showing the user that they're pointed at a working copy is a
@@ -598,6 +618,23 @@ public class MapperViewModel : ReactiveObject
         _displayPath = displayPath;
         if (Color.TryParse(display.MapBackgroundHex, out var c))
             MapBackground = c;
+
+        // Status-bar location line (#66). Zone field follows the user's
+        // Zone-name-vs-number setting; Room is always $roomid (the mapper node
+        // id), never the server $gameroomid. Wired here (not the constructor) so
+        // it can react to the DisplaySettings toggle. Idempotent: the OAPH is
+        // built once even if AttachDisplay is somehow called again.
+        _locationDisplay ??= this
+            .WhenAnyValue(x => x.ZoneName, x => x.CurrentZoneId, x => x.CurrentRoomId)
+            .CombineLatest(
+                display.WhenAnyValue(d => d.ZoneRoomShowNumber),
+                (parts, showNumber) =>
+                {
+                    var (name, zoneId, roomId) = parts;
+                    var zone = showNumber ? zoneId : name;
+                    return $"Zone: {zone}   Room: {roomId}";
+                })
+            .ToProperty(this, x => x.LocationDisplay);
     }
 
     private void RecomputeIsGitManaged()
@@ -946,6 +983,13 @@ public class MapperViewModel : ReactiveObject
         ZoneName  = string.IsNullOrEmpty(_engine.ActiveZone.Name)
             ? "(unsaved)" : _engine.ActiveZone.Name;
         RoomCount = _engine.ActiveZone.Nodes.Count;
+
+        // Mapper $roomid (#66) — the current node's id (what scripts/#goto use),
+        // "0" off-map. Matches the $roomid script variable exactly, NOT the
+        // server's $gameroomid.
+        CurrentRoomId = _engine.CurrentNode?.Id.ToString() ?? "0";
+        // $zoneid (#66) — the active zone's Genie 4 numeric id, "0" off-map.
+        CurrentZoneId = string.IsNullOrEmpty(_engine.ActiveZone.Genie4Id) ? "0" : _engine.ActiveZone.Genie4Id;
 
         // Surface the live references for the canvas. Reference may not have
         // changed since last call (the engine mutates Nodes in place), so we

--- a/src/Genie.App/Views/MainWindow.axaml
+++ b/src/Genie.App/Views/MainWindow.axaml
@@ -132,6 +132,17 @@
                   IsChecked="{Binding Display.ShowStatusBar}"
                   Command="{Binding ToggleStatusBarCommand}"
                   ToolTip.Tip="Show/hide the Wrayth-style vitals strip at the bottom of the window"/>
+        <MenuItem Header="_Zone / Room ID"
+                  ToggleType="CheckBox"
+                  IsChecked="{Binding Display.ShowZoneRoomId}"
+                  Command="{Binding ToggleZoneRoomIdCommand}"
+                  ToolTip.Tip="Show the current mapper zone and $roomid on a line at the bottom of the window (#66)"/>
+        <MenuItem Header="Zone as _Number"
+                  ToggleType="CheckBox"
+                  IsChecked="{Binding Display.ZoneRoomShowNumber}"
+                  Command="{Binding ToggleZoneRoomNumberCommand}"
+                  IsEnabled="{Binding Display.ShowZoneRoomId}"
+                  ToolTip.Tip="On the Zone / Room ID line, show the numeric $zoneid (e.g. 33) instead of the zone name. Room is always $roomid."/>
         <MenuItem Header="_Windowed Mode (MDI)"
                   ToggleType="CheckBox"
                   IsChecked="{Binding Display.WindowedMode, Mode=OneWay}"
@@ -840,6 +851,18 @@
                    FontSize="11" Foreground="#fff" FontWeight="SemiBold"/>
       </Grid>
     </Grid>
+
+    <!-- ── Zone / Room location line (#66, opt-in via View → Zone / Room ID) ── -->
+    <!-- Declared AFTER the vitals strip so DockPanel stacks it just ABOVE it.   -->
+    <Border DockPanel.Dock="Bottom"
+            IsVisible="{Binding Display.ShowZoneRoomId}"
+            Background="#1b2024" BorderBrush="#3a4148" BorderThickness="0,1,0,0"
+            Padding="6,2">
+      <TextBlock Text="{Binding Mapper.LocationDisplay}"
+                 FontFamily="Consolas,Courier New,monospace" FontSize="11"
+                 Foreground="#8aa3b5" VerticalAlignment="Center"
+                 ToolTip.Tip="Current mapper zone and DR server room id (#66)"/>
+    </Border>
 
     <!-- ── Hands strip (bottom position — Genie 4 style) ────────────────── -->
     <!-- Declared AFTER the StatusBar and BEFORE the CommandBar so the         -->


### PR DESCRIPTION
Closes #66.

A toggleable bottom-of-window line showing the mapper's current zone + `$roomid`, so you can always see where you are without opening the Mapper.

- **Room** is always `$roomid` (the mapper node id scripts/`#goto` use) — NOT the server `$gameroomid`.
- **Zone** is user-selectable (View menu): zone **name** (default) or numeric **`$zoneid`**, via `Display.ZoneRoomShowNumber`.
- `MapperViewModel` exposes `CurrentRoomId`/`CurrentZoneId`; `LocationDisplay` OAPH (wired in `AttachDisplay`) reacts to the name/number toggle.
- View menu: "Zone / Room ID" (on/off) + "Zone as Number" sub-item; thin bottom strip bound to `Mapper.LocationDisplay`.

Verified live: zone + `$roomid` populate once a zone is loaded; name↔number toggle works. Build clean (Release).