### PR TITLE
fix(lich): nil-safe GENIE5-IDENT probe when XMLData.name is unset

### DIFF
--- a/src/Genie.Core/DrXmlParser.cs
+++ b/src/Genie.Core/DrXmlParser.cs
@@ -307,8 +307,9 @@ public sealed class DrXmlParser : IDisposable
     }
 
     // ── Lich ident reply (public issue #127) ─────────────────────────────────
-    // GenieCore asks Lich for the bare character name via `,eq respond
-    // "GENIE5-IDENT " + XMLData.name` on attach. The reply is a mono-bracketed
+    // GenieCore asks Lich for the bare character name via `,eq` +
+    // `respond "GENIE5-IDENT #{XMLData.name}"` on attach (nil-safe; waits briefly
+    // if name is not populated yet). The reply is a mono-bracketed
     // marker line; while the window is armed we consume it (never displayed)
     // and emit CharacterNameEvent. One-shot: disarms on match or deadline.
     private DateTimeOffset _identDeadline = DateTimeOffset.MinValue;

--- a/src/Genie.Core/GenieCore.cs
+++ b/src/Genie.Core/GenieCore.cs
@@ -1141,8 +1141,8 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
         // parser's one-shot captures, then reconstruct both — `look` re-emits
         // the room as display text (folded into synthetic components while the
         // seed is armed), and the `,eq` ident query asks Lich itself for the
-        // bare character name (`info` can't be used: its Name field embeds
-        // optional pre-titles and surname).
+        // bare character name once XMLData.name is populated (`info` can't be
+        // used: its Name field embeds optional pre-titles and surname).
         if (lichAttachParser is not null)
         {
             lichAttachParser.BeginRoomSeedCapture();
@@ -1168,8 +1168,14 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
             if (_connection is null) return;
             await _connection.SendCommandAsync("look").ConfigureAwait(false);
             if (lichAttach)
-                await _connection.SendCommandAsync(",eq respond \"GENIE5-IDENT \" + XMLData.name")
-                                 .ConfigureAwait(false);
+                // XMLData.name is often still nil for a beat after FE attach (fresh
+                // Lich launch / before game XML fills identity). Bare
+                // `"…" + XMLData.name` raises NilClass#to_str in Lich ExecScript.
+                // Wait briefly (≤3s), then respond only when we have a non-empty name.
+                await _connection.SendCommandAsync(
+                        ",eq 30.times{ break unless XMLData.name.to_s.empty?; sleep 0.1 }; " +
+                        "n=XMLData.name.to_s; respond \"GENIE5-IDENT #{n}\" unless n.empty?")
+                    .ConfigureAwait(false);
 
             // Flag-state probe (issue #29): silently read the DR `flags` verb and
             // warn if any stream-affecting flag is in a state the parser wasn't

--- a/tests/Genie.Core.Tests/LichSeedTests.cs
+++ b/tests/Genie.Core.Tests/LichSeedTests.cs
@@ -14,9 +14,8 @@ namespace Genie.Core.Tests;
 /// room components and character identity) never reaches Genie. The parser
 /// reconstructs both: an armed room-seed capture folds the next `look`
 /// response into synthetic room ComponentEvents, and an armed ident window
-/// consumes the `,eq respond "GENIE5-IDENT " + XMLData.name` reply into a
-/// CharacterNameEvent. Raw formats verbatim from live captures
-/// (raw_session_20260521_202149.xml).
+/// consumes the `,eq` / <c>GENIE5-IDENT …</c> reply into a CharacterNameEvent.
+/// Raw formats verbatim from live captures (raw_session_20260521_202149.xml).
 /// </summary>
 public class LichSeedTests
 {


### PR DESCRIPTION
## Summary
- On Lich FE attach, Genie seeds identity with `,eq respond "GENIE5-IDENT " + XMLData.name`.
- If `XMLData.name` is still `nil` (common right after Lich comes up), Lich ExecScript raises `can't convert NilClass to String` (`exec1:1` / `String#+`).
- Wait up to ~3s for a non-empty name, then `respond "GENIE5-IDENT #{n}"` only when present.
## Test plan
- [x] `dotnet test tests/Genie.Core.Tests --filter "FullyQualifiedName~LichSeed"`
- [x] Manual: Lich-proxy connect (esp. fresh auto-launch) — no `NilClass#to_str` / `exec1` error; character name still resolves when Lich has it