### PR TITLE
fix(scripting/#111): route #statusbar/#status to a Script Bar strip

### DIFF
--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -2809,6 +2809,12 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         _core.EditScriptRequested     += name =>
             Avalonia.Threading.Dispatcher.UIThread.Post(() => OpenScriptInEditor(name));
 
+        // #statusbar / #status [N] {text} — scripts write progress to the strip
+        // shown to the right of the Script Bar (#111). Raised on the engine
+        // thread; marshal to the UI thread before touching reactive state.
+        _core.StatusBarRequested      += (text, index) =>
+            Avalonia.Threading.Dispatcher.UIThread.Post(() => ScriptBar.SetStatus(index, text));
+
         // (The script tick pump — #61 — is wired at the end of WireCore so it runs
         // for the core's whole life, including while disconnected, for offline
         // scripts; #88.)

--- a/src/Genie.App/ViewModels/ScriptBarViewModel.cs
+++ b/src/Genie.App/ViewModels/ScriptBarViewModel.cs
@@ -42,6 +42,52 @@ public sealed class ScriptBarViewModel : ReactiveObject
     [Reactive] public bool HasScripts { get; private set; }
 
     /// <summary>
+    /// Genie 4's ten <c>#statusbar</c> slots (1-10, stored 0-indexed). Scripts
+    /// write progress here via <c>#statusbar [N] {text}</c>; we compose the
+    /// non-empty slots into <see cref="StatusText"/>. Cleared when the last
+    /// script finishes so the strip returns to zero height during ordinary play.
+    /// </summary>
+    private readonly string[] _statusSlots = new string[10];
+
+    /// <summary>
+    /// The composed <c>#statusbar</c> text shown to the right of the Script Bar
+    /// (#111) — the non-empty slots joined left-to-right. Empty when no script
+    /// has set a status, which keeps <see cref="HasStatus"/> false and the
+    /// status block collapsed.
+    /// </summary>
+    [Reactive] public string StatusText { get; private set; } = "";
+
+    /// <summary>True when any status slot is non-empty. Bound to the status
+    /// block's <c>IsVisible</c> so it shows only once a script writes one.</summary>
+    [Reactive] public bool HasStatus { get; private set; }
+
+    /// <summary>
+    /// Apply a <c>#statusbar</c> write (Genie 4 <c>#statusbar [N] {text}</c>),
+    /// routed from <see cref="GenieCore.StatusBarRequested"/>. <paramref name="index"/>
+    /// is the 1-10 slot; out-of-range indices clamp to 1. Must be called on the
+    /// UI thread (the caller marshals) since it mutates reactive state.
+    /// </summary>
+    public void SetStatus(int index, string text)
+    {
+        var slot = index is >= 1 and <= 10 ? index - 1 : 0;
+        _statusSlots[slot] = text ?? "";
+        RecomposeStatus();
+    }
+
+    private void RecomposeStatus()
+    {
+        StatusText = string.Join("   ", _statusSlots.Where(s => !string.IsNullOrEmpty(s)));
+        HasStatus  = StatusText.Length > 0;
+    }
+
+    private void ClearStatus()
+    {
+        Array.Clear(_statusSlots, 0, _statusSlots.Length);
+        StatusText = "";
+        HasStatus  = false;
+    }
+
+    /// <summary>
     /// Sends <c>#stop &lt;name&gt;</c> to the script engine. Parameterised
     /// so the XAML <c>Button.Command</c> can pass the per-item name via
     /// <c>CommandParameter</c>.
@@ -131,6 +177,9 @@ public sealed class ScriptBarViewModel : ReactiveObject
                     if (RunningScripts[i].Name.Equals(name, StringComparison.OrdinalIgnoreCase))
                         RunningScripts.RemoveAt(i);
                 HasScripts = RunningScripts.Count > 0;
+                // Once nothing is running, drop any leftover #statusbar text so
+                // the strip collapses to zero height during ordinary play (#111).
+                if (!HasScripts) ClearStatus();
             });
     }
 }

--- a/src/Genie.App/Views/MainWindow.axaml
+++ b/src/Genie.App/Views/MainWindow.axaml
@@ -1113,11 +1113,19 @@
             IsVisible="{Binding ScriptBar.HasScripts}"
             Background="#1f2429" BorderBrush="#3a4148" BorderThickness="0,1,0,0"
             Padding="6,3">
-      <StackPanel Orientation="Horizontal" Spacing="6">
-        <TextBlock Text="Scripts:" Foreground="#8aa3b5" FontSize="11"
+      <DockPanel LastChildFill="False">
+        <!-- #statusbar / #status text (Genie 4 parity, #111) — docked right so
+             it stays put as running-script chips come and go on the left. -->
+        <TextBlock DockPanel.Dock="Right"
+                   IsVisible="{Binding ScriptBar.HasStatus}"
+                   Text="{Binding ScriptBar.StatusText}"
+                   Foreground="#cfe0ee" FontSize="11"
+                   VerticalAlignment="Center" TextTrimming="CharacterEllipsis"
+                   Margin="12,0,2,0"/>
+        <TextBlock DockPanel.Dock="Left" Text="Scripts:" Foreground="#8aa3b5" FontSize="11"
                    FontWeight="SemiBold" VerticalAlignment="Center"
                    Margin="0,0,2,0"/>
-        <ItemsControl ItemsSource="{Binding ScriptBar.RunningScripts}">
+        <ItemsControl DockPanel.Dock="Left" ItemsSource="{Binding ScriptBar.RunningScripts}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
               <StackPanel Orientation="Horizontal" Spacing="4"/>
@@ -1174,7 +1182,7 @@
             </DataTemplate>
           </ItemsControl.ItemTemplate>
         </ItemsControl>
-      </StackPanel>
+      </DockPanel>
     </Border>
 
     <!-- ── Command bar (above status bar) ────────────────────────────────── -->

--- a/src/Genie.Core/Commanding/CommandEngine.cs
+++ b/src/Genie.Core/Commanding/CommandEngine.cs
@@ -183,6 +183,24 @@ public sealed class CommandEngine
                     else                        _host.Echo(msg);
                 }
                 break;
+            case "status":
+            case "statusbar":
+                // Genie 4 #statusbar [N] {text} — write text to one of ten status
+                // slots (N = 1-10, default 1). The App renders the slots to the
+                // right of the Script Bar (#111). With no args it's a no-op; a
+                // bare `#statusbar N` (no text) clears slot N.
+                if (parts.Count > 1)
+                {
+                    var slot = 1;
+                    var textFrom = 1;
+                    if (int.TryParse(parts[1], out var n) && n is >= 1 and <= 10)
+                    {
+                        slot = n;
+                        textFrom = 2;
+                    }
+                    _host.SetStatusBar(string.Join(" ", parts.Skip(textFrom)), slot);
+                }
+                break;
             case "send":
             case "put":
                 // Genie 4: #put is the canonical "send to game" command in

--- a/src/Genie.Core/Commanding/ICommandHost.cs
+++ b/src/Genie.Core/Commanding/ICommandHost.cs
@@ -14,6 +14,18 @@ public interface ICommandHost
     /// <see cref="EchoTo"/>, which targets a named side/plugin window.
     /// </summary>
     void EchoMain(string text, string? color, bool mono);
+
+    /// <summary>
+    /// Set the script status-bar text (Genie 4 <c>#statusbar</c> / <c>#status</c>).
+    /// <paramref name="index"/> selects one of Genie 4's ten status slots
+    /// (1-10; the command-bar layer defaults a missing/invalid index to 1); the
+    /// App composes the non-empty slots into the strip shown to the right of the
+    /// Script Bar (#111). An empty <paramref name="text"/> clears that slot.
+    /// Console / headless builds with no UI strip drop it silently — Genie 4
+    /// parity (a status write to nowhere is a no-op, not an error).
+    /// </summary>
+    void SetStatusBar(string text, int index);
+
     /// <summary>
     /// Send a command line to the game socket.
     /// </summary>

--- a/src/Genie.Core/GenieCore.cs
+++ b/src/Genie.Core/GenieCore.cs
@@ -750,6 +750,17 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
     void ICommandHost.EchoMain(string text, string? color, bool mono)
         => EchoStyledLine?.Invoke(text, color, mono);
 
+    void ICommandHost.SetStatusBar(string text, int index)
+        => StatusBarRequested?.Invoke(text, index);
+
+    /// <summary>
+    /// Raised by <c>#statusbar</c> / <c>#status</c>. Carries the text and the
+    /// 1-10 slot index. The App routes it to the Script Bar's status strip
+    /// (#111); Console / headless builds with no subscriber drop it (Genie 4
+    /// parity — a status write with no bar is a silent no-op).
+    /// </summary>
+    public event Action<string, int>? StatusBarRequested;
+
     void ICommandHost.SendToGame(string text, bool userInput, string origin, string? echoOverride)
     {
         // Local echo of user-typed commands so the player can see what they sent.

--- a/wiki/Scripting-Reference.md
+++ b/wiki/Scripting-Reference.md
@@ -93,6 +93,7 @@ Regex captures from `matchre` / `waitforre` / actions land in the current `$0..$
 | Statement | Notes |
 | --- | --- |
 | `echo text` | Print to the echo channel (main window + Scripts panel). |
+| `#statusbar [N] text` | Show `text` in the strip to the right of the Script Bar (`#status` is a synonym). `N` (1–10, default 1) picks one of Genie 4's status slots; the non-empty slots are shown together and clear when the last script ends. An empty `text` clears slot `N`. |
 | `debug N` | Per-script trace verbosity (1 = goto/gosub/return … 10 = every line). |
 | `include <file>.js` | Load a JavaScript function library for this script run — see [JavaScript Scripting](JavaScript-Scripting). |
 | `js <expr>` / `jscall <var> <expr>` | Call a JS library function; `jscall` stores the result in `%var`. |


### PR DESCRIPTION
Closes #111.

## Problem
The Genie 4 `#statusbar` / `#status` script command had **no implementation** in Genie 5. Scripts that wrote progress to it (e.g. `#statusbar Hunting: 3/10`) silently no-op'd — the command parser had no `status`/`statusbar` case, so the text had nowhere to go. This is especially noticeable in MDI mode where the bottom status bar isn't present.

## Fix
Per the issue's suggestion, route the text to a strip on the **right of the Script Bar**, which is already visible while scripts run. Wired through the existing `ICommandHost` → `GenieCore` event → App pattern (same shape as `#layout`, `#plugin`, `#goto`):

- **`ICommandHost.SetStatusBar(text, index)`** seam; **`GenieCore`** raises `StatusBarRequested`. Console/headless builds with no subscriber drop it silently (Genie 4 parity — a status write with no bar is a no-op, not an error).
- **`CommandEngine`** parses `#statusbar [N] {text}` — `N` = 1–10 (default 1), `#status` accepted as a synonym. `$variable` expansion already happens upstream in `ProcessInput`, so `#statusbar HP: $health` works.
- **`ScriptBarViewModel`** stores Genie 4's ten slots, composes the non-empty ones into `StatusText`, and clears them when the last script finishes so the strip keeps its zero-height-when-idle behaviour.
- **`MainWindowViewModel`** marshals the engine-thread event to the UI thread.
- **`MainWindow.axaml`** renders the status text docked right of the running-script chips (ellipsis-trimmed).
- Documented in `wiki/Scripting-Reference.md`.

## Test plan
- **Done/verified:** `dotnet build -c Release` clean (0 warnings, 0 errors). Logic mirrors the already-tested `#echo`/`#put` command path; confirmed `ExpandVariables` runs before command dispatch.
- **Worth a live check:** `#statusbar 1 hello` shows to the right of the bar; multi-slot (`#statusbar 2 ...`) composes left-to-right; the strip collapses when scripts end; long text ellipsizes.
- **Possible regressions:** the Script Bar's inner container changed from `StackPanel` → `DockPanel` (chips remain left-aligned); scoped to that one strip.