### PR TITLE
feat(lich): dynamic lichargs + owned auto-launch lifecycle

### DIFF
--- a/src/Genie.App/ViewModels/GameTextViewModel.cs
+++ b/src/Genie.App/ViewModels/GameTextViewModel.cs
@@ -332,11 +332,35 @@ public class GameTextViewModel : ReactiveObject
             presets = presets?.Select(s => s with { Start = s.Start + shift }).ToList();
         }
         Lines.Add(new TextLine(text, color, links, bolds, presets));
-        while (Lines.Count > _maxLines)
-            Lines.RemoveAt(0);
+        TrimScrollback();
         // Only a prompt line arms the dedup; every other line clears it so the
         // next prompt is allowed through (Genie 4 LastRowWasPrompt semantics).
         _lastLineWasPrompt = isPrompt;
+    }
+
+    /// <summary>
+    /// Drop oldest lines when over the scrollback cap. Trimming is deferred when
+    /// a <see cref="ObservableCollection{T}.CollectionChanged"/> is already in
+    /// flight (Avalonia ItemsControl / nested Add) — mutating inside that event
+    /// throws <c>Cannot change ObservableCollection during a CollectionChanged event</c>.
+    /// </summary>
+    private void TrimScrollback()
+    {
+        if (Lines.Count <= _maxLines) return;
+        try
+        {
+            while (Lines.Count > _maxLines)
+                Lines.RemoveAt(0);
+        }
+        catch (InvalidOperationException ex)
+            when (ex.Message.Contains("CollectionChanged", StringComparison.Ordinal))
+        {
+            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                while (Lines.Count > _maxLines)
+                    Lines.RemoveAt(0);
+            });
+        }
     }
 
     /// <summary>
@@ -391,8 +415,7 @@ public class GameTextViewModel : ReactiveObject
         if (Settings?.Timestamp == true)              // #90: stamp echoes too
             text = WindowTimestamp.Prefix() + text;
         Lines.Add(new TextLine(text, StreamColor.System, EchoColor: color, Mono: mono));
-        while (Lines.Count > _maxLines)
-            Lines.RemoveAt(0);
+        TrimScrollback();
         _lastLineWasPrompt = false;
     }
 }

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -1216,7 +1216,12 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         ConnectCommand = ReactiveCommand.CreateFromTask(async () =>
         {
             var result = await ShowConnectDialog.Handle(Unit.Default);
-            if (result is not null) await ConnectAsync(result.Config, result.Profile);
+            if (result is null) return;
+            // Same teardown as #connect — character change must drop the old
+            // session (and Genie-owned Lich) before the new auto-launch.
+            if (IsConnected) await DisconnectAsync();
+            else _manualDisconnect = true;
+            await ConnectAsync(result.Config, result.Profile);
         });
 
         DisplaySettingsCommand = ReactiveCommand.CreateFromTask(async () =>
@@ -3578,11 +3583,15 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                 && !string.Equals(_ownedLichLaunchKey, launchKey, StringComparison.OrdinalIgnoreCase))
                 StopOwnedLich();
 
+            // EnsureRunningAsync uses ConfigureAwait(false); marshal progress onto
+            // the UI thread so GameText.Lines isn't mutated during / across a
+            // CollectionChanged (character change races the "disconnected" line).
             var lich = await Genie.Core.Connection.LichLauncher.EnsureRunningAsync(
                 coreCfg.LichProxyHost, coreCfg.LichProxyPort,
                 _core.Config.LichRubyPath, _core.Config.LichPath, lichArgs,
                 _core.Config.LichStartPause,
-                progress: msg => GameText.AddSystemLine(msg));
+                progress: msg => Avalonia.Threading.Dispatcher.UIThread.Post(
+                    () => GameText.AddSystemLine(msg)));
             GameText.AddSystemLine(lich.Message);
             if (lich.Outcome == Genie.Core.Connection.LichLaunchOutcome.Failed)
                 return;   // don't attempt a connect we know can't reach Lich

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -3546,11 +3546,23 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         // already listening on the proxy port this attaches without launching, so
         // a manually-started Lich still works. A hard launch failure aborts the
         // connect (a doomed LichProxy connect would only fail with a vaguer error).
+        // lichargs may use {character}/{port} placeholders filled from this connect.
         if (coreCfg.Mode == ConnectionMode.LichProxy && _core.Config.LichAutoLaunch)
         {
+            if (!Genie.Core.Connection.LichLauncher.TryExpandArguments(
+                    _core.Config.LichArguments,
+                    coreCfg.CharacterName,
+                    coreCfg.LichProxyPort,
+                    out var lichArgs,
+                    out var expandError))
+            {
+                GameText.AddSystemLine(expandError);
+                return;
+            }
+
             var lich = await Genie.Core.Connection.LichLauncher.EnsureRunningAsync(
                 coreCfg.LichProxyHost, coreCfg.LichProxyPort,
-                _core.Config.LichRubyPath, _core.Config.LichPath, _core.Config.LichArguments,
+                _core.Config.LichRubyPath, _core.Config.LichPath, lichArgs,
                 _core.Config.LichStartPause,
                 progress: msg => GameText.AddSystemLine(msg));
             GameText.AddSystemLine(lich.Message);

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -924,6 +924,14 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// session-ending "Disconnected" popup (#114) can show it. Null for a clean close.</summary>
     private string? _lastDropReason;
 
+    /// <summary>PID of a Lich process Genie auto-launched this session. Null when we only
+    /// attached to an already-running Lich (never kill that). Cleared after <see cref="StopOwnedLich"/>.</summary>
+    private int? _ownedLichProcessId;
+
+    /// <summary>Character + port key for the owned auto-launched Lich — used to detect a
+    /// character/port switch that needs a stop-then-relaunch before connect.</summary>
+    private string? _ownedLichLaunchKey;
+
     /// <summary>Base name of the recipe script whose completion should auto-stop
     /// the current capture (null for a manual capture, which the user stops).</summary>
     private string? _activeCaptureScript;
@@ -3547,6 +3555,8 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         // a manually-started Lich still works. A hard launch failure aborts the
         // connect (a doomed LichProxy connect would only fail with a vaguer error).
         // lichargs may use {character}/{port} placeholders filled from this connect.
+        // Genie-started Lich is owned (PID tracked) and stopped on disconnect /
+        // character change; an AlreadyRunning attach is never claimed as owned.
         if (coreCfg.Mode == ConnectionMode.LichProxy && _core.Config.LichAutoLaunch)
         {
             if (!Genie.Core.Connection.LichLauncher.TryExpandArguments(
@@ -3560,6 +3570,14 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                 return;
             }
 
+            var launchKey = OwnedLichLaunchKey(coreCfg.CharacterName, coreCfg.LichProxyPort);
+            // Character/port switch: stop the previous Genie-started Lich so the
+            // new --login can bind the proxy port (AlreadyRunning would otherwise
+            // leave us attached to the wrong character).
+            if (_ownedLichProcessId is not null
+                && !string.Equals(_ownedLichLaunchKey, launchKey, StringComparison.OrdinalIgnoreCase))
+                StopOwnedLich();
+
             var lich = await Genie.Core.Connection.LichLauncher.EnsureRunningAsync(
                 coreCfg.LichProxyHost, coreCfg.LichProxyPort,
                 _core.Config.LichRubyPath, _core.Config.LichPath, lichArgs,
@@ -3568,9 +3586,32 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             GameText.AddSystemLine(lich.Message);
             if (lich.Outcome == Genie.Core.Connection.LichLaunchOutcome.Failed)
                 return;   // don't attempt a connect we know can't reach Lich
+
+            if (lich.Outcome == Genie.Core.Connection.LichLaunchOutcome.Launched
+                && lich.ProcessId is int pid)
+            {
+                _ownedLichProcessId = pid;
+                _ownedLichLaunchKey = launchKey;
+            }
         }
 
         await _core.ConnectAsync(coreCfg, reloadRules: reloadRules, clearPerCharacter: charSwitch);
+    }
+
+    /// <summary>Stable key for the owned auto-launched Lich (character + proxy port).</summary>
+    private static string OwnedLichLaunchKey(string? characterName, int port) =>
+        $"{characterName ?? ""}\0{port}";
+
+    /// <summary>Kill a Lich process Genie auto-launched. No-op when we only attached
+    /// to an already-running Lich (<see cref="_ownedLichProcessId"/> null).</summary>
+    private void StopOwnedLich()
+    {
+        if (_ownedLichProcessId is not int pid) return;
+        _ownedLichProcessId = null;
+        _ownedLichLaunchKey = null;
+        Genie.Core.Connection.LichLauncher.TryStop(pid, out var message);
+        if (!string.IsNullOrEmpty(message))
+            GameText.AddSystemLine(message);
     }
 
     /// <summary>Build the one persistent core + run all once-per-app App wiring the
@@ -4046,6 +4087,11 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                 if (e.Kind == ConnectionEventKind.Disconnected && _reconnectAt is null)
                 {
                     GameText.AddSystemLine(WindowTimestamp.Prefix() + "disconnected");
+
+                    // Final session end (no auto-reconnect): stop a Genie-started
+                    // Lich. Idempotent with DisconnectAsync's StopOwnedLich. Skipped
+                    // while reconnect is armed so a transient drop can reattach.
+                    StopOwnedLich();
 
                     if (Display.ShowDisconnectPopup)
                     {
@@ -4595,6 +4641,11 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         // (issue #88). The pump is cheap when no scripts are active.
         if (_core is not null)
             await _core.DisconnectAsync();
+
+        // Manual disconnect ends the Genie-owned Lich session (logout). Kept
+        // AFTER the TCP teardown so the FE detach completes first. Auto-reconnect
+        // paths do not call this method, so a transient drop can reattach.
+        StopOwnedLich();
     }
 
     /// <summary>Heartbeat handler — pumps the script engine so time-based

--- a/src/Genie.Core/Commanding/CommandEngine.cs
+++ b/src/Genie.Core/Commanding/CommandEngine.cs
@@ -725,6 +725,9 @@ public sealed class CommandEngine
                 _host.Echo($"Lich Path:\t {(_config.LichPath.Length == 0 ? "(not set)" : _config.LichPath)}");
                 _host.Echo($"Lich Args:\t {(_config.LichArguments.Length == 0 ? "(none)" : _config.LichArguments)}");
                 _host.Echo($"Start Pause:\t {_config.LichStartPause}s");
+                if (_config.LichArguments.Contains("{character}", StringComparison.OrdinalIgnoreCase)
+                    || _config.LichArguments.Contains("{port}", StringComparison.OrdinalIgnoreCase))
+                    _host.Echo("Placeholders:\t {character} and {port} expand from the Lich-proxy Character / port at connect.");
                 if (!_config.LichAutoLaunch)
                     _host.Echo("Auto-launch is off — #lc / #lichconnect attach to an already-running Lich. " +
                                "Set #config lichpath {path} and #config lichautolaunch on to have Genie start it.");

--- a/src/Genie.Core/Config/GenieConfig.cs
+++ b/src/Genie.Core/Config/GenieConfig.cs
@@ -247,6 +247,9 @@ public sealed class GenieConfig
 
     /// <summary>Extra arguments passed to Lich after the script path (e.g.
     /// <c>--login MyChar --without-frontend --detachable-client=8000</c>).
+    /// Supports <c>{character}</c> and <c>{port}</c> placeholders, expanded at
+    /// auto-launch from the Lich-proxy profile's Character field and proxy port
+    /// (e.g. <c>--login {character} --dragonrealms --genie --headless {port}</c>).
     /// Genie 4's <c>LichArguments</c>. <c>#config lichargs {args}</c>.</summary>
     public string LichArguments { get; set; } = string.Empty;
 

--- a/src/Genie.Core/LichLauncher.cs
+++ b/src/Genie.Core/LichLauncher.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net.Sockets;
+using System.Text.RegularExpressions;
 
 namespace Genie.Core.Connection;
 
@@ -41,6 +42,61 @@ public sealed record LichLaunchResult(LichLaunchOutcome Outcome, string Message)
 /// </summary>
 public static class LichLauncher
 {
+    private static readonly Regex CharacterPlaceholder =
+        new(@"\{character\}", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex PortPlaceholder =
+        new(@"\{port\}", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Expands <c>{character}</c> and <c>{port}</c> placeholders in a
+    /// <c>#config lichargs</c> template so auto-launch can take the Character /
+    /// port from the Genie Lich-proxy profile (or Connect dialog) instead of a
+    /// hard-coded <c>--login</c> name.
+    /// </summary>
+    /// <remarks>
+    /// Placeholders are case-insensitive. Static <c>lichargs</c> with no
+    /// placeholders are returned unchanged (Genie 4 parity). If the template
+    /// contains <c>{character}</c> and <paramref name="characterName"/> is
+    /// empty, expansion fails so the caller can abort before launching Lich
+    /// with a broken command line.
+    /// </remarks>
+    /// <param name="template">Raw <see cref="Config.GenieConfig.LichArguments"/> value.</param>
+    /// <param name="characterName">Profile / Connect-dialog Character field.</param>
+    /// <param name="port">Lich proxy port (<see cref="ConnectionConfig.LichProxyPort"/>).</param>
+    /// <param name="expanded">Resolved argument string on success; empty on failure.</param>
+    /// <param name="error">Human-readable <c>[lich] …</c> message on failure; empty on success.</param>
+    /// <returns><see langword="true"/> when <paramref name="expanded"/> is safe to pass to
+    /// <see cref="EnsureRunningAsync"/>.</returns>
+    public static bool TryExpandArguments(
+        string? template,
+        string? characterName,
+        int port,
+        out string expanded,
+        out string error)
+    {
+        var args = template ?? string.Empty;
+        var needsCharacter = CharacterPlaceholder.IsMatch(args);
+        if (needsCharacter && string.IsNullOrWhiteSpace(characterName))
+        {
+            expanded = string.Empty;
+            error =
+                "[lich] lichargs uses {character} but no Character is set on this Lich-proxy " +
+                "connect. Set Character in the Connect dialog / profile, or replace {character} " +
+                "with a fixed --login name in #config lichargs.";
+            return false;
+        }
+
+        if (needsCharacter)
+            args = CharacterPlaceholder.Replace(args, characterName!.Trim());
+
+        args = PortPlaceholder.Replace(args, port.ToString());
+
+        expanded = args;
+        error = string.Empty;
+        return true;
+    }
+
     public static async Task<LichLaunchResult> EnsureRunningAsync(
         string host,
         int port,

--- a/src/Genie.Core/LichLauncher.cs
+++ b/src/Genie.Core/LichLauncher.cs
@@ -20,8 +20,11 @@ public enum LichLaunchOutcome
     Failed,
 }
 
-/// <summary>Outcome + a human-readable message for the game window.</summary>
-public sealed record LichLaunchResult(LichLaunchOutcome Outcome, string Message);
+/// <summary>Outcome + a human-readable message for the game window.
+/// <see cref="ProcessId"/> is set only when <see cref="Outcome"/> is
+/// <see cref="LichLaunchOutcome.Launched"/> — the caller owns that process and
+/// should stop it on disconnect / character change via <see cref="LichLauncher.TryStop"/>.</summary>
+public sealed record LichLaunchResult(LichLaunchOutcome Outcome, string Message, int? ProcessId = null);
 
 /// <summary>
 /// Cross-platform "start Lich for me" helper backing the Genie 4 <c>#lc</c> /
@@ -34,7 +37,10 @@ public sealed record LichLaunchResult(LichLaunchOutcome Outcome, string Message)
 ///   <item>launches <c>ruby</c> directly (no <c>cmd.exe</c>), so it works the same
 ///     on Windows, macOS and Linux;</item>
 ///   <item><b>polls</b> the port and returns as soon as Lich is up, using the
-///     start-pause only as an upper bound.</item>
+///     start-pause only as an upper bound;</item>
+///   <item>returns the launched process id so the App can stop <b>only</b> a
+///     Genie-started Lich on disconnect / character change (never a manually
+///     started one that was merely attached to).</item>
 /// </list>
 /// Pure Core code (no UI dependency); the App calls it from its connect path when
 /// <see cref="Config.GenieConfig.LichAutoLaunch"/> is on and the mode is
@@ -109,7 +115,7 @@ public static class LichLauncher
     {
         // 1. Already listening? Attach — never double-launch. This preserves the
         //    long-standing "start Lich yourself, then #lichconnect" workflow even
-        //    with auto-launch turned on.
+        //    with auto-launch turned on. No ProcessId: caller must not claim ownership.
         if (await IsPortOpenAsync(host, port, TimeSpan.FromMilliseconds(600), ct).ConfigureAwait(false))
             return new(LichLaunchOutcome.AlreadyRunning,
                 $"[lich] already listening on {host}:{port} — attaching.");
@@ -126,7 +132,8 @@ public static class LichLauncher
             return new(LichLaunchOutcome.Failed,
                 $"[lich] Ruby not found at '{rubyPath}'. Fix #config lichruby, or clear it to use Ruby from PATH.");
 
-        // 3. Launch ruby <lichPath> <arguments>.
+        // 3. Launch ruby <lichPath> <arguments> and keep the PID for ownership.
+        int pid;
         try
         {
             var psi = new ProcessStartInfo
@@ -144,6 +151,7 @@ public static class LichLauncher
             using var proc = Process.Start(psi);
             if (proc is null)
                 return new(LichLaunchOutcome.Failed, "[lich] failed to start the Lich process.");
+            pid = proc.Id;
         }
         catch (Exception ex)
         {
@@ -151,21 +159,78 @@ public static class LichLauncher
         }
 
         // 4. Poll the proxy port until it opens or the start-pause elapses.
+        //    If we never see the port, kill the orphan we just started.
         var pause = Math.Clamp(startPauseSeconds, 1, 120);
         for (var i = 0; i < pause; i++)
         {
             if (ct.IsCancellationRequested)
+            {
+                TryStop(pid, out _);
                 return new(LichLaunchOutcome.Failed, "[lich] launch cancelled.");
+            }
             if (await IsPortOpenAsync(host, port, TimeSpan.FromMilliseconds(800), ct).ConfigureAwait(false))
-                return new(LichLaunchOutcome.Launched, $"[lich] up on {host}:{port}.");
+                return new(LichLaunchOutcome.Launched, $"[lich] up on {host}:{port}.", pid);
             progress?.Invoke($"[lich] waiting for Lich… ({i + 1}/{pause}s)");
             try { await Task.Delay(1000, ct).ConfigureAwait(false); }
-            catch (OperationCanceledException) { return new(LichLaunchOutcome.Failed, "[lich] launch cancelled."); }
+            catch (OperationCanceledException)
+            {
+                TryStop(pid, out _);
+                return new(LichLaunchOutcome.Failed, "[lich] launch cancelled.");
+            }
         }
 
+        TryStop(pid, out _);
         return new(LichLaunchOutcome.Failed,
             $"[lich] Lich did not open {host}:{port} within {pause}s. " +
             "Increase #config lichstartpause, or check Lich's own window for errors.");
+    }
+
+    /// <summary>
+    /// Stops a process Genie previously auto-launched. Safe if the PID is already
+    /// gone (treated as success). Uses the entire process tree so a <c>ruby</c>
+    /// wrapper and its Lich children both exit.
+    /// </summary>
+    /// <param name="processId">PID from <see cref="LichLaunchResult.ProcessId"/>.</param>
+    /// <param name="message"><c>[lich] …</c> status line for the game window.</param>
+    /// <returns><see langword="true"/> when the process is gone (killed or already exited);
+    /// <see langword="false"/> only when a kill attempt threw.</returns>
+    public static bool TryStop(int processId, out string message)
+    {
+        if (processId <= 0)
+        {
+            message = string.Empty;
+            return false;
+        }
+
+        try
+        {
+            Process proc;
+            try { proc = Process.GetProcessById(processId); }
+            catch (ArgumentException)
+            {
+                message = $"[lich] auto-launched process {processId} already exited.";
+                return true;
+            }
+
+            using (proc)
+            {
+                if (proc.HasExited)
+                {
+                    message = $"[lich] auto-launched process {processId} already exited.";
+                    return true;
+                }
+
+                proc.Kill(entireProcessTree: true);
+                proc.WaitForExit(5_000);
+                message = $"[lich] stopped auto-launched process {processId}.";
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            message = $"[lich] failed to stop process {processId}: {ex.Message}";
+            return false;
+        }
     }
 
     /// <summary>Ruby executable name when none is configured — resolved off PATH

--- a/src/Genie.Core/LichLauncher.cs
+++ b/src/Genie.Core/LichLauncher.cs
@@ -133,6 +133,10 @@ public static class LichLauncher
                 $"[lich] Ruby not found at '{rubyPath}'. Fix #config lichruby, or clear it to use Ruby from PATH.");
 
         // 3. Launch ruby <lichPath> <arguments> and keep the PID for ownership.
+        //    Progress is best-effort and must NEVER abort the launch — callers often
+        //    push lines into a UI ObservableCollection, and this method uses
+        //    ConfigureAwait(false), so progress may run off the UI thread and race
+        //    CollectionChanged (character change: "disconnected" + relaunch).
         int pid;
         try
         {
@@ -147,7 +151,6 @@ public static class LichLauncher
             foreach (var a in SplitArguments(arguments))
                 psi.ArgumentList.Add(a);
 
-            progress?.Invoke($"[lich] starting: {ruby} {lichPath} {arguments}".TrimEnd());
             using var proc = Process.Start(psi);
             if (proc is null)
                 return new(LichLaunchOutcome.Failed, "[lich] failed to start the Lich process.");
@@ -157,6 +160,8 @@ public static class LichLauncher
         {
             return new(LichLaunchOutcome.Failed, $"[lich] failed to start Lich: {ex.Message}");
         }
+
+        ReportProgress(progress, $"[lich] starting: {ruby} {lichPath} {arguments}".TrimEnd());
 
         // 4. Poll the proxy port until it opens or the start-pause elapses.
         //    If we never see the port, kill the orphan we just started.
@@ -170,7 +175,7 @@ public static class LichLauncher
             }
             if (await IsPortOpenAsync(host, port, TimeSpan.FromMilliseconds(800), ct).ConfigureAwait(false))
                 return new(LichLaunchOutcome.Launched, $"[lich] up on {host}:{port}.", pid);
-            progress?.Invoke($"[lich] waiting for Lich… ({i + 1}/{pause}s)");
+            ReportProgress(progress, $"[lich] waiting for Lich… ({i + 1}/{pause}s)");
             try { await Task.Delay(1000, ct).ConfigureAwait(false); }
             catch (OperationCanceledException)
             {
@@ -231,6 +236,15 @@ public static class LichLauncher
             message = $"[lich] failed to stop process {processId}: {ex.Message}";
             return false;
         }
+    }
+
+    /// <summary>Invoke <paramref name="progress"/> without letting UI/logging
+    /// failures fail the launch. See <see cref="EnsureRunningAsync"/>.</summary>
+    private static void ReportProgress(Action<string>? progress, string message)
+    {
+        if (progress is null) return;
+        try { progress(message); }
+        catch { /* best-effort */ }
     }
 
     /// <summary>Ruby executable name when none is configured — resolved off PATH

--- a/tests/Genie.Core.Tests/LichArgsConfigRoundTripTests.cs
+++ b/tests/Genie.Core.Tests/LichArgsConfigRoundTripTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+using System.Linq;
+using Genie.Core.Commanding;
+using Genie.Core.Config;
+using Genie.Core.Connection;
+using Genie.Core.Parsing;
+using Genie.Core.Queue;
+using Genie.Core.Runtime;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// Nested-brace <c>#config lichargs {--login {character} …}</c> round-trip —
+/// the path the PR review asked about. Existing <see cref="LichArgsExpandTests"/>
+/// call <see cref="LichLauncher.TryExpandArguments"/> directly; these cover the
+/// config parser / settings.cfg / <c>#ls</c> surface instead.
+/// </summary>
+public class LichArgsConfigRoundTripTests : IDisposable
+{
+    private const string NestedTemplate =
+        "--login {character} --dragonrealms --genie --headless {port}";
+
+    private const string NestedConfigLine =
+        "#config lichargs {--login {character} --dragonrealms --genie --headless {port}}";
+
+    private readonly string _root;
+    private readonly GenieConfig _config;
+
+    public LichArgsConfigRoundTripTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "genie_lichargs_rt_" + Guid.NewGuid().ToString("N"));
+        var lds = new LocalDirectoryService("GenieLichArgsRt", _root);
+        lds.UseExplicitRoot(_root);
+        _config = new GenieConfig(lds);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch { /* best-effort temp cleanup */ }
+    }
+
+    [Fact]
+    public void ArgumentParser_strips_outer_braces_keeps_inner_placeholders()
+    {
+        // Mirrors what CommandEngine feeds HandleInternalCommand (command char stripped).
+        var parts = ArgumentParser.ParseArgs(
+            "config lichargs {--login {character} --dragonrealms --genie --headless {port}}");
+
+        Assert.Equal(new[] { "config", "lichargs", NestedTemplate }, parts.ToArray());
+    }
+
+    [Fact]
+    public void SettingsCfg_save_load_preserves_inner_placeholders()
+    {
+        _config.SetSetting("lichargs", NestedTemplate, showException: false);
+        Assert.True(_config.Save());
+
+        var onDisk = File.ReadAllText(Path.Combine(_config.ConfigDir, "settings.cfg"));
+        Assert.Contains("{lichargs}", onDisk);
+        Assert.Contains("{character}", onDisk);
+        Assert.Contains("{port}", onDisk);
+        // Saved line must wrap the value; inner placeholders stay inside that wrapper.
+        Assert.Contains(
+            "#config {lichargs} {--login {character} --dragonrealms --genie --headless {port}}",
+            onDisk);
+
+        // Clear then reload from the just-written settings.cfg (same ConfigDir).
+        _config.LichArguments = "SHOULD_BE_OVERWRITTEN";
+        Assert.True(_config.Load());
+
+        Assert.Equal(NestedTemplate, _config.LichArguments);
+        // Outer grouping braces must be stripped; inner {character}/{port} stay.
+        Assert.False(_config.LichArguments.StartsWith("{--login", StringComparison.Ordinal));
+        Assert.DoesNotContain("{{", _config.LichArguments); // no brace accumulation on re-save
+    }
+
+    [Fact]
+    public void Typed_config_line_via_ParseArgs_then_SetSetting_stores_verbatim()
+    {
+        // CommandEngine path: ParseArgs → join Skip(1) → App Split(' ', 2) → SetSetting.
+        var parts = ArgumentParser.ParseArgs(NestedConfigLine[1..]); // strip '#'
+        var forwarded = string.Join(" ", parts.Skip(1));
+        var split = forwarded.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal("lichargs", split[0]);
+        Assert.Equal(NestedTemplate, split[1]);
+
+        _config.SetSetting(split[0], split[1], showException: false);
+        Assert.Equal(NestedTemplate, _config.LichArguments);
+
+        Assert.True(LichLauncher.TryExpandArguments(
+            _config.LichArguments, "MyChar", 8000, out var expanded, out var error));
+        Assert.Equal("--login MyChar --dragonrealms --genie --headless 8000", expanded);
+        Assert.Equal(string.Empty, error);
+    }
+
+    [Fact]
+    public void Ls_shows_stored_placeholders_after_nested_brace_set()
+    {
+        _config.SetSetting("lichargs", NestedTemplate, showException: false);
+        var host = new CapturingHost();
+        var engine = new CommandEngine(_config, new CommandQueue(), new EventQueue(), host);
+
+        engine.ProcessInput("#ls");
+
+        var dump = string.Join("\n", host.Echoes);
+        Assert.Contains(NestedTemplate, dump);
+        Assert.Contains("Placeholders:", dump);
+        Assert.Contains("{character}", dump);
+        Assert.Contains("{port}", dump);
+    }
+
+    [Fact]
+    public void App_style_Split_without_ParseArgs_would_keep_outer_braces()
+    {
+        // Documents the latent App-layer footgun: HandleConfigCommand uses a
+        // naive Split(' ', 2) and does not strip {…}. Today CommandEngine
+        // ParseArgs's first, so the live typed path is safe — but if anything
+        // ever forwards the braced remainder raw, outer braces would be stored.
+        var rawForwarded = "lichargs {--login {character} --dragonrealms --genie --headless {port}}";
+        var split = rawForwarded.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Equal(
+            "{--login {character} --dragonrealms --genie --headless {port}}",
+            split[1]);
+    }
+
+    private sealed class CapturingHost : ICommandHost
+    {
+        public System.Collections.Generic.List<string> Echoes { get; } = new();
+        public System.Collections.Generic.Dictionary<string, string> Globals { get; } = new();
+
+        public void Echo(string text) => Echoes.Add(text);
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> GetGlobalVariables() => Globals;
+        public string ExpandVariables(string text) => text;
+        public void MapperReset() { }
+        public void MapperCommand(string args) { }
+        public void SendToGame(string text, bool userInput = false, string origin = "", string? echoOverride = null) { }
+        public void EchoTo(string text, string? window, string? color) { }
+        public void EchoMain(string text, string? color, bool mono) { }
+        public void EchoLink(string text, string command, string? window) { }
+        public void EchoClear(string? window) { }
+        public void WindowCommand(string sub, string window) { }
+        public void SetStatusBar(string text, int index) { }
+        public void RunScript(string text) { }
+        public void InjectParsedLine(string line) { }
+        public void StopScript(string? name) { }
+        public void PauseScript(string? name) { }
+        public void ResumeScript(string? name) { }
+        public void StopAllScripts() { }
+        public void PauseAllScripts() { }
+        public void ResumeAllScripts() { }
+        public void SetTraceLevelAll(int level) { }
+        public System.Collections.Generic.IReadOnlyList<string> RunningScripts() => Array.Empty<string>();
+        public void SetGlobalVariable(string name, string value) => Globals[name] = value;
+        public void RemoveGlobalVariable(string name) => Globals.Remove(name);
+        public string SetLiveAudit(Genie.Core.Diagnostics.AuditMode mode) => string.Empty;
+        public void EditScript(string name) { }
+        public void LayoutCommand(string args) { }
+        public void PluginCommand(string args) { }
+        public void ConfigCommand(string args) { }
+        public void MapperGoto(string args) { }
+        public void PlaySound(string soundName) { }
+        public void Speak(string text, bool urgent = false) { }
+        public void TtsCommand(string args) { }
+        public void FlashWindow() { }
+        public void Connect(ConnectRequest request) { }
+    }
+}

--- a/tests/Genie.Core.Tests/LichArgsExpandTests.cs
+++ b/tests/Genie.Core.Tests/LichArgsExpandTests.cs
@@ -1,0 +1,118 @@
+using Genie.Core.Connection;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// <see cref="LichLauncher.TryExpandArguments"/> — dynamic <c>lichargs</c>
+/// placeholders filled from the Lich-proxy profile at auto-launch.
+/// </summary>
+public class LichArgsExpandTests
+{
+    [Fact]
+    public void Static_args_pass_through_unchanged()
+    {
+        var ok = LichLauncher.TryExpandArguments(
+            "--login FixedChar --dragonrealms --genie --headless 8000",
+            characterName: "Ignored",
+            port: 9999,
+            out var expanded,
+            out var error);
+
+        Assert.True(ok);
+        Assert.Equal("--login FixedChar --dragonrealms --genie --headless 8000", expanded);
+        Assert.Equal(string.Empty, error);
+    }
+
+    [Fact]
+    public void Character_and_port_placeholders_expand()
+    {
+        var ok = LichLauncher.TryExpandArguments(
+            "--login {character} --dragonrealms --genie --headless {port}",
+            characterName: "MyChar",
+            port: 8000,
+            out var expanded,
+            out var error);
+
+        Assert.True(ok);
+        Assert.Equal("--login MyChar --dragonrealms --genie --headless 8000", expanded);
+        Assert.Equal(string.Empty, error);
+    }
+
+    [Theory]
+    [InlineData("{character}", "{port}")]
+    [InlineData("{CHARACTER}", "{PORT}")]
+    [InlineData("{Character}", "{Port}")]
+    public void Placeholders_are_case_insensitive(string charToken, string portToken)
+    {
+        var ok = LichLauncher.TryExpandArguments(
+            $"--login {charToken} --headless {portToken}",
+            characterName: "Ada",
+            port: 9001,
+            out var expanded,
+            out _);
+
+        Assert.True(ok);
+        Assert.Equal("--login Ada --headless 9001", expanded);
+    }
+
+    [Fact]
+    public void Character_placeholder_trims_the_name()
+    {
+        var ok = LichLauncher.TryExpandArguments(
+            "--login {character}",
+            characterName: "  Spaced  ",
+            port: 8000,
+            out var expanded,
+            out _);
+
+        Assert.True(ok);
+        Assert.Equal("--login Spaced", expanded);
+    }
+
+    [Fact]
+    public void Missing_character_fails_when_placeholder_present()
+    {
+        var ok = LichLauncher.TryExpandArguments(
+            "--login {character} --headless {port}",
+            characterName: "  ",
+            port: 8000,
+            out var expanded,
+            out var error);
+
+        Assert.False(ok);
+        Assert.Equal(string.Empty, expanded);
+        Assert.Contains("{character}", error);
+        Assert.StartsWith("[lich]", error);
+    }
+
+    [Fact]
+    public void Port_only_template_does_not_require_character()
+    {
+        var ok = LichLauncher.TryExpandArguments(
+            "--login Fixed --headless {port}",
+            characterName: null,
+            port: 8123,
+            out var expanded,
+            out var error);
+
+        Assert.True(ok);
+        Assert.Equal("--login Fixed --headless 8123", expanded);
+        Assert.Equal(string.Empty, error);
+    }
+
+    [Fact]
+    public void Null_template_expands_to_empty()
+    {
+        var ok = LichLauncher.TryExpandArguments(
+            null,
+            characterName: "Anyone",
+            port: 8000,
+            out var expanded,
+            out var error);
+
+        Assert.True(ok);
+        Assert.Equal(string.Empty, expanded);
+        Assert.Equal(string.Empty, error);
+    }
+}

--- a/tests/Genie.Core.Tests/LichConnectTests.cs
+++ b/tests/Genie.Core.Tests/LichConnectTests.cs
@@ -128,6 +128,20 @@ public class LichConnectTests : IDisposable
         Assert.Empty(host.GameCommands);   // never reaches the game
     }
 
+    [Fact]
+    public void LichSettings_mentions_placeholders_when_lichargs_uses_them()
+    {
+        _config.SetSetting("lichargs", "--login {character} --headless {port}", showException: false);
+        var (host, engine) = Make();
+
+        engine.ProcessInput("#ls");
+
+        var dump = string.Join("\n", host.Echoes);
+        Assert.Contains("Placeholders:", dump);
+        Assert.Contains("{character}", dump);
+        Assert.Contains("{port}", dump);
+    }
+
     private sealed class FakeConnectHost : ICommandHost
     {
         public ConnectRequest? LastRequest { get; private set; }

--- a/tests/Genie.Core.Tests/LichStopTests.cs
+++ b/tests/Genie.Core.Tests/LichStopTests.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Genie.Core.Connection;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// <see cref="LichLauncher.TryStop"/> — ownership cleanup for Genie-started Lich.
+/// </summary>
+public class LichStopTests
+{
+    [Fact]
+    public void TryStop_treats_already_exited_pid_as_success()
+    {
+        // Spawn a process that exits immediately, wait for it, then TryStop.
+        using var proc = StartShortLivedProcess();
+        Assert.NotNull(proc);
+        proc!.WaitForExit(5_000);
+        var pid = proc.Id;
+
+        var ok = LichLauncher.TryStop(pid, out var message);
+
+        Assert.True(ok);
+        Assert.Contains("already exited", message);
+    }
+
+    [Fact]
+    public void TryStop_kills_a_running_process()
+    {
+        using var proc = StartLongLivedProcess();
+        Assert.NotNull(proc);
+        Assert.False(proc!.HasExited);
+        var pid = proc.Id;
+
+        var ok = LichLauncher.TryStop(pid, out var message);
+
+        Assert.True(ok);
+        Assert.Contains("stopped", message);
+        // Give the OS a moment; HasExited can lag a tick after Kill.
+        proc.WaitForExit(5_000);
+        Assert.True(proc.HasExited);
+    }
+
+    [Fact]
+    public void TryStop_rejects_non_positive_pid()
+    {
+        Assert.False(LichLauncher.TryStop(0, out var message));
+        Assert.Equal(string.Empty, message);
+        Assert.False(LichLauncher.TryStop(-1, out _));
+    }
+
+    [Fact]
+    public void Launched_result_can_carry_process_id()
+    {
+        var result = new LichLaunchResult(LichLaunchOutcome.Launched, "[lich] up", 42_424);
+        Assert.Equal(42_424, result.ProcessId);
+
+        var attach = new LichLaunchResult(LichLaunchOutcome.AlreadyRunning, "[lich] attaching");
+        Assert.Null(attach.ProcessId);
+    }
+
+    private static Process? StartShortLivedProcess()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Process.Start(new ProcessStartInfo
+            {
+                FileName               = "cmd.exe",
+                Arguments              = "/c exit 0",
+                UseShellExecute        = false,
+                CreateNoWindow         = true,
+            });
+
+        return Process.Start(new ProcessStartInfo
+        {
+            FileName        = "/bin/sh",
+            Arguments       = "-c exit 0",
+            UseShellExecute = false,
+            CreateNoWindow  = true,
+        });
+    }
+
+    private static Process? StartLongLivedProcess()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Process.Start(new ProcessStartInfo
+            {
+                FileName               = "cmd.exe",
+                Arguments              = "/c ping -n 60 127.0.0.1 >NUL",
+                UseShellExecute        = false,
+                CreateNoWindow         = true,
+            });
+
+        return Process.Start(new ProcessStartInfo
+        {
+            FileName        = "/bin/sleep",
+            Arguments       = "60",
+            UseShellExecute = false,
+            CreateNoWindow  = true,
+        });
+    }
+}

--- a/wiki/Lich-5-Integration.md
+++ b/wiki/Lich-5-Integration.md
@@ -43,7 +43,8 @@ You can mix them: a Lich script can be doing one thing while a Genie `.cmd` scri
   #config lichautolaunch on
   ```
 
-  Switch characters by changing the profile Character (and stopping any already-running Lich on that port). If `{character}` is present but Character is empty, Genie aborts the connect with a clear error.
+  Switch characters by changing the profile Character — Genie stops the Lich it auto-launched before starting the new one. If `{character}` is present but Character is empty, Genie aborts the connect with a clear error.
+- **Auto-launched Lich lifecycle.** When Genie starts Lich (outcome `Launched`), it owns that process and stops it on manual disconnect, final session end (no auto-reconnect), or character/port change. If Lich was already running and Genie only attached, Genie never kills it. Transient drops that arm auto-reconnect leave the owned Lich up so Genie can reattach.
 - **Policy still applies.** Running behind Lich doesn't change DragonRealms' [Scripting Policy](https://elanthipedia.play.net/Policy:Scripting_policy). The responsiveness expectation in [Policy Compliance](Policy-Compliance) applies to whatever automation you run, in either tool.
 
 ## Related

--- a/wiki/Lich-5-Integration.md
+++ b/wiki/Lich-5-Integration.md
@@ -35,6 +35,15 @@ You can mix them: a Lich script can be doing one thing while a Genie `.cmd` scri
 ## Notes & current limits
 
 - **Lich launch: manual by default, auto-launch opt-in.** Out of the box, start Lich first, then connect Genie to it. If you'd rather Genie start Lich for you, turn on auto-launch: set `#config lichpath {path-to-lich.rbw}` and `#config lichautolaunch on`, and Genie will launch Lich before a Lich-proxy connect (it's idempotent — if Lich is already up, Genie just connects). Genie 4's `#lc` / `#lconnect` shortcuts work too, and `#ls` dumps the current Lich settings.
+- **Dynamic `lichargs`.** Auto-launch expands `{character}` and `{port}` in `#config lichargs` from the Lich-proxy profile's Character field and proxy port at connect time. Nested braces are fine (Genie’s `{…}` config grouping allows them):
+
+  ```text
+  #config lichpath {/path/to/lich.rbw}
+  #config lichargs {--login {character} --dragonrealms --genie --headless {port}}
+  #config lichautolaunch on
+  ```
+
+  Switch characters by changing the profile Character (and stopping any already-running Lich on that port). If `{character}` is present but Character is empty, Genie aborts the connect with a clear error.
 - **Policy still applies.** Running behind Lich doesn't change DragonRealms' [Scripting Policy](https://elanthipedia.play.net/Policy:Scripting_policy). The responsiveness expectation in [Policy Compliance](Policy-Compliance) applies to whatever automation you run, in either tool.
 
 ## Related


### PR DESCRIPTION
<!--
Thanks for contributing to Genie 5! Keep PRs focused — one feature or one fix.
For anything beyond a trivial change, please open an issue first (see CONTRIBUTING.md).
-->

## Summary

Makes **opt-in Lich auto-launch** usable across character switches without editing a static `lichargs` string or leaving orphan Lich processes behind.

1. **`{character}` / `{port}` in `#config lichargs`** — expanded at connect from the Lich-proxy profile’s Character field and proxy port. Static `lichargs` (no placeholders) unchanged. Missing Character when `{character}` is present aborts with a clear `[lich]` error.
2. **Owned-process lifecycle** — when Genie actually launches Lich (`Launched` + PID), it stops that process tree on manual disconnect, final session end (no auto-reconnect), or character/port change. Attach-only (`AlreadyRunning`) never claims ownership. Transient drops that arm auto-reconnect leave the owned Lich up so Genie can reattach.
3. **Character-change race fix** — `EnsureRunningAsync` progress was mutating `GameText.Lines` off the UI thread (`ConfigureAwait(false)`), racing Avalonia `CollectionChanged` and aborting before `Process.Start` with `Cannot change ObservableCollection during a CollectionChanged event`. Progress is now marshaled to the UI thread and best-effort so UI glitches cannot fail the launch. Connect dialog also disconnects before reconnect (parity with `#connect`).

Docs: `wiki/Lich-5-Integration.md`.

Example config:

```text
#config lichpath {/path/to/lich.rbw}
#config lichargs {--login {character} --dragonrealms --genie --headless {port}}
#config lichautolaunch on
```

## Test plan

- [x] `dotnet build -c Release` succeeds cleanly
- [x] `dotnet test tests/Genie.Core.Tests --filter "FullyQualifiedName~Lich"` (`LichArgsExpandTests`, `LichStopTests`, `LichConnectTests`) (Depends on #183 to run without additional parameters)
- [x] Manual (Lich proxy + `lichautolaunch on`):
- [x] Connect character A → Genie launches Lich with expanded `--login A`
- [x] Disconnect → Genie-started Lich exits; manually-started Lich (attach-only) is left alone
- [x] Connect A, then switch to B via Connect dialog / `#connect` → old owned Lich stopped, new launch with `--login B`
- [x] Same-character reconnect after a transient drop (auto-reconnect armed) → owned Lich left running, Genie reattaches (See #186)
- [x] Static `lichargs` without placeholders still launches as before
- [x] `{character}` set but Character empty → connect aborted with the `[lich] lichargs uses {character}…` message (no broken launch)

## Checklist

- [x] `dotnet build -c Release` succeeds cleanly (warnings OK, errors not)
- [x] Tests / relevant test-harness modes pass for the subsystems I touched
- [x] **No machine-specific paths** committed (no `C:\Users\…`, no hard-coded home dirs, no local absolute paths — use `AppPaths` / config)
- [x] **No AI brand references** in tracked files (the public repo stays vendor-neutral)
- [x] Docs updated if user-visible behaviour changed (README / CONTRIBUTING / `docs/`)
- [x] This is a focused PR — one feature or one fix

## Compatibility & policy

- [x] **DR policy acknowledged** — this change introduces no auto-reconnect, no agentive AI driving commands, no headless mode, and ships no other-player speech off-machine without consent. Anything that constrains how a player runs the client is opt-in and off by default. (See `docs/POLICY.md`.)

  Lich auto-launch remains opt-in (`lichautolaunch` off by default). Lifecycle only stops processes Genie itself started; attach-to-existing-Lich is unchanged.