### PR TITLE
fix(release): download prior osx-x64 packages by channel so Intel mac deltas generate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,12 +382,18 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Download previous Velopack releases (for delta packages)
+        # --channel is required here: `vpk download` defaults to the runner
+        # OS's default channel, which on a macOS runner is `osx` (Apple
+        # Silicon). Without it this job pulls the arm64 packages, so Intel
+        # deltas are diffed against the wrong base or skipped entirely. Must
+        # match the `--channel osx-x64` used by the pack step below.
         continue-on-error: true
         run: |
           vpk download github \
             --repoUrl https://github.com/GenieClient/Genie5 \
             --outputDir velopack-releases \
-            --pre
+            --pre \
+            --channel osx-x64
 
       - name: Velopack pack
         run: |


### PR DESCRIPTION
## What

The `velopack-osx-x64` release job packs with `--channel osx-x64`, but its download-previous-releases step relied on `vpk download`'s default channel — which on a macOS runner is `osx` (Apple Silicon). The job therefore pulled the arm64 packages, so Intel delta updates would be diffed against the wrong base or skipped entirely. This passes `--channel osx-x64` explicitly to match the pack step.

## Why no release has hit this yet

v5.0.0-alpha.8.1 published no macOS packages, so 8.2 was a first-of-channel release and correctly shipped `-osx-full` / `-osx-x64-full` only. The first tag after this merge should produce both `-osx-delta` and `-osx-x64-delta`; that is the verification signal.

Part of #27 (macOS / Linux update channels — verification pass).