### PR TITLE
fix(tests): resolve Genie.Core test DLL via host RID

### DIFF
--- a/tests/Genie.Core.Tests/Genie.Core.Tests.csproj
+++ b/tests/Genie.Core.Tests/Genie.Core.Tests.csproj
@@ -9,9 +9,14 @@
 
     <!-- Genie.Core is a self-contained Exe, so it can't be a ProjectReference
          (NETSDK1151). Reference the built DLL instead and load it + its deps at
-         runtime via the ModuleInitializer resolver (ModuleInit.cs). Build Core
-         before running these tests. -->
-    <CoreOutDir>$(MSBuildThisFileDirectory)..\..\src\Genie.Core\bin\$(Configuration)\net8.0\win-x64\</CoreOutDir>
+         runtime via the ModuleInitializer resolver (ModuleInit.cs).
+         CoreOutDir follows the host RID (osx-arm64 / win-x64 / linux-x64 / …)
+         so `dotnet test` works on every platform without -p:CoreOutDir=….
+         Override with -p:CoreRid=… or -p:CoreOutDir=… when needed. -->
+    <CoreRid Condition="'$(CoreRid)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</CoreRid>
+    <CoreRid Condition="'$(CoreRid)' == ''">$(NETCoreSdkRuntimeIdentifier)</CoreRid>
+    <CoreOutDir Condition="'$(CoreOutDir)' == ''">$(MSBuildThisFileDirectory)../../src/Genie.Core/bin/$(Configuration)/net8.0/$(CoreRid)/</CoreOutDir>
+    <_GenieCoreProject>$(MSBuildThisFileDirectory)../../src/Genie.Core/Genie.Core.csproj</_GenieCoreProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,5 +47,14 @@
   <ItemGroup>
     <AssemblyMetadata Include="CoreOutDir" Value="$(CoreOutDir)" />
   </ItemGroup>
+
+  <!-- Build Core into the host-RID folder before HintPath resolution so a bare
+       `dotnet test` does not require a separate Core build step. -->
+  <Target Name="EnsureGenieCoreBuilt" BeforeTargets="ResolveAssemblyReferences">
+    <MSBuild
+      Projects="$(_GenieCoreProject)"
+      Targets="Build"
+      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(CoreRid)" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
<!--
Thanks for contributing to Genie 5! Keep PRs focused — one feature or one fix.
For anything beyond a trivial change, please open an issue first (see CONTRIBUTING.md).
-->

## Summary

`Genie.Core.Tests` hardcoded `CoreOutDir` to `…/net8.0/win-x64/`, so a bare `dotnet test` failed on macOS/Linux (missing `Genie.Core.dll` → mass CS0234s). Point `CoreOutDir` at the **host RID** (`$(NETCoreSdkRuntimeIdentifier)`) and build Core into that folder before `ResolveAssemblyReferences`, so `dotnet test tests/Genie.Core.Tests/Genie.Core.Tests.csproj` works with no extra `-p:CoreOutDir=…` step.

Overrides still work: `-p:CoreRid=…` or `-p:CoreOutDir=…`.

## Test plan

- [x] On macOS (osx-arm64): `dotnet test tests/Genie.Core.Tests/Genie.Core.Tests.csproj --filter "FullyQualifiedName~Lich"` → 37 passed (no CoreOutDir override)
- [ ] On Windows: same command resolves `win-x64` and passes
- [x] `dotnet build -c Release` still succeeds

## Checklist

- [x] `dotnet build -c Release` succeeds cleanly (warnings OK, errors not)
- [x] Tests / relevant test-harness modes pass for the subsystems I touched
- [x] **No machine-specific paths** committed (no `C:\Users\…`, no hard-coded home dirs, no local absolute paths — use `AppPaths` / config)
- [x] **No AI brand references** in tracked files (the public repo stays vendor-neutral)
- [x] Docs updated if user-visible behaviour changed (README / CONTRIBUTING / `docs/`) — N/A (dev test harness only)
- [x] This is a focused PR — one feature or one fix

## Compatibility & policy

- [x] **DR policy acknowledged** — test-project build wiring only; no runtime/client behaviour change.
