### PR TITLE
Extract FileBrowser helper for spaces-safe folder/editor launches

### DIFF
--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -1534,28 +1534,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             var scriptsDir = _core is not null
                                  ? _core.Config.ScriptDir
                                  : Path.Combine(Path.GetDirectoryName(_configDir)!, "Scripts");
-            try
-            {
-                if (!Directory.Exists(scriptsDir)) Directory.CreateDirectory(scriptsDir);
-                // explorer.exe/open/xdg-open with the resolved absolute path —
-                // the SAME pattern as every other folder-open (Maps, Recordings,
-                // Plugins, Open Directory). The previous ShellExecute-on-the-dir
-                // route is exactly what OpenMapsFolder documents as failing with
-                // "Location is not available" on some Windows setups.
-                var nativePath = Path.GetFullPath(scriptsDir);
-                if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                        System.Runtime.InteropServices.OSPlatform.Windows))
-                    System.Diagnostics.Process.Start("explorer.exe", nativePath);
-                else if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                             System.Runtime.InteropServices.OSPlatform.OSX))
-                    System.Diagnostics.Process.Start("open", nativePath);
-                else
-                    System.Diagnostics.Process.Start("xdg-open", nativePath);
-            }
-            catch (Exception ex)
-            {
-                GameText.AddSystemLine($"[scripts] could not open {scriptsDir} ({ex.Message})");
-            }
+            OpenFolder(scriptsDir, "OpenScriptsFolder");
         });
 
         // Seed the Help ▸ Update Settings checkboxes from update-feeds.json,
@@ -2342,22 +2321,14 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     }
 
     /// <summary>Open a folder in the OS file browser, creating it if missing.
-    /// Cross-platform (explorer / open / xdg-open).</summary>
+    /// See <see cref="Genie.Core.Runtime.FileBrowser"/> for why this must use
+    /// <c>ArgumentList</c> rather than string arguments (paths with spaces,
+    /// e.g. macOS <c>~/Library/Application Support/Genie5</c>).</summary>
     private static void OpenFolder(string dir, string logTag)
     {
-        if (string.IsNullOrWhiteSpace(dir)) return;
         try
         {
-            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
-            var nativePath = Path.GetFullPath(dir);
-            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                    System.Runtime.InteropServices.OSPlatform.Windows))
-                System.Diagnostics.Process.Start("explorer.exe", nativePath);
-            else if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                         System.Runtime.InteropServices.OSPlatform.OSX))
-                System.Diagnostics.Process.Start("open", nativePath);
-            else
-                System.Diagnostics.Process.Start("xdg-open", nativePath);
+            Genie.Core.Runtime.FileBrowser.OpenDirectory(dir, createIfMissing: true);
         }
         catch (Exception ex) { ErrorLog.Log(logTag, ex); }
     }
@@ -2413,34 +2384,9 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             return;
         }
 
-        try
-        {
-            // First-run users typically haven't pulled the Maps repo yet, so
-            // the configured directory may not exist on disk. Create it so
-            // the menu item actually opens a folder instead of silently
-            // failing — matches OpenRecordingsFolder's behavior.
-            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
-            // Canonical Windows pattern: Process.Start(filename, argument).
-            // Quoting / escaping handled internally. The ProcessStartInfo
-            // route with explicit Arguments was failing here with
-            // "Location is not available" — likely because the quoted arg
-            // was being passed to explorer.exe in a form it interpreted
-            // as a literal filename to OPEN (not navigate to). The simpler
-            // overload works reliably.
-            var nativePath = Path.GetFullPath(dir);
-            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                    System.Runtime.InteropServices.OSPlatform.Windows))
-                System.Diagnostics.Process.Start("explorer.exe", nativePath);
-            else if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                         System.Runtime.InteropServices.OSPlatform.OSX))
-                System.Diagnostics.Process.Start("open", nativePath);
-            else
-                System.Diagnostics.Process.Start("xdg-open", nativePath);
-        }
-        catch (Exception ex)
-        {
-            ErrorLog.Log("OpenMapsFolder", ex);
-        }
+        // First-run users typically haven't pulled the Maps repo yet, so
+        // OpenFolder creates the configured directory when missing.
+        OpenFolder(dir, "OpenMapsFolder");
     }
 
     /// <summary>
@@ -2448,28 +2394,8 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// <see cref="OpenMapsFolder"/>. Creates the directory if it doesn't
     /// exist yet (user may have installed but never recorded).
     /// </summary>
-    private void OpenRecordingsFolder()
-    {
-        var dir = _logsDir;
-        try
-        {
-            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+    private void OpenRecordingsFolder() => OpenFolder(_logsDir, "OpenRecordingsFolder");
 
-            var nativePath = Path.GetFullPath(dir);
-            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                    System.Runtime.InteropServices.OSPlatform.Windows))
-                System.Diagnostics.Process.Start("explorer.exe", nativePath);
-            else if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                         System.Runtime.InteropServices.OSPlatform.OSX))
-                System.Diagnostics.Process.Start("open", nativePath);
-            else
-                System.Diagnostics.Process.Start("xdg-open", nativePath);
-        }
-        catch (Exception ex)
-        {
-            ErrorLog.Log("OpenRecordingsFolder", ex);
-        }
-    }
 
     private async Task SetMapsDirectoryAsync()
     {
@@ -2748,20 +2674,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             GameText.AddSystemLine("[analyst] no capture folder set — use Analyst → Set Capture Folder first.");
             return;
         }
-        try
-        {
-            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
-            var nativePath = Path.GetFullPath(dir);
-            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                    System.Runtime.InteropServices.OSPlatform.Windows))
-                System.Diagnostics.Process.Start("explorer.exe", nativePath);
-            else if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                         System.Runtime.InteropServices.OSPlatform.OSX))
-                System.Diagnostics.Process.Start("open", nativePath);
-            else
-                System.Diagnostics.Process.Start("xdg-open", nativePath);
-        }
-        catch (Exception ex) { ErrorLog.Log("OpenCaptureFolder", ex); }
+        OpenFolder(dir, "OpenCaptureFolder");
     }
 
     /// <summary>
@@ -5668,6 +5581,10 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// </summary>
     private string LaunchExternalEditor(string file)
     {
+        // Normalize once so every rung — custom/config candidates and the OS
+        // default — passes the editor the same absolute path.
+        var fullPath = System.IO.Path.GetFullPath(file);
+
         // 1) explicit GUI override, then 2) the #config editor value.
         foreach (var candidate in new[] { Display.EditorPath, _core?.Config?.Editor })
         {
@@ -5675,8 +5592,8 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             try
             {
                 System.Diagnostics.Process.Start(
-                    new System.Diagnostics.ProcessStartInfo(candidate, $"\"{file}\"")
-                    { UseShellExecute = false });
+                    new System.Diagnostics.ProcessStartInfo(candidate)
+                    { UseShellExecute = false, ArgumentList = { fullPath } });
                 return candidate;
             }
             catch (Exception ex)
@@ -5686,16 +5603,9 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             }
         }
 
-        // 3) OS default plain-text editor.
-        if (OperatingSystem.IsWindows())
-            System.Diagnostics.Process.Start("notepad.exe", $"\"{file}\"");
-        else if (OperatingSystem.IsMacOS())
-            // -t opens in the default TEXT editor regardless of extension.
-            System.Diagnostics.Process.Start("open", $"-t \"{file}\"");
-        else
-            // Linux doesn't treat `.cmd` as executable, so xdg-open routes it to
-            // the text/plain handler (a text editor).
-            System.Diagnostics.Process.Start("xdg-open", $"\"{file}\"");
+        // 3) OS default plain-text editor (see Genie.Core.Runtime.FileBrowser
+        // for the platform ladder and the ArgumentList spaces rationale).
+        System.Diagnostics.Process.Start(Genie.Core.Runtime.FileBrowser.BuildOpenInDefaultTextEditorInfo(fullPath));
         return "OS default";
     }
 

--- a/src/Genie.App/ViewModels/ScriptsViewModel.cs
+++ b/src/Genie.App/ViewModels/ScriptsViewModel.cs
@@ -454,18 +454,12 @@ public class ScriptsViewModel : ReactiveObject
     {
         if (SelectedFile is not { } n) return;
         var dir = n.IsFolder ? n.FullPath : Path.GetDirectoryName(n.FullPath);
-        if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir)) return;
+        if (string.IsNullOrEmpty(dir)) return;
         try
         {
-            // Same explicit file-manager launch as the Open Scripts Folder
-            // menu (issue #37 — ShellExecute-on-the-dir fails on some setups).
-            var native = Path.GetFullPath(dir);
-            if (OperatingSystem.IsWindows())
-                System.Diagnostics.Process.Start("explorer.exe", $"\"{native}\"");
-            else if (OperatingSystem.IsMacOS())
-                System.Diagnostics.Process.Start("open", $"\"{native}\"");
-            else
-                System.Diagnostics.Process.Start("xdg-open", $"\"{native}\"");
+            // Reveal-only: createIfMissing: false — a missing dir is a no-op
+            // inside OpenDirectory itself (see FileBrowser.OpenDirectory).
+            Genie.Core.Runtime.FileBrowser.OpenDirectory(dir, createIfMissing: false);
         }
         catch (Exception ex)
         {

--- a/src/Genie.Core/Runtime/FileBrowser.cs
+++ b/src/Genie.Core/Runtime/FileBrowser.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+
+namespace Genie.Core.Runtime;
+
+/// <summary>
+/// Builds and launches OS file-manager / default-text-editor processes for a
+/// given path. Always uses <see cref="ProcessStartInfo.ArgumentList"/> rather
+/// than the string-<c>Arguments</c> overload: on Unix, <c>Process.Start(fileName,
+/// arguments)</c> tokenizes the argument string on whitespace, so a path like
+/// macOS <c>~/Library/Application Support/Genie5</c> arrives at the file
+/// manager as two fragments and Finder reports them as missing paths.
+/// <c>ArgumentList</c> keeps the whole path as one argv entry regardless of
+/// spaces.
+/// </summary>
+public static class FileBrowser
+{
+    /// <summary>
+    /// The OS file-manager executable for the current platform: <c>explorer.exe</c>
+    /// on Windows, <c>open</c> on macOS, <c>xdg-open</c> elsewhere.
+    /// </summary>
+    public static string FileManagerExecutable
+        => OperatingSystem.IsWindows() ? "explorer.exe"
+         : OperatingSystem.IsMacOS()   ? "open"
+         : "xdg-open";
+
+    /// <summary>
+    /// The OS default plain-text-editor executable for the current platform:
+    /// <c>notepad.exe</c> on Windows, <c>open</c> on macOS (paired with the
+    /// <c>-t</c> flag in <see cref="BuildOpenInDefaultTextEditorInfo"/> to force
+    /// the text-editor handler regardless of extension), <c>xdg-open</c>
+    /// elsewhere (routes to the text/plain handler since Linux doesn't treat
+    /// <c>.cmd</c> as executable).
+    /// </summary>
+    public static string DefaultTextEditorExecutable
+        => OperatingSystem.IsWindows() ? "notepad.exe"
+         : OperatingSystem.IsMacOS()   ? "open"
+         : "xdg-open";
+
+    /// <summary>
+    /// Builds the <see cref="ProcessStartInfo"/> that opens <paramref name="directory"/>
+    /// in the OS file browser. Does not touch the filesystem or start a process —
+    /// pure construction so it can be unit-tested without launching Finder/Explorer.
+    /// </summary>
+    public static ProcessStartInfo BuildOpenDirectoryInfo(string directory)
+    {
+        var nativePath = Path.GetFullPath(directory);
+        return new ProcessStartInfo(FileManagerExecutable)
+        {
+            ArgumentList = { nativePath },
+        };
+    }
+
+    /// <summary>
+    /// Builds the <see cref="ProcessStartInfo"/> that opens <paramref name="file"/>
+    /// in the OS default plain-text editor. Pure construction, no process launch.
+    /// </summary>
+    public static ProcessStartInfo BuildOpenInDefaultTextEditorInfo(string file)
+    {
+        var nativePath = Path.GetFullPath(file);
+        var psi = new ProcessStartInfo(DefaultTextEditorExecutable);
+        if (OperatingSystem.IsMacOS())
+            // -t opens in the default TEXT editor regardless of extension.
+            psi.ArgumentList.Add("-t");
+        psi.ArgumentList.Add(nativePath);
+        return psi;
+    }
+
+    /// <summary>
+    /// Opens <paramref name="directory"/> in the OS file browser.
+    /// When <paramref name="createIfMissing"/> is true (menu "Open …" commands),
+    /// a missing directory is created first. When false (e.g. Script Manager's
+    /// "reveal containing folder"), a missing directory is left alone and this
+    /// returns without launching anything — there is nothing to reveal.
+    /// No-ops on a null/whitespace <paramref name="directory"/>.
+    /// </summary>
+    /// <param name="launch">
+    /// Test seam: how to launch the built <see cref="ProcessStartInfo"/>. Defaults
+    /// to <see cref="Process.Start(ProcessStartInfo)"/>; unit tests pass a no-op
+    /// here so running the create/reveal contract never actually opens Finder/
+    /// Explorer/xdg-open on the developer's or CI's machine.
+    /// </param>
+    public static void OpenDirectory(string directory, bool createIfMissing = true, Action<ProcessStartInfo>? launch = null)
+    {
+        if (string.IsNullOrWhiteSpace(directory)) return;
+
+        if (!Directory.Exists(directory))
+        {
+            if (!createIfMissing) return;
+            Directory.CreateDirectory(directory);
+        }
+
+        (launch ?? (psi => Process.Start(psi)))(BuildOpenDirectoryInfo(directory));
+    }
+}

--- a/tests/Genie.Core.Tests/FileBrowserTests.cs
+++ b/tests/Genie.Core.Tests/FileBrowserTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.IO;
+using System.Linq;
+using Genie.Core.Runtime;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// <see cref="FileBrowser"/> — regression coverage for the
+/// <c>ProcessStartInfo.ArgumentList</c> spaces fix (paths under macOS
+/// <c>~/Library/Application Support/Genie5</c> must never be tokenized) plus
+/// the platform-<c>FileName</c> and <c>createIfMissing</c>/reveal contracts.
+/// Only <c>Build*Info</c> and filesystem side effects are asserted; every
+/// <see cref="FileBrowser.OpenDirectory"/> call passes a no-op <c>launch</c>
+/// so no test ever actually opens Finder/Explorer/xdg-open.
+/// </summary>
+public class FileBrowserTests : IDisposable
+{
+    private static readonly string RootDir =
+        Path.Combine(Path.GetTempPath(), "Genie5FileBrowserTests");
+
+    private static string SpacesPath(params string[] segments)
+        => Path.Combine(RootDir, Path.Combine(
+            new[] { "Application Support", "Genie5" }.Concat(segments).ToArray()));
+
+    // OpenDirectory(createIfMissing: true) actually creates directories on
+    // disk (under RootDir); remove them so repeated test runs don't pile up
+    // empty folders in the OS temp dir.
+    public void Dispose()
+    {
+        if (Directory.Exists(RootDir))
+            Directory.Delete(RootDir, recursive: true);
+    }
+
+    [Fact]
+    public void BuildOpenDirectoryInfo_keeps_spaces_path_as_single_argument()
+    {
+        var dir = SpacesPath("Config");
+
+        var psi = FileBrowser.BuildOpenDirectoryInfo(dir);
+
+        Assert.Single(psi.ArgumentList);
+        Assert.Equal(Path.GetFullPath(dir), psi.ArgumentList[0]);
+        Assert.Equal(string.Empty, psi.Arguments);
+    }
+
+    [Fact]
+    public void BuildOpenDirectoryInfo_uses_platform_file_manager()
+    {
+        var psi = FileBrowser.BuildOpenDirectoryInfo(Path.GetTempPath());
+
+        var expected = OperatingSystem.IsWindows() ? "explorer.exe"
+                     : OperatingSystem.IsMacOS()   ? "open"
+                     : "xdg-open";
+        Assert.Equal(expected, psi.FileName);
+    }
+
+    [Fact]
+    public void OpenDirectory_createIfMissing_true_creates_directory_first()
+    {
+        var dir = SpacesPath("CreateIfMissing", Guid.NewGuid().ToString("N"));
+        Assert.False(Directory.Exists(dir));
+        var launched = 0;
+
+        // launch: no-op so this never actually opens Finder/Explorer/xdg-open.
+        FileBrowser.OpenDirectory(dir, createIfMissing: true, launch: _ => launched++);
+
+        Assert.True(Directory.Exists(dir));
+        Assert.Equal(1, launched);
+    }
+
+    [Fact]
+    public void OpenDirectory_createIfMissing_false_on_missing_dir_is_a_noop()
+    {
+        var dir = SpacesPath("Reveal", Guid.NewGuid().ToString("N"));
+        Assert.False(Directory.Exists(dir));
+        var launched = 0;
+
+        var ex = Record.Exception(() =>
+            FileBrowser.OpenDirectory(dir, createIfMissing: false, launch: _ => launched++));
+
+        Assert.Null(ex);
+        Assert.False(Directory.Exists(dir));
+        Assert.Equal(0, launched);
+    }
+
+    [Fact]
+    public void BuildOpenInDefaultTextEditorInfo_keeps_spaces_path_as_single_argument()
+    {
+        var file = SpacesPath("scripts", "my script.cmd");
+
+        var psi = FileBrowser.BuildOpenInDefaultTextEditorInfo(file);
+
+        var expectedPath = Path.GetFullPath(file);
+        if (OperatingSystem.IsMacOS())
+        {
+            Assert.Equal(2, psi.ArgumentList.Count);
+            Assert.Equal("-t", psi.ArgumentList[0]);
+            Assert.Equal(expectedPath, psi.ArgumentList[1]);
+        }
+        else
+        {
+            Assert.Single(psi.ArgumentList);
+            Assert.Equal(expectedPath, psi.ArgumentList[0]);
+        }
+        Assert.Equal(string.Empty, psi.Arguments);
+    }
+
+    [Fact]
+    public void BuildOpenInDefaultTextEditorInfo_uses_platform_default_editor()
+    {
+        var psi = FileBrowser.BuildOpenInDefaultTextEditorInfo(Path.Combine(Path.GetTempPath(), "file.cmd"));
+
+        var expected = OperatingSystem.IsWindows() ? "notepad.exe"
+                     : OperatingSystem.IsMacOS()   ? "open"
+                     : "xdg-open";
+        Assert.Equal(expected, psi.FileName);
+    }
+}


### PR DESCRIPTION
## Summary
- `Process.Start(fileName, argsString)` tokenizes on whitespace on Unix, so opening paths like macOS `~/Library/Application Support/Genie5` in Finder split into fragments and failed.
- Adds `Genie.Core.Runtime.FileBrowser` to build `ProcessStartInfo` via `ArgumentList` (one argv entry regardless of spaces) for both directory-open and default-text-editor launches.
- Routes `MainWindowViewModel.OpenFolder`, `ScriptsViewModel.OpenContainingFolder`, and `LaunchExternalEditor`'s custom/config/OS-default rungs through the shared helper, removing duplicated per-platform launch logic.
- `FileBrowser.OpenDirectory` takes an optional `launch` callback (test seam) so unit tests never actually open Finder/Explorer/xdg-open.

## Test plan
- [x] `dotnet build` (Genie.Core, Genie.App) — clean
- [x] `dotnet test tests/Genie.Core.Tests` — 676/676 passing, including new `FileBrowserTests`
- [x] Manual: opened Config/Scripts/Maps folders under `~/Library/Application Support/Genie5` (a path with a space) — Finder opens correctly, no split-path error
- [x] Manual: launched external editor on a script — opens correctly