### PR TITLE
fix(connection): avoid double Disconnected on normal disconnect

### DIFF
--- a/src/Genie.Core/GameConnection.cs
+++ b/src/Genie.Core/GameConnection.cs
@@ -232,13 +232,20 @@ public sealed class GameConnection : IAsyncDisposable
 
     public async Task DisconnectAsync()
     {
+        // Only emit Disconnected here if there was no read loop to unwind —
+        // when one exists, its own finally block (below, in ReadLoopAsync)
+        // already emits it after being cancelled, so emitting again here
+        // would double-fire the event for every normal disconnect.
+        bool hadReadLoop = _readLoop is not null;
+
         await _cts.CancelAsync();
         if (_readLoop is not null)
             await _readLoop.ConfigureAwait(false);
         if (_watchdogLoop is not null)
             await _watchdogLoop.ConfigureAwait(false);
         Cleanup();
-        _stateSubject.OnNext(new ConnectionEvent(ConnectionEventKind.Disconnected));
+        if (!hadReadLoop)
+            _stateSubject.OnNext(new ConnectionEvent(ConnectionEventKind.Disconnected));
     }
 
     // ── Connection establishment ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `DisconnectAsync` no longer emits `Disconnected` after awaiting a read loop that already emits it in its `finally` block.
- Prevents double-firing the disconnect event on normal disconnects; still emits when there was no read loop to unwind.

## Test plan
- [x] Connect then disconnect — only one disconnect/session-end handling path fires (no duplicate UI/system lines from a double event)
- [x] Disconnect before a read loop exists (failed/early connect) still surfaces Disconnected