### PR TITLE
release: v5.0.0-alpha.8.4 — Parser Gap Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The Genie 4 codebase is WinForms + Windows-only and hasn't kept pace with modern
 | JavaScript (`.js`) array scripts via Jint — `genie.*` API (put/waitFor/matchWait/pause/timers/vars), coexists with `.cmd`, memory + runaway-loop guards | ✅ Working |
 | `#connect` / `#reconnect` / `#lichconnect` — typed/scripted login (Genie 4 parity; saved-profile, explicit, and reconnect forms; password-masked) | ✅ Working |
 | Analyst Capture — redacted, recipe-driven session capture for parser/analysis (other-player speech stripped by default) | ✅ Working |
+| Report parser gap — when the game sends an element Genie doesn't recognize, a one-click prompt opens a **pre-filled, pre-redacted** GitHub issue in your browser (nothing sent until you submit) | ✅ Working |
 | Performance overlay — live per-stage pipeline timing + running-`.js` list, behind the Performance menu | ✅ Working |
 | Game prompt in the window — `prompt` string + `promptbreak` (own-line) / `promptforce` (reconstructed status letters) | ✅ Working |
 | Portrait panel — DR room/scene artwork (`#config showimages`), fetched from the play.net art CDN | ✅ Working |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,23 @@
+# Genie 5 — v5.0.0-alpha.8.4
+
+Genie can now help improve its own parser: when the game sends an element it
+doesn't recognize yet, a one-click prompt drafts a pre-redacted GitHub issue
+for you to review and submit.
+
+> **Alpha software.** Windows SmartScreen may warn on first launch
+> (More info → Run anyway) while code signing is being rolled out — tracked
+> in #33.
+
+## ✨ New
+
+- **Report parser gaps (#152)** — if DragonRealms ever sends an element Genie's
+  parser doesn't handle yet, a slim notice appears above the vitals bar offering
+  to report it. One click opens a **pre-filled GitHub issue** in your browser,
+  with the sample **already redacted** (other players' speech removed) and your
+  Genie version attached — nothing is posted until you review it and press
+  Submit. A one-click way to help the parser keep pace as the game evolves; each
+  unknown element only asks once per session.
+
 # Genie 5 — v5.0.0-alpha.8.3
 
 The Experience window catches up to Genie 3/4 — session rank-gain, numeric

--- a/src/Genie.App/Genie.App.csproj
+++ b/src/Genie.App/Genie.App.csproj
@@ -12,10 +12,10 @@
     <AssemblyName>Genie5</AssemblyName>
 
     <!-- ── Versioning (shown in File Properties → Details + About box) ── -->
-    <Version>5.0.0-alpha.8.3</Version>
+    <Version>5.0.0-alpha.8.4</Version>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <FileVersion>5.0.0.0</FileVersion>
-    <InformationalVersion>5.0.0-alpha.8.3</InformationalVersion>
+    <InformationalVersion>5.0.0-alpha.8.4</InformationalVersion>
     <Product>Genie 5</Product>
     <Company>Genie 5 Project</Company>
     <Copyright>Copyright © 2026 — GPL-3.0</Copyright>

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -319,6 +319,28 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
 
     public ReactiveCommand<Unit, Unit> DismissUpdateNoticeCommand { get; private set; } = null!;
 
+    // ── Report-XML-gap notice (crowdsourced parser-gap reporting) ────────────
+
+    /// <summary>One-line prompt shown when the parser meets an XML element it
+    /// doesn't consume (<see cref="UnknownTagEvent"/>). Empty = the strip is
+    /// collapsed. Click drafts a REDACTED GitHub issue and opens the prefill URL
+    /// in the browser (nothing is posted automatically); the × dismisses it.
+    /// One prompt per tag type per session — the parser rarely meets an unknown
+    /// element, so this does not nag.</summary>
+    [Reactive] public string XmlGapNotice { get; private set; } = "";
+
+    /// <summary>Prefill new-issue URL for the pending XML-gap draft, opened by
+    /// <see cref="ReportXmlGapCommand"/>. Empty when no gap is pending.</summary>
+    private string _pendingXmlGapUrl = "";
+
+    /// <summary>Tag types already surfaced this session — dedup so the same
+    /// unknown element never re-prompts.</summary>
+    private readonly System.Collections.Generic.HashSet<string> _reportedGapTags =
+        new(System.StringComparer.OrdinalIgnoreCase);
+
+    public ReactiveCommand<Unit, Unit> ReportXmlGapCommand { get; private set; } = null!;
+    public ReactiveCommand<Unit, Unit> DismissXmlGapNoticeCommand { get; private set; } = null!;
+
     // ── Plugins menu ────────────────────────────────────────────────────────
     /// <summary>Loaded plugins shown in the Plugins menu (enable/disable).
     /// Rebuilt when the menu opens.</summary>
@@ -1505,6 +1527,14 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         // auto-applies where the matching Auto-Apply toggle is on.
         LoadUpdatePolicies();
         DismissUpdateNoticeCommand = ReactiveCommand.Create(() => { UpdateNotice = ""; });
+
+        DismissXmlGapNoticeCommand = ReactiveCommand.Create(() => { XmlGapNotice = ""; });
+        ReportXmlGapCommand = ReactiveCommand.Create(() =>
+        {
+            if (!string.IsNullOrEmpty(_pendingXmlGapUrl))
+                OpenUrl(_pendingXmlGapUrl, "the XML gap report");
+            XmlGapNotice = "";
+        });
         _ = CheckForUpdatesInBackgroundAsync();
 
         this.WhenAnyValue(x => x.UpdatesAvailable)
@@ -2311,6 +2341,25 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         {
             GameText.AddSystemLine($"[help] could not open {label} ({ex.Message}). Visit {url} manually.");
         }
+    }
+
+    /// <summary>Environment/context for an XML-gap issue draft. Version comes
+    /// from the assembly InformationalVersion (single source of truth); the git
+    /// hash after '+' becomes the parser-commit line when present.</summary>
+    private static Genie.Core.Diagnostics.XmlGapReport.ReportContext BuildXmlGapContext(string trigger)
+    {
+        var asm  = System.Reflection.Assembly.GetEntryAssembly();
+        var info = (asm is null ? null : System.Reflection.CustomAttributeExtensions
+                       .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>(asm)?.InformationalVersion)
+                   ?? "5.0.0";
+        var plus    = info.IndexOf('+');
+        var version = plus >= 0 ? info[..plus] : info;
+        var commit  = plus >= 0 ? info[(plus + 1)..] : "local";
+        return new Genie.Core.Diagnostics.XmlGapReport.ReportContext(
+            AppVersion: version,
+            Os:         System.Runtime.InteropServices.RuntimeInformation.OSDescription,
+            Commit:     commit,
+            Trigger:    trigger);
     }
 
     private void OpenMapsFolder()
@@ -3628,6 +3677,28 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                     LastConnectionConfig = LastConnectionConfig with { CharacterName = e.Name };
                 if (IsConnected)
                     ConnectionStatus = $"Connected — {Genie.Core.Profiles.CharacterIdentity.Format(e.Name, LastConnectionConfig?.AccountName ?? "")}";
+            });
+
+        // Report XML Gap: when the parser meets an element it doesn't consume
+        // (UnknownTagEvent), offer a one-click, human-in-the-loop report. The
+        // draft is redacted (policy gate G2) and only a browser prefill URL is
+        // produced — nothing is posted automatically. One prompt per tag type
+        // per session so a routine gap doesn't nag.
+        _core.GameEvents.OfType<UnknownTagEvent>()
+            .ObserveOn(RxApp.MainThreadScheduler)
+            .Subscribe(e =>
+            {
+                if (string.IsNullOrWhiteSpace(e.TagName)) return;
+                if (!_reportedGapTags.Add(e.TagName)) return;
+                try
+                {
+                    var fate  = Genie.Core.Parser.DrXmlParser.ClassifyTag(e.TagName);
+                    var draft = Genie.Core.Diagnostics.XmlGapReport.Build(
+                        e.TagName, fate, e.RawXml ?? "", BuildXmlGapContext($"live element <{e.TagName}>"));
+                    _pendingXmlGapUrl = draft.Url;
+                    XmlGapNotice = $"Genie received an unrecognized game element: <{e.TagName}>. Help improve the parser — report it?";
+                }
+                catch (Exception ex) { ErrorLog.Log("XmlGapReport", ex); }
             });
 
         _core.ConnectionState.ObserveOn(RxApp.MainThreadScheduler)

--- a/src/Genie.App/Views/MainWindow.axaml
+++ b/src/Genie.App/Views/MainWindow.axaml
@@ -1149,6 +1149,29 @@
       </DockPanel>
     </Border>
 
+    <!-- ── Report-XML-gap notice strip (parser met an element it doesn't      -->
+    <!-- consume). One-click, human-in-the-loop: drafts a REDACTED GitHub issue -->
+    <!-- and opens the prefill URL in the browser — nothing is posted           -->
+    <!-- automatically. Auto-shows only while a gap is pending; × dismisses.    -->
+    <!-- Independent of the vitals Status Bar toggle, like the update strip.    -->
+    <Border DockPanel.Dock="Bottom"
+            IsVisible="{Binding XmlGapNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+            Background="{DynamicResource Theme.StripBg}" BorderBrush="{DynamicResource Theme.Border}" BorderThickness="0,1,0,0"
+            Padding="6,1">
+      <DockPanel>
+        <Button DockPanel.Dock="Right" Content="✕"
+                Command="{Binding DismissXmlGapNoticeCommand}"
+                Background="Transparent" BorderThickness="0" Padding="4,0"
+                FontSize="10" Foreground="{DynamicResource Theme.SectionHeader}"
+                ToolTip.Tip="Dismiss (this element won't prompt again this session)"/>
+        <Button Content="{Binding XmlGapNotice}"
+                Command="{Binding ReportXmlGapCommand}"
+                Background="Transparent" BorderThickness="0" Padding="2,0"
+                HorizontalAlignment="Left" FontSize="11" Foreground="{DynamicResource Theme.SectionHeader}"
+                ToolTip.Tip="Opens a pre-filled, pre-redacted GitHub issue in your browser — you review and submit it"/>
+      </DockPanel>
+    </Border>
+
     <!-- ── Hands strip (bottom position — Genie 4 style) ────────────────── -->
     <!-- Declared AFTER the StatusBar and BEFORE the CommandBar so the         -->
     <!-- DockPanel stacks (bottom → top): StatusBar, HandsBottom, CommandBar.  -->

--- a/tests/Genie.Core.Tests/XmlGapReportTests.cs
+++ b/tests/Genie.Core.Tests/XmlGapReportTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Genie.Core.Diagnostics;
+using Genie.Core.Events;
+using Genie.Core.Parser;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// "Report XML Gap" data path. When the parser meets an element it does not
+/// consume it emits an <see cref="UnknownTagEvent"/>; <see cref="XmlGapReport"/>
+/// turns that into a review-ready, redacted GitHub new-issue prefill URL. This
+/// is exactly the Core path the App's notice strip consumes: subscribe to
+/// UnknownTagEvent → Build a draft → open draft.Url in the browser.
+/// </summary>
+public class XmlGapReportTests
+{
+    private sealed class Collector : IObserver<GameEvent>
+    {
+        private readonly List<GameEvent> _sink;
+        public Collector(List<GameEvent> sink) => _sink = sink;
+        public void OnNext(GameEvent e) => _sink.Add(e);
+        public void OnError(Exception error) { }
+        public void OnCompleted() { }
+    }
+
+    private static List<GameEvent> Feed(params string[] chunks)
+    {
+        var parser = new DrXmlParser(NullLogger<DrXmlParser>.Instance);
+        var events = new List<GameEvent>();
+        using var _ = parser.GameEvents.Subscribe(new Collector(events));
+        foreach (var chunk in chunks) parser.Feed(chunk);
+        return events;
+    }
+
+    [Fact]
+    public void Parser_emits_UnknownTagEvent_for_an_unconsumed_element()
+    {
+        var events  = Feed("<frobnitz kind='7'>whatever</frobnitz>\n");
+        var unknown = events.OfType<UnknownTagEvent>().FirstOrDefault();
+
+        Assert.NotNull(unknown);
+        Assert.Equal("frobnitz", unknown!.TagName, ignoreCase: true);
+        Assert.Contains("frobnitz", unknown.RawXml);
+    }
+
+    [Fact]
+    public void Build_produces_a_prefilled_github_new_issue_url()
+    {
+        var ctx   = new XmlGapReport.ReportContext("5.0.0-alpha.test", "TestOS", "local", "unit test");
+        var draft = XmlGapReport.Build("frobnitz", DrXmlParser.TagFate.Unknown, "<frobnitz kind='7'/>", ctx);
+
+        Assert.Contains("/issues/new", draft.Url);
+        Assert.Contains("frobnitz", draft.Title);
+        Assert.Equal("xml-coverage", draft.Labels);
+        // The App hands draft.Url straight to the browser, so it must be a single
+        // percent-encoded token — no raw spaces or newlines.
+        Assert.DoesNotContain(' ', draft.Url);
+        Assert.DoesNotContain('\n', draft.Url);
+    }
+
+    [Fact]
+    public void Build_redacts_other_players_speech_from_the_sample()
+    {
+        var ctx = new XmlGapReport.ReportContext("5.0.0", "TestOS", "local", "unit test");
+        // A sample that (implausibly) carried another player's speech on its own
+        // line: the redactor (policy gate G2) must strip the spoken text before
+        // it can reach the drafted issue body.
+        var sample = "<frobnitz/>\nSomeone says, \"secret plan\"\n";
+        var draft  = XmlGapReport.Build("frobnitz", DrXmlParser.TagFate.Unknown, sample, ctx);
+
+        Assert.DoesNotContain("secret plan", draft.Body);
+    }
+}

--- a/wiki/Releases.md
+++ b/wiki/Releases.md
@@ -4,7 +4,17 @@ Where to get Genie 5 and what changed in each build. Downloads live on the [Rele
 
 > Genie 5 is **alpha**. Versions are tagged `v5.0.0-alpha.N`. Builds are unsigned for now (Windows/macOS show a first-launch warning — see [Installation](Installation#platform-first-launch-notes)); signed Windows builds are expected from an upcoming release.
 
-## Latest: v5.0.0-alpha.8.3 — Experience & Highlights
+## Latest: v5.0.0-alpha.8.4 — Parser Gap Reporting
+
+When DragonRealms sends an element Genie's parser doesn't recognize yet, a one-click prompt drafts a pre-redacted GitHub issue for you to review and submit.
+
+> **📡 Still on the beta channel — that's intentional.** Every alpha ships as a GitHub **pre-release**, so the Core updater defaults to **beta**; that's what lets **Help → Check for Updates** see new alpha builds. Already on an earlier alpha? Open the Updates dialog and you'll be offered **alpha.8.4** as a delta.
+
+- **Report parser gaps ([#152](https://github.com/GenieClient/Genie5/issues/152))** — if the game sends an element the parser doesn't handle yet, a slim notice offers to report it. One click opens a **pre-filled, pre-redacted** GitHub issue in your browser (other players' speech removed, your version attached); nothing is posted until you review and submit. Each unknown element asks once per session.
+
+[Full release notes →](https://github.com/GenieClient/Genie5/releases/tag/v5.0.0-alpha.8.4)
+
+## v5.0.0-alpha.8.3 — Experience & Highlights
 
 The Experience window catches up to Genie 3/4, a Display Settings Theme manager arrives, dock windows gain Save As / Find / Word Wrap, and a batch of highlight fixes land.
 

--- a/wiki/The-Interface.md
+++ b/wiki/The-Interface.md
@@ -41,6 +41,13 @@ Scripts can create their **own named windows** too — the Genie 4 menu-script c
 - **Hands strip** — what's in your **left** and **right** hands, your **prepared spell** (with a cast-time bar), and your **stance**. Its position (top or bottom) is configurable from the **Window** menu.
 - **Command bar** — where you type. A **roundtime** indicator shows here (or on the hands strip — your choice) so you can see when you can act again.
 
+## Notices
+
+Two slim, dismissible strips appear just above the vitals bar — but only when there's something to tell you. Each has an **✕** to hide it.
+
+- **Updates available** — shows after the startup check finds a newer Core, map, script, or plugin. Click it to open the **Updates** dialog. See [Keeping Up to Date](Updates).
+- **Help improve the parser** — if the game ever sends Genie an element it doesn't recognize, this strip asks whether you'd like to report it. Click it and Genie opens a **pre-filled GitHub issue** in your browser, with the sample **already redacted** (other players' speech removed) and your Genie version attached. **Nothing is sent until you review it and press Submit** — no account data, no automatic posting. It's a one-click way to help Genie's parser keep pace as DragonRealms evolves. Each unknown element only asks once per session.
+
 ## The command bar
 
 Type a game command and press **Enter**. Beyond plain commands:

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -101,6 +101,9 @@ Details: [Application Folders](Application-Folders#resetting-to-defaults).
 
 Recordings stay on your machine until you choose to share a snippet.
 
+**What's the "Genie received an unrecognized game element" prompt?**
+That's Genie offering to help itself. When DragonRealms sends a tag the parser doesn't handle yet, a slim strip appears above the vitals bar. Click it and Genie opens a **pre-filled GitHub issue** in your browser — the sample is **already redacted** (other players' speech removed) and your Genie version is attached. **Nothing is sent until you review it and press Submit.** It's the fastest way to help the parser keep up as the game changes; each unknown element only asks once per session, and **✕** dismisses it. See [The Interface → Notices](The-Interface#notices).
+
 ## Related
 
 - [Connecting & Profiles](Connecting) · [Application Folders](Application-Folders) · [The Mapper](Mapper) · [Scripting](Scripting) · [Policy Compliance](Policy-Compliance)


### PR DESCRIPTION
Ships the **Report XML Gap** notice and cuts **v5.0.0-alpha.8.4**.

When the parser meets an element it doesn't consume, a dismissible notice strip offers to report it — one click opens a pre-filled, pre-redacted GitHub new-issue URL (other players' speech stripped; nothing posted automatically). One prompt per tag type per session.

- Feature + `XmlGapReportTests`
- README status row; wiki The-Interface "Notices" section; Troubleshooting FAQ
- Version bump + RELEASE_NOTES + wiki Releases entry

Closes #152