### PR TITLE
chore: add CODEOWNERS to auto-request reviewers (#31)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for Genie 5
+# Auto-requests review from the listed owner(s) when a PR touches matching paths.
+# Docs: https://docs.github.com/articles/about-code-owners
+#
+# Global fallback owner. Refine with per-area entries (Genie.Core, Genie.App,
+# .github, wiki) as the maintainer roster stabilises.
+* @monil2233


### PR DESCRIPTION
Adds a `CODEOWNERS` file so reviewers are auto-requested on matching PRs.

Part of #31 (branch-protection hardening). Starts with a global fallback
owner (`* @monil2233`); per-area entries (Genie.Core, Genie.App, .github,
wiki) can be layered on later as the maintainer roster stabilises.

This PR also serves as the first exercise of the new `main` ruleset
(requires the `dotnet build (ubuntu-latest)` check + 1 approval).
