### PR TITLE
fix(mapper/#115): #goto matches note-label and title shorthands (prefix)

### DIFF
--- a/src/Genie.App/ViewModels/MapperViewModel.cs
+++ b/src/Genie.App/ViewModels/MapperViewModel.cs
@@ -1427,7 +1427,19 @@ public class MapperViewModel : ReactiveObject
         GotoNode(target);
     }
 
-    /// <summary>Resolve a #goto token to a node: id → label → title.</summary>
+    /// <summary>
+    /// Resolve a #goto token to a node, in Genie 4 priority order: numeric id,
+    /// then note label (exact, then prefix), then title (exact, then prefix),
+    /// then a single unambiguous title substring.
+    /// <para>
+    /// The prefix steps are Genie 4's shorthand handling (#115): typing
+    /// <c>#goto gem</c> reaches a room labelled <c>gems</c>, and <c>#goto
+    /// brickwell</c> reaches one labelled/titled <c>brickwell tower</c>. Prefix
+    /// matches take the first hit (Genie 4 + the Kzin prototype's resolver
+    /// behaviour); the unambiguous-substring fallback only fires when exactly
+    /// one title contains the token.
+    /// </para>
+    /// </summary>
     private MapNode? ResolveNode(string arg)
     {
         var zone = _engine!.ActiveZone;
@@ -1436,20 +1448,21 @@ public class MapperViewModel : ReactiveObject
         if (int.TryParse(arg, out var id) && zone.Nodes.TryGetValue(id, out var byId))
             return byId;
 
-        // 2) Note label — notes hold '|'-separated labels.
-        foreach (var n in zone.Nodes.Values)
-        {
-            if (string.IsNullOrEmpty(n.Notes)) continue;
-            foreach (var label in n.Notes.Split('|'))
-                if (label.Trim().Equals(arg, StringComparison.OrdinalIgnoreCase))
-                    return n;
-        }
+        // Notes hold '|'-separated labels; match the predicate against any one.
+        bool Label(MapNode n, Func<string, bool> pred)
+            => !string.IsNullOrEmpty(n.Notes) &&
+               n.Notes.Split('|').Any(label => pred(label.Trim()));
 
-        // 3) Title — exact match first, then a single unambiguous contains.
-        var exact = zone.Nodes.Values.FirstOrDefault(
-            n => n.Title.Equals(arg, StringComparison.OrdinalIgnoreCase));
-        if (exact is not null) return exact;
+        // 2) Note label exact → 3) note label prefix (shorthand, #115) →
+        //    4) title exact → 5) title prefix (shorthand).
+        var hit =
+               zone.Nodes.Values.FirstOrDefault(n => Label(n, l => l.Equals(arg, StringComparison.OrdinalIgnoreCase)))
+            ?? zone.Nodes.Values.FirstOrDefault(n => Label(n, l => l.StartsWith(arg, StringComparison.OrdinalIgnoreCase)))
+            ?? zone.Nodes.Values.FirstOrDefault(n => n.Title.Equals(arg, StringComparison.OrdinalIgnoreCase))
+            ?? zone.Nodes.Values.FirstOrDefault(n => n.Title.StartsWith(arg, StringComparison.OrdinalIgnoreCase));
+        if (hit is not null) return hit;
 
+        // 6) Final fallback: a single unambiguous title substring.
         var partial = zone.Nodes.Values
             .Where(n => n.Title.IndexOf(arg, StringComparison.OrdinalIgnoreCase) >= 0)
             .ToList();


### PR DESCRIPTION
Closes #115.

## Problem
`#goto <label>` only matched note labels by **exact** string, so Genie 4's shorthand never worked:
- `#goto gem` did nothing even though the Shard gem room is labelled `gems` (Map68: `note="Mhar|Gems|Gem Seller"`).
- `#goto brickwell` did nothing where the label/title is `brickwell tower` (per #115).

This breaks community scripts that rely on shorthand. Concretely, `TradeShard.cmd`'s finance routine issues `put #goto gem` and then loops forever re-issuing the unresolved goto (confirmed via a `debug 10` trace) — the same hang that surfaced while chasing the `.travel` issue.

## Fix
`MapperViewModel.ResolveNode` now resolves in Genie 4 priority order, adding the missing prefix (shorthand) steps:

1. numeric map id (`#goto 232`)
2. note label **exact**
3. note label **prefix** ← new (`gem` → `gems`)
4. title **exact**
5. title **prefix** ← new (`brickwell` → `brickwell tower`)
6. single unambiguous title substring (existing lenient fallback)

Prefix matches take the first hit, mirroring Genie 4 (and the Kzin prototype's resolver, which this is ported from).

## Test plan
- **Verified live** in Shard: `#goto gem` now walks to the `Gems`/`Mhar` room; `TradeShard.cmd` → `.travel cortik` gets past the `put #goto gem` / `matchwait` loop.
- Regressions checked: `#goto gems` (exact), `#goto mhar` (exact), numeric `#goto 232` still resolve as before; the unambiguous-substring title fallback is unchanged.
- `dotnet build -c Release` clean (0 warnings, 0 errors).