### PR TITLE
feat(#94): per-script pause/resume + debug level on the Script Bar

### DIFF
--- a/src/Genie.App/ViewModels/ScriptBarViewModel.cs
+++ b/src/Genie.App/ViewModels/ScriptBarViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Reactive;
+using System.Reactive.Linq;
 using Avalonia.Threading;
 using Genie.Core;
 using ReactiveUI;
@@ -54,6 +55,14 @@ public sealed class ScriptBarViewModel : ReactiveObject
     /// </summary>
     public ReactiveCommand<string, Unit> EditScriptCommand { get; }
 
+    /// <summary>Toggle pause/resume for one script chip (#94). Mirrors the engine's
+    /// per-script <see cref="ScriptEngine.PauseScript"/>/<c>ResumeScript</c>.</summary>
+    public ReactiveCommand<ScriptBarItem, Unit> PauseResumeCommand { get; }
+
+    /// <summary>Cycle one script chip's debug/trace level 0→1→5→10→0 (#94),
+    /// pushing it to the engine via <see cref="ScriptEngine.SetTrace"/>.</summary>
+    public ReactiveCommand<ScriptBarItem, Unit> CycleDebugCommand { get; }
+
     public ScriptBarViewModel()
     {
         StopScriptCommand = ReactiveCommand.Create<string, Unit>(name =>
@@ -67,6 +76,22 @@ public sealed class ScriptBarViewModel : ReactiveObject
         {
             if (string.IsNullOrWhiteSpace(name) || _core is null) return Unit.Default;
             EditScript?.Invoke(name);
+            return Unit.Default;
+        });
+
+        PauseResumeCommand = ReactiveCommand.Create<ScriptBarItem, Unit>(item =>
+        {
+            if (item is null || _core is null) return Unit.Default;
+            if (item.IsPaused) { _core.Scripts.ResumeScript(item.Name); item.IsPaused = false; }
+            else               { _core.Scripts.PauseScript(item.Name);  item.IsPaused = true;  }
+            return Unit.Default;
+        });
+
+        CycleDebugCommand = ReactiveCommand.Create<ScriptBarItem, Unit>(item =>
+        {
+            if (item is null || _core is null) return Unit.Default;
+            item.DebugLevel = item.DebugLevel switch { 0 => 1, 1 => 5, 5 => 10, _ => 0 };
+            _core.Scripts.SetTrace(item.Name, item.DebugLevel);
             return Unit.Default;
         });
     }
@@ -111,5 +136,41 @@ public sealed class ScriptBarViewModel : ReactiveObject
 }
 
 /// <summary>One running-script chip in the script bar. Carries the language so
-/// the bar can show a "js" tag; the Stop/Edit commands key off <see cref="Name"/>.</summary>
-public sealed record ScriptBarItem(string Name, bool IsJavaScript);
+/// the bar can show a "js" tag; the Stop/Edit/Pause/Debug commands key off
+/// <see cref="Name"/>. Reactive so per-chip Pause/Resume (#94) and the debug-level
+/// readout update live.</summary>
+public sealed class ScriptBarItem : ReactiveObject
+{
+    private readonly ObservableAsPropertyHelper<string> _debugLabel;
+    private readonly ObservableAsPropertyHelper<string> _pauseGlyph;
+
+    public ScriptBarItem(string name, bool isJavaScript)
+    {
+        Name = name;
+        IsJavaScript = isJavaScript;
+        _debugLabel = this.WhenAnyValue(x => x.DebugLevel)
+            .Select(n => $"dbg:{n}")
+            .ToProperty(this, x => x.DebugLabel);
+        _pauseGlyph = this.WhenAnyValue(x => x.IsPaused)
+            .Select(p => p ? "▶" : "⏸")
+            .ToProperty(this, x => x.PauseGlyph);
+    }
+
+    public string Name { get; }
+    public bool   IsJavaScript { get; }
+
+    /// <summary>User-paused via the chip's ⏸/▶ button (mirrors the engine's
+    /// per-script pause). Drives the button glyph.</summary>
+    [Reactive] public bool IsPaused { get; set; }
+
+    /// <summary>Per-script debug/trace level set via the chip (0 = off, cycles
+    /// 0→1→5→10). <c>.js</c> scripts have no trace level, so the control is
+    /// hidden for them.</summary>
+    [Reactive] public int DebugLevel { get; set; }
+
+    /// <summary>Debug button caption ("dbg:N"), live-tracking <see cref="DebugLevel"/>.</summary>
+    public string DebugLabel => _debugLabel.Value;
+
+    /// <summary>Pause button glyph — ⏸ while running, ▶ while paused.</summary>
+    public string PauseGlyph => _pauseGlyph.Value;
+}

--- a/src/Genie.App/Views/MainWindow.axaml
+++ b/src/Genie.App/Views/MainWindow.axaml
@@ -1115,6 +1115,23 @@
                     <TextBlock Text="js" FontSize="9" Foreground="#e8c97a"
                                VerticalAlignment="Center"/>
                   </Border>
+                  <!-- Pause / resume this script (#94). Glyph flips ⏸/▶. -->
+                  <Button Content="{Binding PauseGlyph}"
+                          FontSize="10" Padding="3,0" MinWidth="0" MinHeight="0"
+                          Background="Transparent" BorderThickness="0"
+                          Foreground="#9ec59a"
+                          ToolTip.Tip="Pause / resume this script"
+                          Command="{ReflectionBinding $parent[ItemsControl].DataContext.ScriptBar.PauseResumeCommand}"
+                          CommandParameter="{Binding}"/>
+                  <!-- Per-script debug level (#94): cycles 0→1→5→10. .cmd only. -->
+                  <Button Content="{Binding DebugLabel}"
+                          FontSize="9" Padding="3,0" MinWidth="0" MinHeight="0"
+                          Background="Transparent" BorderThickness="0"
+                          Foreground="#c0a060"
+                          IsVisible="{Binding !IsJavaScript}"
+                          ToolTip.Tip="Cycle this script's debug/trace level (0→1→5→10)"
+                          Command="{ReflectionBinding $parent[ItemsControl].DataContext.ScriptBar.CycleDebugCommand}"
+                          CommandParameter="{Binding}"/>
                   <Button Content="✏"
                           FontSize="10" Padding="3,0" MinWidth="0" MinHeight="0"
                           Background="Transparent" BorderThickness="0"

--- a/src/Genie.Core/Scripting/ScriptEngine.cs
+++ b/src/Genie.Core/Scripting/ScriptEngine.cs
@@ -405,6 +405,20 @@ public sealed class ScriptEngine
             { inst.UserPaused = false; _echo($"[script] {name} resumed"); }
     }
 
+    /// <summary>Set the debug/trace level for a SINGLE running <c>.cmd</c> script
+    /// by name (the per-chip control on the Script Bar, #94). Level is clamped to
+    /// 0–10 (0 = off; higher surfaces more <c>[dbg:N]</c> traces). The global
+    /// equivalent is <c>#traceall</c> (<see cref="GenieCore"/> ICommandHost).
+    /// <c>.js</c> scripts have no per-line trace level, so they're unaffected.</summary>
+    public void SetTrace(string name, int level)
+    {
+        if (level < 0) level = 0;
+        if (level > 10) level = 10;
+        foreach (var inst in _instances)
+            if (inst.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+            { inst.DebugLevel = level; _echo($"[script] {name} debug level set to {level}"); }
+    }
+
     public void PauseAll()
     {
         _js.PauseAll();


### PR DESCRIPTION
Closes #94.

Each running-script chip gains two controls beside Edit/Stop:
- **Pause/Resume (⏸/▶)** — toggles the engine's per-script pause (`ScriptEngine.PauseScript`/`ResumeScript`), works for `.cmd` and `.js`.
- **Debug level (dbg:N)** — cycles 0→1→5→10 and pushes it to the script via a new per-script `ScriptEngine.SetTrace(name, level)` (the engine only had the global `#traceall` before). Hidden for `.js` scripts, which have no per-line trace level.

`ScriptBarItem` becomes a `ReactiveObject` carrying `IsPaused`/`DebugLevel` with OAPH labels so the chip updates live; two parameterised commands drive the engine.

Verified live: pause stops a running `.cmd` (glyph flips) and resume continues it; dbg cycling surfaces `[dbg:N]` traces. Build clean (Release).