### PR TITLE
Fix Script Manager panel before first connect/command

### DIFF
--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -1868,7 +1868,20 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         ToggleAtmosphericsCommand = MakeToggleCommand("atmospherics", v => AtmosphericsVisible = v);
         ToggleLogCommand      = MakeToggleCommand("log",       v => LogVisible      = v);
         ToggleItemLogCommand  = MakeToggleCommand("itemlog",   v => ItemLogVisible  = v);
-        ToggleScriptsCommand  = MakeToggleCommand("scripts",   v => ScriptsVisible  = v);
+        // Scripts gets its own toggle (not MakeToggleCommand): the panel reads
+        // live off Core (script library scan, running-scripts list, folder
+        // open) but Core itself is built lazily on first connect/command
+        // (EnsureCoreBuilt). Opening the panel before either of those has
+        // happened must not leave it stuck showing an empty library — build
+        // Core first, the same on-demand pattern Genie4ImportCommand uses.
+        ToggleScriptsCommand = ReactiveCommand.Create(() =>
+        {
+            EnsureCoreBuilt(null, eagerLoadOfflineRules: true);
+            if (DockFactory is not GenieDockFactory factory) return;
+            var newVisible = !factory.IsToolVisible("scripts");
+            factory.SetToolVisibility("scripts", newVisible);
+            ScriptsVisible = newVisible;
+        });
         ToggleSceneCommand    = MakeToggleCommand("scene",     v => SceneVisible    = v);
         ToggleMobsCommand     = MakeToggleCommand("mobs",      v => MobsVisible     = v);
         TogglePlayersCommand  = MakeToggleCommand("players",   v => PlayersVisible  = v);
@@ -3420,7 +3433,14 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             case "atmospherics": ForceSet(visible, v => AtmosphericsVisible = v, () => AtmosphericsVisible); break;
             case "log":       ForceSet(visible, v => LogVisible      = v, () => LogVisible);      break;
             case "itemlog":   ForceSet(visible, v => ItemLogVisible  = v, () => ItemLogVisible);  break;
-            case "scripts":   ForceSet(visible, v => ScriptsVisible  = v, () => ScriptsVisible);  break;
+            case "scripts":
+                // Dock-driven show (drag the tab back into view, restore a
+                // layout, etc.) bypasses ToggleScriptsCommand — ensure Core
+                // here too so the panel's library/folder-open aren't stuck
+                // waiting on a connect that may never come.
+                if (visible) EnsureCoreBuilt(null, eagerLoadOfflineRules: true);
+                ForceSet(visible, v => ScriptsVisible = v, () => ScriptsVisible);
+                break;
             case "scene":     ForceSet(visible, v => SceneVisible    = v, () => SceneVisible);    break;
             case "mobs":      ForceSet(visible, v => MobsVisible     = v, () => MobsVisible);     break;
             case "players":   ForceSet(visible, v => PlayersVisible  = v, () => PlayersVisible);  break;

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -1868,20 +1868,13 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         ToggleAtmosphericsCommand = MakeToggleCommand("atmospherics", v => AtmosphericsVisible = v);
         ToggleLogCommand      = MakeToggleCommand("log",       v => LogVisible      = v);
         ToggleItemLogCommand  = MakeToggleCommand("itemlog",   v => ItemLogVisible  = v);
-        // Scripts gets its own toggle (not MakeToggleCommand): the panel reads
-        // live off Core (script library scan, running-scripts list, folder
-        // open) but Core itself is built lazily on first connect/command
-        // (EnsureCoreBuilt). Opening the panel before either of those has
-        // happened must not leave it stuck showing an empty library — build
-        // Core first, the same on-demand pattern Genie4ImportCommand uses.
-        ToggleScriptsCommand = ReactiveCommand.Create(() =>
-        {
-            EnsureCoreBuilt(null, eagerLoadOfflineRules: true);
-            if (DockFactory is not GenieDockFactory factory) return;
-            var newVisible = !factory.IsToolVisible("scripts");
-            factory.SetToolVisibility("scripts", newVisible);
-            ScriptsVisible = newVisible;
-        });
+        // The panel reads live off Core (script library scan, running-scripts
+        // list, folder open) but Core itself is built lazily on first
+        // connect/command (EnsureCoreBuilt). Opening the panel before either
+        // of those has happened must not leave it stuck showing an empty
+        // library — build Core first via beforeShow, the same on-demand
+        // pattern Genie4ImportCommand uses. See also EnsureScriptsPanelReady.
+        ToggleScriptsCommand  = MakeToggleCommand("scripts",   v => ScriptsVisible  = v, beforeShow: EnsureScriptsPanelReady);
         ToggleSceneCommand    = MakeToggleCommand("scene",     v => SceneVisible    = v);
         ToggleMobsCommand     = MakeToggleCommand("mobs",      v => MobsVisible     = v);
         TogglePlayersCommand  = MakeToggleCommand("players",   v => PlayersVisible  = v);
@@ -3388,17 +3381,31 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// menu's check mark and the dock's true state aligned even if the user
     /// closed a tool by some other means (e.g. the X on its tab).
     /// </summary>
-    private ReactiveCommand<Unit, Unit> MakeToggleCommand(string toolId, Action<bool> updateBool)
+    private ReactiveCommand<Unit, Unit> MakeToggleCommand(string toolId, Action<bool> updateBool, Action? beforeShow = null)
         => ReactiveCommand.Create(() =>
         {
             if (DockFactory is not GenieDockFactory factory) return;
             var newVisible = !factory.IsToolVisible(toolId);
+            // Only run beforeShow on the transition TO visible — a hide should
+            // never have a side effect meant for "the panel is about to be seen".
+            if (newVisible) beforeShow?.Invoke();
             factory.SetToolVisibility(toolId, newVisible);
             // The Opened/Closed events also push this; explicitly setting it
             // here covers cases where the event already fired with the same
             // value (no PropertyChanged would otherwise refresh the binding).
             updateBool(newVisible);
         });
+
+    /// <summary>Build Core on demand (see <see cref="EnsureCoreBuilt"/>) before
+    /// the Script Manager panel is shown. The panel is fully Core-driven —
+    /// script library scan, running-scripts list, folder open — but Core is
+    /// otherwise built lazily on first connect/command, so showing the panel
+    /// without this would leave it stuck with an empty library and a dead
+    /// folder-open button. Called from both places the panel can become
+    /// visible: <see cref="ToggleScriptsCommand"/> and the dock-driven
+    /// "scripts" case in <see cref="SetVisibilityBool"/> (tab dragged back
+    /// into view, layout restore, etc.).</summary>
+    private void EnsureScriptsPanelReady() => EnsureCoreBuilt(null, eagerLoadOfflineRules: true);
 
     /// <summary>
     /// Sync the matching <c>XxxVisible</c> bool to <paramref name="visible"/>
@@ -3435,10 +3442,10 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             case "itemlog":   ForceSet(visible, v => ItemLogVisible  = v, () => ItemLogVisible);  break;
             case "scripts":
                 // Dock-driven show (drag the tab back into view, restore a
-                // layout, etc.) bypasses ToggleScriptsCommand — ensure Core
-                // here too so the panel's library/folder-open aren't stuck
-                // waiting on a connect that may never come.
-                if (visible) EnsureCoreBuilt(null, eagerLoadOfflineRules: true);
+                // layout, etc.) bypasses ToggleScriptsCommand — this Core
+                // side effect on a checkmark-sync path is intentional; see
+                // EnsureScriptsPanelReady.
+                if (visible) EnsureScriptsPanelReady();
                 ForceSet(visible, v => ScriptsVisible = v, () => ScriptsVisible);
                 break;
             case "scene":     ForceSet(visible, v => SceneVisible    = v, () => SceneVisible);    break;


### PR DESCRIPTION
## Summary
- `GenieCore` is built lazily (`EnsureCoreBuilt`, on first connect or the first typed command). `ScriptsViewModel` is fully Core-driven — `RefreshLibrary()` no-ops with a null `_core`, and `Scripts.OpenFolderRequested` only gets a subscriber inside `WireCore()`.
- Opening the Script Manager panel before that first connect/command left it stuck: empty script library, and the "Open the scripts folder" button silently did nothing (no subscriber).
- Both ways the panel can become visible — the menu/toolbar toggle and a dock-driven show (dragging the tab back into view, layout restore) — now build Core first via a new `EnsureScriptsPanelReady()` helper, the same on-demand pattern `Genie4ImportCommand` already uses for offline use before a connect.
- `MakeToggleCommand` gained an optional `beforeShow` hook (only fires on the transition to visible) so the Scripts toggle reuses the shared helper instead of a hand-rolled copy.

## Test plan
- [x] `dotnet build` (Genie.Core, Genie.App) — clean
- [x] `dotnet test tests/Genie.Core.Tests` — 670/670 passing (no Core changes in this PR)
- [x] Manual: launched the app, opened Script Manager **before** connecting to any character — library now shows scripts from the Scripts folder, "Open the scripts folder" opens Finder, launching the external editor on a script works