### PR TITLE
fix(lich): bind-probe FE port and preserve owned PID on reconnect

### DIFF
--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -3583,24 +3583,50 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                 && !string.Equals(_ownedLichLaunchKey, launchKey, StringComparison.OrdinalIgnoreCase))
                 StopOwnedLich();
 
-            // EnsureRunningAsync uses ConfigureAwait(false); marshal progress onto
-            // the UI thread so GameText.Lines isn't mutated during / across a
-            // CollectionChanged (character change races the "disconnected" line).
-            var lich = await Genie.Core.Connection.LichLauncher.EnsureRunningAsync(
-                coreCfg.LichProxyHost, coreCfg.LichProxyPort,
-                _core.Config.LichRubyPath, _core.Config.LichPath, lichArgs,
-                _core.Config.LichStartPause,
-                progress: msg => Avalonia.Threading.Dispatcher.UIThread.Post(
-                    () => GameText.AddSystemLine(msg)));
-            GameText.AddSystemLine(lich.Message);
-            if (lich.Outcome == Genie.Core.Connection.LichLaunchOutcome.Failed)
-                return;   // don't attempt a connect we know can't reach Lich
-
-            if (lich.Outcome == Genie.Core.Connection.LichLaunchOutcome.Launched
-                && lich.ProcessId is int pid)
+            // Same character/port reconnect while we still own a live Lich: attach
+            // only. Calling EnsureRunningAsync here could launch a *second* Lich if
+            // the FE port is briefly not listening (Lich recreates the listener
+            // after an FE drop) and then overwrite ownership with the new PID.
+            if (_ownedLichProcessId is int ownedPid
+                && string.Equals(_ownedLichLaunchKey, launchKey, StringComparison.OrdinalIgnoreCase)
+                && Genie.Core.Connection.LichLauncher.TryIsProcessAlive(ownedPid))
             {
-                _ownedLichProcessId = pid;
-                _ownedLichLaunchKey = launchKey;
+                GameText.AddSystemLine(
+                    $"[lich] reattaching to owned process {ownedPid} on {coreCfg.LichProxyHost}:{coreCfg.LichProxyPort}.");
+            }
+            else
+            {
+                // Owned PID gone (crash / external kill) — drop the stale claim so a
+                // fresh Launched outcome can take ownership again.
+                if (_ownedLichProcessId is int stalePid
+                    && !Genie.Core.Connection.LichLauncher.TryIsProcessAlive(stalePid))
+                {
+                    _ownedLichProcessId = null;
+                    _ownedLichLaunchKey = null;
+                }
+
+                // EnsureRunningAsync uses ConfigureAwait(false); marshal progress onto
+                // the UI thread so GameText.Lines isn't mutated during / across a
+                // CollectionChanged (character change races the "disconnected" line).
+                var lich = await Genie.Core.Connection.LichLauncher.EnsureRunningAsync(
+                    coreCfg.LichProxyHost, coreCfg.LichProxyPort,
+                    _core.Config.LichRubyPath, _core.Config.LichPath, lichArgs,
+                    _core.Config.LichStartPause,
+                    progress: msg => Avalonia.Threading.Dispatcher.UIThread.Post(
+                        () => GameText.AddSystemLine(msg)));
+                GameText.AddSystemLine(lich.Message);
+                if (lich.Outcome == Genie.Core.Connection.LichLaunchOutcome.Failed)
+                    return;   // don't attempt a connect we know can't reach Lich
+
+                // Only claim ownership on a fresh launch, and never overwrite an
+                // existing owned PID (AlreadyRunning must not become "ours").
+                if (lich.Outcome == Genie.Core.Connection.LichLaunchOutcome.Launched
+                    && lich.ProcessId is int pid
+                    && _ownedLichProcessId is null)
+                {
+                    _ownedLichProcessId = pid;
+                    _ownedLichLaunchKey = launchKey;
+                }
             }
         }
 

--- a/src/Genie.Core/LichLauncher.cs
+++ b/src/Genie.Core/LichLauncher.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net;
 using System.Net.Sockets;
 using System.Text.RegularExpressions;
 
@@ -116,7 +117,10 @@ public static class LichLauncher
         // 1. Already listening? Attach — never double-launch. This preserves the
         //    long-standing "start Lich yourself, then #lichconnect" workflow even
         //    with auto-launch turned on. No ProcessId: caller must not claim ownership.
-        if (await IsPortOpenAsync(host, port, TimeSpan.FromMilliseconds(600), ct).ConfigureAwait(false))
+        //    Probe via bind (not connect): Lich's detachable FE accepts exactly one
+        //    client then closes the listen socket, so a TCP connect probe steals that
+        //    accept and races the real FE connect (auto-reconnect always failed).
+        if (IsProxyPortInUse(host, port))
             return new(LichLaunchOutcome.AlreadyRunning,
                 $"[lich] already listening on {host}:{port} — attaching.");
 
@@ -173,7 +177,7 @@ public static class LichLauncher
                 TryStop(pid, out _);
                 return new(LichLaunchOutcome.Failed, "[lich] launch cancelled.");
             }
-            if (await IsPortOpenAsync(host, port, TimeSpan.FromMilliseconds(800), ct).ConfigureAwait(false))
+            if (IsProxyPortInUse(host, port))
                 return new(LichLaunchOutcome.Launched, $"[lich] up on {host}:{port}.", pid);
             ReportProgress(progress, $"[lich] waiting for Lich… ({i + 1}/{pause}s)");
             try { await Task.Delay(1000, ct).ConfigureAwait(false); }
@@ -188,6 +192,29 @@ public static class LichLauncher
         return new(LichLaunchOutcome.Failed,
             $"[lich] Lich did not open {host}:{port} within {pause}s. " +
             "Increase #config lichstartpause, or check Lich's own window for errors.");
+    }
+
+    /// <summary>
+    /// True when <paramref name="processId"/> still refers to a live process.
+    /// Used by the App to reattach to a Genie-owned Lich without calling
+    /// <see cref="EnsureRunningAsync"/> (which might launch a second instance).
+    /// </summary>
+    public static bool TryIsProcessAlive(int processId)
+    {
+        if (processId <= 0) return false;
+        try
+        {
+            using var proc = Process.GetProcessById(processId);
+            return !proc.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;   // PID unknown / already reaped
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     /// <summary>
@@ -262,21 +289,72 @@ public static class LichLauncher
             ? Array.Empty<string>()
             : arguments.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
 
-    /// <summary>True if a TCP connection to <paramref name="host"/>:<paramref name="port"/>
-    /// succeeds within <paramref name="timeout"/> — used to detect a listening Lich.</summary>
-    private static async Task<bool> IsPortOpenAsync(string host, int port, TimeSpan timeout, CancellationToken ct)
+    /// <summary>
+    /// True when something is already bound to <paramref name="host"/>:<paramref name="port"/>.
+    /// Uses a bind probe — never a TCP connect — so Lich's single-accept detachable
+    /// FE listener is not consumed. Internal for tests.
+    /// </summary>
+    internal static bool IsProxyPortInUse(string host, int port)
     {
+        if (port is < 1 or > 65535) return false;
+        if (!TryResolveBindAddress(host, out var address)) return false;
+
+        TcpListener? listener = null;
         try
         {
-            using var tcp = new TcpClient();
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            cts.CancelAfter(timeout);
-            await tcp.ConnectAsync(host, port, cts.Token).ConfigureAwait(false);
-            return tcp.Connected;
+            listener = new TcpListener(address, port);
+            // Prefer exclusive bind so AddressAlreadyInUse means a real occupant
+            // (not a SO_REUSEADDR dual-bind false negative on Windows). Unsupported
+            // on some Unix stacks — ignore and rely on the default bind semantics.
+            try { listener.ExclusiveAddressUse = true; }
+            catch (SocketException) { /* platform default */ }
+            listener.Start();
+            return false;   // we bound → nothing was listening
+        }
+        catch (SocketException ex) when (
+            ex.SocketErrorCode is SocketError.AddressAlreadyInUse
+                                or SocketError.AccessDenied
+                                or SocketError.AddressNotAvailable)
+        {
+            // In use, or we can't bind for the same practical reason (port held).
+            return true;
         }
         catch
         {
-            return false;   // refused / timed out / unreachable → not listening
+            return false;
+        }
+        finally
+        {
+            try { listener?.Stop(); }
+            catch { /* best-effort */ }
+        }
+    }
+
+    /// <summary>Resolve <paramref name="host"/> to a single bindable address
+    /// (prefers loopback literals / first DNS result).</summary>
+    private static bool TryResolveBindAddress(string host, out IPAddress address)
+    {
+        address = IPAddress.None;
+        if (string.IsNullOrWhiteSpace(host)) return false;
+
+        if (IPAddress.TryParse(host.Trim(), out var parsed))
+        {
+            address = parsed;
+            return true;
+        }
+
+        try
+        {
+            var addrs = Dns.GetHostAddresses(host.Trim());
+            if (addrs.Length == 0) return false;
+            // Prefer IPv4 loopback-family results when present — Lich defaults to 127.0.0.1.
+            address = addrs.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork)
+                      ?? addrs[0];
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 }

--- a/tests/Genie.Core.Tests/LichPortProbeTests.cs
+++ b/tests/Genie.Core.Tests/LichPortProbeTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Genie.Core.Connection;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// Bind-based FE port probe + owned-PID liveness — fixes auto-reconnect stealing
+/// Lich's single accept and double-launch ownership clobber.
+/// </summary>
+public class LichPortProbeTests
+{
+    [Fact]
+    public void IsProxyPortInUse_false_when_nothing_listens()
+    {
+        var port = FreeTcpPort();
+        Assert.False(LichLauncher.IsProxyPortInUse("127.0.0.1", port));
+    }
+
+    [Fact]
+    public void IsProxyPortInUse_true_when_listener_holds_port()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Assert.True(LichLauncher.IsProxyPortInUse("127.0.0.1", port));
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task IsProxyPortInUse_does_not_consume_single_accept()
+    {
+        // Lich closes the listen socket after one accept. A connect-based probe
+        // would steal that accept; the bind probe must leave it available.
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Assert.True(LichLauncher.IsProxyPortInUse("127.0.0.1", port));
+
+            var acceptTask = listener.AcceptTcpClientAsync();
+            using var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, port);
+            using var accepted = await acceptTask.WaitAsync(TimeSpan.FromSeconds(3));
+
+            Assert.True(client.Connected);
+            Assert.NotNull(accepted);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public void TryIsProcessAlive_false_for_non_positive_and_missing_pids()
+    {
+        Assert.False(LichLauncher.TryIsProcessAlive(0));
+        Assert.False(LichLauncher.TryIsProcessAlive(-1));
+        Assert.False(LichLauncher.TryIsProcessAlive(int.MaxValue)); // almost certainly missing
+    }
+
+    [Fact]
+    public void TryIsProcessAlive_true_for_running_process()
+    {
+        using var proc = StartLongLivedProcess();
+        Assert.NotNull(proc);
+        Assert.False(proc!.HasExited);
+
+        Assert.True(LichLauncher.TryIsProcessAlive(proc.Id));
+
+        LichLauncher.TryStop(proc.Id, out _);
+        proc.WaitForExit(5_000);
+        Assert.False(LichLauncher.TryIsProcessAlive(proc.Id));
+    }
+
+    private static int FreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static Process? StartLongLivedProcess()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Process.Start(new ProcessStartInfo
+            {
+                FileName        = "cmd.exe",
+                Arguments       = "/c ping -n 60 127.0.0.1 >NUL",
+                UseShellExecute = false,
+                CreateNoWindow  = true,
+            });
+
+        return Process.Start(new ProcessStartInfo
+        {
+            FileName        = "/bin/sleep",
+            Arguments       = "60",
+            UseShellExecute = false,
+            CreateNoWindow  = true,
+        });
+    }
+}


### PR DESCRIPTION
## Summary
Stacked on #182.
While running #182’s manual matrix (case 4 — transient FE drop + auto-reconnect), Genie armed the 5-attempt ladder but never reattached. Owned Lich stayed up; the failure was Genie’s port probe.
- Lich’s detachable FE accepts **one** client then closes the listen socket.
- `EnsureRunningAsync` used `TcpClient.Connect` to detect the port, which **stole that accept** and raced the real FE connect.
- Same gap could launch a **second** Lich and overwrite `_ownedLichProcessId`.
This PR:
1. Detects the FE port via **bind** (no accept steal).
2. If Genie already owns a live PID for the same character/port, **reattaches without** `EnsureRunningAsync`.
3. Never overwrites an existing owned PID on `Launched`; clears stale ownership if the process is dead.
## Test plan
- [x] `dotnet test tests/Genie.Core.Tests --filter "FullyQualifiedName~Lich"`
- [x] After #182: reconnect matrix case 4 — FE drop → 5 attempts → reattach; same owned Lich PID; no second launch
- [x] Character switch still stop-then-relaunch
- [x] Attach-only (manual Lich) still does not claim ownership