### PR TITLE
Render the Game window with AvaloniaEdit, behind a default-off config flag

### DIFF
--- a/src/Genie.App/App.axaml
+++ b/src/Genie.App/App.axaml
@@ -35,6 +35,11 @@
     <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml"/>
     <!-- DataGrid likewise — used by the Configuration dialog's rule tables. -->
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
+    <!-- AvaloniaEdit ships its own control theme; without this the experimental
+         editor-backed Game window (#config useeditorgamewindow) renders as blank
+         space. Inert when the flag is off — nothing else in the app is a
+         TextEditor, so these styles match no control. -->
+    <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml"/>
 
     <!-- Tool header: just the title -->
     <Style Selector="ToolControl">
@@ -84,6 +89,112 @@
   </Application.Styles>
 
   <Application.DataTemplates>
+
+    <!-- ── Game text (experimental AvaloniaEdit renderer) ─────────────────── -->
+    <!-- MUST stay ABOVE the GameTextDocument template below: template matching
+         is first-match-wins on IsInstanceOfType, and EditorGameTextDocument is a
+         GameTextDocument. Only reached when #config useeditorgamewindow is on —
+         GenieDockFactory constructs the subtype only then, so with the flag off
+         (the default) this template matches nothing and the legacy subtree below
+         is built exactly as it always was.
+         Everything outside the text surface itself — the window menu, the
+         ↓ Bottom overlay, the Find bar — is a deliberate copy of the legacy
+         template's chrome so the two renderers are swappable without the shared
+         parts drifting; the differences are the GameTextEditor in place of the
+         ScrollViewer+ItemsControl, and the overlay binding to the editor's own
+         IsScrolledUp / JumpToBottomCommand instead of AutoScrollBehavior's. -->
+    <DataTemplate DataType="docking:EditorGameTextDocument">
+      <Grid Background="{Binding ToolBackground}">
+        <Grid.ContextMenu>
+          <ContextMenu docking:WindowMenuBehavior.RefreshOnOpen="True">
+            <!-- Platform gesture, not Ctrl: this renderer gets Copy/Select-All from
+                 AvaloniaEdit's CommandBindings, so it answers Cmd+C on macOS. The
+                 legacy template below stays hardcoded Ctrl+C, which is what that
+                 renderer's own key handler implements. -->
+            <MenuItem Header="Copy"
+                      InputGesture="{x:Static docking:WindowMenuBehavior.CopySelectionGesture}"
+                      Command="{x:Static docking:WindowMenuBehavior.CopySelectionCommand}"
+                      IsVisible="{Binding WindowMenu.ShowCopyAll}" />
+            <MenuItem Header="Copy All"
+                      Command="{Binding WindowMenu.CopyAllCommand}"
+                      IsVisible="{Binding WindowMenu.ShowCopyAll}" />
+            <MenuItem Header="Save As…"
+                      Command="{Binding WindowMenu.SaveAsCommand}"
+                      IsVisible="{Binding WindowMenu.ShowSaveAs}" />
+            <!-- Find really is Ctrl+F on both renderers (MainWindow's key handler),
+                 so this label is accurate everywhere and stays as-is. -->
+            <MenuItem Header="Find…"
+                      InputGesture="Ctrl+F"
+                      Command="{Binding WindowMenu.FindCommand}"
+                      IsVisible="{Binding WindowMenu.ShowFind}" />
+            <MenuItem Header="Clear"
+                      Command="{Binding WindowMenu.ClearCommand}"
+                      IsVisible="{Binding WindowMenu.ShowClear}" />
+            <MenuItem Header="Time Stamp"
+                      ToggleType="CheckBox"
+                      IsChecked="{Binding WindowMenu.IsTimestampOn, Mode=TwoWay}"
+                      IsVisible="{Binding WindowMenu.ShowTimestamp}" />
+            <MenuItem Header="Name List Only"
+                      ToggleType="CheckBox"
+                      IsChecked="{Binding WindowMenu.IsNameListOnlyOn, Mode=TwoWay}"
+                      IsVisible="{Binding WindowMenu.ShowNameListOnly}" />
+            <MenuItem Header="Word Wrap"
+                      ToggleType="CheckBox"
+                      IsChecked="{Binding WindowMenu.IsWordWrapOn, Mode=TwoWay}"
+                      IsVisible="{Binding WindowMenu.ShowWordWrap}" />
+            <MenuItem Header="Pause Scrolling"
+                      ToggleType="CheckBox"
+                      IsChecked="{Binding WindowMenu.IsScrollPaused, Mode=TwoWay}"
+                      IsVisible="{Binding WindowMenu.ShowPauseScroll}" />
+          </ContextMenu>
+        </Grid.ContextMenu>
+
+        <!-- Same MDI width/height pinning the legacy ScrollViewer needs (#124):
+             the windowed DocumentControl host measures with infinite width, so
+             word wrap never engages unless a finite width is forced. -->
+        <controls:GameTextEditor x:Name="gameEditor"
+                                 Width="{Binding $parent[Grid].Bounds.Width}"
+                                 Height="{Binding $parent[Grid].Bounds.Height}"/>
+
+        <Button HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                Margin="0,0,20,8"
+                IsVisible="{Binding #gameEditor.IsScrolledUp}"
+                Command="{Binding #gameEditor.JumpToBottomCommand}"
+                Content="↓ Bottom" FontSize="11" Padding="8,4" Opacity="0.85"/>
+
+        <Border HorizontalAlignment="Right" VerticalAlignment="Top"
+                Margin="0,4,20,0" Padding="4,2" CornerRadius="3"
+                Background="{DynamicResource Theme.ToolbarBg}"
+                BorderBrush="{DynamicResource Theme.Border}" BorderThickness="1"
+                IsVisible="{Binding Find.IsOpen}">
+          <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBox Text="{Binding Find.FindText}" Watermark="Find…"
+                     AutomationProperties.Name="Find in window"
+                     Width="160" FontSize="11" MinHeight="0" Padding="4,2"
+                     controls:FindInWindow.BoxModel="{Binding Find}"/>
+            <TextBlock Text="{Binding Find.Status}" FontSize="10"
+                       Foreground="{DynamicResource Theme.TextMuted}"
+                       VerticalAlignment="Center"/>
+            <Button Content="▲" FontSize="10" Padding="4,1" MinHeight="0" MinWidth="0"
+                    AutomationProperties.Name="Find previous"
+                    AutomationProperties.HelpText="Older match (Enter)"
+                    Command="{Binding Find.OlderCommand}"
+                    ToolTip.Tip="Older match (Enter)"/>
+            <Button Content="▼" FontSize="10" Padding="4,1" MinHeight="0" MinWidth="0"
+                    AutomationProperties.Name="Find next"
+                    AutomationProperties.HelpText="Newer match (Shift+Enter)"
+                    Command="{Binding Find.NewerCommand}"
+                    ToolTip.Tip="Newer match (Shift+Enter)"/>
+            <Button Content="✕" FontSize="10" Padding="4,1" MinHeight="0" MinWidth="0"
+                    Background="Transparent" BorderThickness="0"
+                    AutomationProperties.Name="Close find bar"
+                    AutomationProperties.HelpText="Close (Esc)"
+                    Command="{Binding Find.CloseCommand}"
+                    ToolTip.Tip="Close (Esc)"/>
+          </StackPanel>
+        </Border>
+      </Grid>
+    </DataTemplate>
 
     <!-- ── Game text ──────────────────────────────────────────────────────── -->
     <DataTemplate DataType="docking:GameTextDocument">

--- a/src/Genie.App/Controls/GameLinkGenerator.cs
+++ b/src/Genie.App/Controls/GameLinkGenerator.cs
@@ -1,0 +1,230 @@
+using System;
+using Avalonia;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using AvaloniaEdit.Editing;
+using AvaloniaEdit.Rendering;
+using Genie.App.Highlighting;
+using Genie.Core.Events;
+
+namespace Genie.App.Controls;
+
+/// <summary>
+/// Turns each of a line's <c>&lt;d cmd="…"&gt;</c> / <c>&lt;a href="…"&gt;</c> spans
+/// into a clickable visual-line element, the AvaloniaEdit equivalent of the
+/// <c>InlineUIContainer</c> the legacy renderer emits. Modelled on AvaloniaEdit's
+/// own <c>LinkElementGenerator</c> / <c>VisualLineLinkText</c> pair.
+///
+/// <para>The spans come from <see cref="GameLineEntry.Links"/> — the same validated,
+/// start-ordered list the legacy emit pass walks — so <c>ShowLinks=false</c>
+/// (<see cref="DefaultHighlights.LinksEnabled"/>) and out-of-bounds spans are
+/// already filtered out upstream and this generator simply produces nothing for
+/// them.</para>
+/// </summary>
+internal sealed class GameLinkGenerator : VisualLineElementGenerator
+{
+    private readonly Func<int, GameLineEntry?> _entryAt;
+    private readonly TextArea _textArea;
+    private readonly LinkClickArbiter _clicks;
+
+    internal GameLinkGenerator(Func<int, GameLineEntry?> entryAt, TextArea textArea)
+    {
+        _entryAt  = entryAt;
+        _textArea = textArea;
+        _clicks   = new LinkClickArbiter(textArea);
+    }
+
+    public override int GetFirstInterestedOffset(int startOffset)
+    {
+        if (Resolve(startOffset, out var lineStart, out var relative) is not { } links) return -1;
+        foreach (var link in links)
+        {
+            // Links are start-ordered, so the first one reaching past `relative`
+            // is the next point of interest. A span that straddles startOffset can
+            // only happen if the view asks mid-element; start it where we are.
+            if (link.Start >= relative) return lineStart + link.Start;
+            if (link.Start + link.Length > relative) return startOffset;
+        }
+        return -1;
+    }
+
+    public override VisualLineElement? ConstructElement(int offset)
+    {
+        if (Resolve(offset, out var lineStart, out var relative) is not { } links) return null;
+        foreach (var link in links)
+        {
+            if (link.Start != relative) continue;
+            // Never overrun the visual line: an element longer than the remaining
+            // document line would corrupt the visual-column mapping.
+            var length = Math.Min(link.Length, CurrentContext.VisualLine.LastDocumentLine.EndOffset - offset);
+            if (length <= 0) return null;
+            return new GameLinkElement(CurrentContext.VisualLine, length, link, _textArea, _clicks);
+        }
+        return null;
+    }
+
+    /// <summary>Map a document offset to (start of its document line, offset within
+    /// that line) and hand back that line's link spans. Null when the line has no
+    /// buffered metadata — the side list and the document can be a beat apart.</summary>
+    private IReadOnlyList<LinkSpan>? Resolve(int offset, out int lineStart, out int relative)
+    {
+        lineStart = 0;
+        relative  = 0;
+        var context = CurrentContext;
+        if (context is null) return null;
+        var docLine = context.Document.GetLineByOffset(offset);
+        var entry   = _entryAt(docLine.LineNumber);
+        if (entry is null || entry.Links.Count == 0) return null;
+        lineStart = docLine.Offset;
+        relative  = offset - docLine.Offset;
+        return entry.Links;
+    }
+}
+
+/// <summary>
+/// A run of link text inside the game window: Wrayth-blue (or URL-green) and
+/// underlined, hand cursor on hover, and a click that dispatches through the very
+/// same handlers the legacy renderer uses.
+///
+/// <para><b>Release without a drag</b>, matching the legacy window. AvaloniaEdit's
+/// own <c>VisualLineLinkText</c> fires on press, which cost us the ability to start
+/// a selection on link text — and inventory and exit-heavy screens are mostly link
+/// text. So the press only <i>arms</i> the click and is deliberately left unhandled,
+/// letting <see cref="TextArea"/>'s normal selection machinery run; the decision is
+/// made by <see cref="LinkClickArbiter"/> at release.</para>
+/// </summary>
+internal sealed class GameLinkElement : VisualLineText
+{
+    private readonly LinkSpan _link;
+    private readonly TextArea _textArea;
+    private readonly LinkClickArbiter _clicks;
+
+    internal GameLinkElement(VisualLine parentVisualLine, int length, LinkSpan link,
+                             TextArea textArea, LinkClickArbiter clicks)
+        : base(parentVisualLine, length)
+    {
+        _link     = link;
+        _textArea = textArea;
+        _clicks   = clicks;
+    }
+
+    public override Avalonia.Media.TextFormatting.TextRun CreateTextRun(
+        int startVisualColumn, ITextRunConstructionContext context)
+    {
+        // Set here rather than from the colorizer: transformers run before the run
+        // is created, so this is the last word on a link's appearance — which is
+        // what we want, since a link paints as a link regardless of what highlight
+        // rules matched the same characters (legacy parity).
+        TextRunProperties.SetForegroundBrush(DefaultHighlights.LinkForeground(_link.IsUrl));
+        TextRunProperties.SetTextDecorations(TextDecorations.Underline);
+        return base.CreateTextRun(startVisualColumn, context);
+    }
+
+    protected override VisualLineText CreateInstance(int length)
+        => new GameLinkElement(ParentVisualLine, length, _link, _textArea, _clicks);
+
+    protected override void OnQueryCursor(PointerEventArgs e)
+    {
+        e.Handled = true;
+        _textArea.Cursor = new Cursor(StandardCursorType.Hand);
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        var pt = e.GetCurrentPoint(_textArea);
+        if (!pt.Properties.IsLeftButtonPressed) return;   // right/middle pass through
+        // Arm only. Crucially `e.Handled` stays false, so TextArea still begins its
+        // own selection from this point — that is what makes a drag starting on link
+        // text select instead of navigating. DisplayText() is read now, while this
+        // element is still attached to a live visual line.
+        _clicks.Arm(_link, DisplayText(), pt.Position);
+    }
+
+    /// <summary>The visible link text, read back off the document so a split
+    /// element still reports the whole span (the legacy path passes the full
+    /// display text, not the fragment under the pointer).</summary>
+    private string DisplayText()
+    {
+        var doc  = ParentVisualLine.Document;
+        var line = ParentVisualLine.FirstDocumentLine;
+        var from = line.Offset + _link.Start;
+        var len  = Math.Min(_link.Length, Math.Max(0, doc.TextLength - from));
+        return len <= 0 ? "" : doc.GetText(from, len);
+    }
+}
+
+/// <summary>
+/// Decides whether a press that landed on link text was a click or the start of a
+/// selection drag, and dispatches only in the former case — the same rule
+/// <c>SelectableLinesControl</c> applies on the legacy path, including its 3 px
+/// threshold and its latch-once semantics (drag out and back is still a drag).
+///
+/// <para>Lives here rather than in <see cref="GameLinkElement"/> because
+/// <c>VisualLineElement</c> exposes no release hook: elements are rebuilt on every
+/// redraw and only see <c>OnPointerPressed</c>, so the release has to be observed on
+/// the <see cref="TextArea"/>. One arbiter per generator, i.e. one per editor.</para>
+/// </summary>
+internal sealed class LinkClickArbiter
+{
+    private const double DragThreshold = 3.0;   // matches SelectableLinesControl
+
+    private readonly TextArea _textArea;
+
+    private LinkSpan? _armed;
+    private string    _display = "";
+    private Point     _pressPoint;
+    private bool      _dragged;
+
+    internal LinkClickArbiter(TextArea textArea)
+    {
+        _textArea = textArea;
+        // Tunnel for the press so this runs *before* TextArea's own handling, which
+        // is what dispatches into the element that arms us — otherwise a press on
+        // ordinary text would never clear a link armed by an earlier press.
+        textArea.AddHandler(InputElement.PointerPressedEvent, OnAnyPressed,
+                            RoutingStrategies.Tunnel);
+        // Bubble + handledEventsToo for move/release: TextArea marks both handled
+        // while it is extending a selection, and those are exactly the events that
+        // tell us this was a drag.
+        textArea.AddHandler(InputElement.PointerMovedEvent, OnMoved,
+                            RoutingStrategies.Bubble, handledEventsToo: true);
+        textArea.AddHandler(InputElement.PointerReleasedEvent, OnReleased,
+                            RoutingStrategies.Bubble, handledEventsToo: true);
+    }
+
+    /// <summary>Called from a link element's press handler: this press landed on a
+    /// link, so a release without a drag should dispatch it.</summary>
+    internal void Arm(LinkSpan link, string display, Point pressPoint)
+    {
+        _armed      = link;
+        _display    = display;
+        _pressPoint = pressPoint;
+        _dragged    = false;
+    }
+
+    private void OnAnyPressed(object? sender, PointerPressedEventArgs e) => _armed = null;
+
+    private void OnMoved(object? sender, PointerEventArgs e)
+    {
+        if (_armed is null || _dragged) return;
+        var p = e.GetPosition(_textArea);
+        var dx = p.X - _pressPoint.X;
+        var dy = p.Y - _pressPoint.Y;
+        if (Math.Sqrt((dx * dx) + (dy * dy)) > DragThreshold) _dragged = true;
+    }
+
+    private void OnReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        var link = _armed;
+        _armed = null;
+        if (link is null || _dragged) return;
+        if (e.InitialPressMouseButton != MouseButton.Left) return;
+
+        // Identical dispatch to SelectableLinesControl's release handler: URLs go to
+        // the OS-browser handler, game commands carry both the server-bound command
+        // and the visible display text (the Game-window echo override).
+        if (link.IsUrl) DefaultHighlights.OnUrlClicked?.Invoke(link.Command);
+        else            DefaultHighlights.OnLinkClicked?.Invoke(link.Command, _display);
+    }
+}

--- a/src/Genie.App/Controls/GameTextArea.cs
+++ b/src/Genie.App/Controls/GameTextArea.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using Avalonia.Input;
+using AvaloniaEdit;
+using AvaloniaEdit.Editing;
+
+namespace Genie.App.Controls;
+
+/// <summary>
+/// The <see cref="TextArea"/> behind the Game window's editor renderer, made
+/// transparent to editing input.
+///
+/// <para>AvaloniaEdit swallows typing whether or not the editor is read-only:
+/// <c>TextArea.OnTextInput</c> marks the event handled after calling
+/// <c>PerformTextInput</c>, and the Backspace/Delete/Enter key bindings mark
+/// their <c>KeyDown</c> handled from the command handler. <c>IsReadOnly</c> only
+/// stops the document from changing — it does not stop the event from being
+/// consumed.</para>
+///
+/// <para>That silently broke type-anywhere (#141). <c>MainWindow</c> listens for
+/// <c>TextInput</c> on the bubble route with <c>handledEventsToo: false</c> and
+/// redirects printable text into the command bar; with the TextArea focused it
+/// never sees the keystroke, so typing after a click in the Game window did
+/// nothing at all. The legacy renderer has no editing input to begin with, which
+/// is why the behaviour only disappeared under the flag.</para>
+///
+/// <para>Nothing suppressed here is behaviour worth keeping: the view is
+/// read-only, so every one of these commands was already a no-op on the
+/// document — apart from the <c>BringCaretToView()</c> that ends the delete and
+/// enter handlers, which yanks a scrolled-back view down to the caret.</para>
+/// </summary>
+internal sealed class GameTextArea : TextArea
+{
+    /// <summary>Keys whose editing bindings are dropped so the keystroke keeps
+    /// bubbling to <c>MainWindow</c>: Backspace is the other half of #141
+    /// (it produces no <c>TextInput</c>, so it has its own redirect), Delete and
+    /// Enter are removed for the caret-scroll reason above.</summary>
+    private static readonly Key[] SuppressedEditingKeys = [Key.Back, Key.Delete, Key.Enter];
+
+    public GameTextArea()
+    {
+        // The Editing handler copies the shared static binding list into its own
+        // on creation (EditingCommandHandler.Create), so pruning it here affects
+        // this TextArea only. Copy/Cut/Paste are not key bindings — they are
+        // matched from CommandBindings against the platform gesture — so Cmd+C /
+        // Ctrl+C is untouched.
+        foreach (var binding in DefaultInputHandler.Editing.KeyBindings
+                     .Where(b => b.Gesture is { } gesture && SuppressedEditingKeys.Contains(gesture.Key))
+                     .ToList())
+            DefaultInputHandler.Editing.KeyBindings.Remove(binding);
+    }
+
+    /// <summary>Take the stock <see cref="TextArea"/> control theme; Avalonia keys
+    /// themes off the concrete type, and AvaloniaEdit's is keyed
+    /// <c>{x:Type editing:TextArea}</c>.</summary>
+    protected override Type StyleKeyOverride => typeof(TextArea);
+
+    /// <summary>Leave printable input for the window's type-anywhere handler.
+    /// Deliberately does not call <c>base</c>: <see cref="TextArea"/>'s
+    /// implementation is what marks the event handled. The base-base
+    /// (<c>InputElement.OnTextInput</c>) is empty, so nothing is lost.</summary>
+    protected override void OnTextInput(TextInputEventArgs e)
+    {
+    }
+}
+
+/// <summary>
+/// A <see cref="TextEditor"/> hosting a <see cref="GameTextArea"/>. The
+/// constructor that injects a TextArea is <c>protected</c>, so a subclass is the
+/// only way in.
+/// </summary>
+internal sealed class GameTextEditorControl : TextEditor
+{
+    public GameTextEditorControl() : base(new GameTextArea())
+    {
+    }
+
+    /// <summary>As <see cref="GameTextArea.StyleKeyOverride"/> — keep the stock
+    /// <see cref="TextEditor"/> theme.</summary>
+    protected override Type StyleKeyOverride => typeof(TextEditor);
+}

--- a/src/Genie.App/Controls/GameTextColorizer.cs
+++ b/src/Genie.App/Controls/GameTextColorizer.cs
@@ -1,0 +1,201 @@
+using System;
+using Avalonia;
+using Avalonia.Media;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Rendering;
+using Genie.App.Highlighting;
+using Genie.App.ViewModels;
+using Genie.Core.Events;
+
+namespace Genie.App.Controls;
+
+/// <summary>
+/// One buffered game line as the AvaloniaEdit renderer sees it: the
+/// <see cref="TextLine"/> the view-model produced, plus the resolved
+/// <see cref="DefaultHighlights.StyleMap"/> for it.
+///
+/// <para>The map is built <b>eagerly, once, when the line arrives</b> — not lazily
+/// at paint time — for two reasons. (1) A highlight rule can carry a sound or a
+/// TTS phrase, and <see cref="DefaultHighlights.BuildStyleMap"/> fires those as a
+/// side effect of matching; the legacy renderer realises every line's container
+/// immediately, so the alert fires on arrival. AvaloniaEdit only paints the
+/// visible window, so a lazily-built map would delay the alert until the user
+/// scrolled to it — and re-fire it on every re-scroll. (2) The colorizer runs on
+/// every visual-line rebuild; caching keeps the regex work per line at one pass.</para>
+/// </summary>
+internal sealed class GameLineEntry
+{
+    private static readonly LinkSpan[] NoLinks = [];
+
+    internal GameLineEntry(TextLine line)
+    {
+        Line = line;
+        // Echo lines bypass highlighting entirely (legacy TextLine.Inlines does the
+        // same), so they never build a map — and never fire highlight sound / TTS.
+        if (!line.IsEcho)
+            Map = DefaultHighlights.BuildStyleMap(
+                line.Text, line.Links, line.BoldSpans, line.PresetSpans, line.Window);
+    }
+
+    internal TextLine Line { get; }
+
+    /// <summary>Resolved style layers; default (all-null arrays) for echo lines.</summary>
+    internal DefaultHighlights.StyleMap Map { get; }
+
+    /// <summary>Validated, start-ordered link spans for this line — the same list
+    /// the legacy emit pass walks, so <c>ShowLinks=false</c> and malformed spans are
+    /// already filtered out. Empty for echo lines.</summary>
+    internal IReadOnlyList<LinkSpan> Links => Line.IsEcho ? NoLinks : Map.Links;
+}
+
+/// <summary>
+/// Paints one document line of the AvaloniaEdit-backed Game window from the same
+/// highlight semantics the legacy per-line renderer uses.
+///
+/// <para>The rules are NOT reimplemented here. <see cref="DefaultHighlights.BuildStyleMap"/>
+/// resolves every layer (player names, user highlight rules, built-in defaults,
+/// MonsterBold, presets) into per-character foreground / background / bold maps;
+/// this class only translates those maps into <c>ChangeLinePart</c> runs. The
+/// legacy path calls the same builder and translates the same maps into
+/// <c>Inline</c>s instead.</para>
+///
+/// <para>Two shapes of line are handled separately, mirroring
+/// <see cref="TextLine.Inlines"/>: echo lines (<c>#echo</c>, script output,
+/// diagnostics) render as one run styled from the <c>EchoBrush</c> /
+/// <c>EchoFontStyle</c> resources — the editor has no AXAML class selector, so the
+/// <c>.echo</c> style is resolved here — and game text runs the full highlight
+/// pipeline.</para>
+///
+/// <para>Character positions inside a link span are deliberately left alone: the
+/// element built by <see cref="GameLinkGenerator"/> owns their colour and
+/// underline, exactly as the legacy emit pass skips link ranges and emits a
+/// clickable run instead.</para>
+/// </summary>
+internal sealed class GameTextColorizer : DocumentColorizingTransformer
+{
+    private readonly Func<int, GameLineEntry?> _entryAt;
+
+    /// <param name="entryAt">Document line number (1-based) → the buffered line that
+    /// produced it, or null when the document and the side list are momentarily out
+    /// of step (nothing to paint — the row renders plain).</param>
+    internal GameTextColorizer(Func<int, GameLineEntry?> entryAt) => _entryAt = entryAt;
+
+    protected override void ColorizeLine(DocumentLine line)
+    {
+        if (line.Length == 0) return;
+        if (_entryAt(line.LineNumber) is not { } entry) return;
+
+        var meta  = entry.Line;
+        var start = line.Offset;
+        var end   = line.EndOffset;
+
+        // #178: a <output class="mono"> block (maps, stat tables, appraisals) or an
+        // `#echo mono` line keeps its highlights but renders monospaced, so a
+        // proportional game font can't break column alignment. Applied to the WHOLE
+        // line first — including link elements — so every glyph on the row shares
+        // one advance width. Later ChangeLinePart calls only set fore/back/weight
+        // (re-deriving the typeface from whatever this left), so they can't undo it.
+        if (meta.Mono)
+            ChangeLinePart(start, end, el => el.TextRunProperties.SetTypeface(
+                Retypeface(el.TextRunProperties.Typeface, TextLine.MonoFont, bold: false)));
+
+        if (meta.IsEcho)
+        {
+            ColorizeEchoLine(meta, start, end);
+            return;
+        }
+
+        var map = entry.Map;
+
+        // The maps are indexed by character position in meta.Text and the document
+        // holds that same string, so document offset = line.Offset + index. Clamp
+        // anyway: a drifted side list must render plain, never throw.
+        var len   = Math.Min(map.Foreground.Length, line.Length);
+        var links = entry.Links;
+
+        var i       = 0;
+        var linkIdx = 0;
+        while (i < len)
+        {
+            // Skip characters owned by a link element.
+            while (linkIdx < links.Count && links[linkIdx].Start + links[linkIdx].Length <= i)
+                linkIdx++;
+            if (linkIdx < links.Count && links[linkIdx].Start <= i)
+            {
+                i = links[linkIdx].Start + links[linkIdx].Length;
+                continue;
+            }
+
+            // Coalesce the maximal run with identical foreground / background /
+            // weight before touching the visual tree — one ChangeLinePart per
+            // character would split every glyph into its own element.
+            var limit = linkIdx < links.Count ? Math.Min(len, links[linkIdx].Start) : len;
+            var fg    = map.Foreground[i];
+            var bg    = map.Background[i];
+            var bold  = map.Bold[i];
+            var j     = i + 1;
+            while (j < limit
+                   && ReferenceEquals(map.Foreground[j], fg)
+                   && ReferenceEquals(map.Background[j], bg)
+                   && map.Bold[j] == bold)
+                j++;
+
+            if (fg is not null || bg is not null || bold)
+                Apply(start + i, start + j, fg, bg, bold, meta.Mono);
+
+            i = j;
+        }
+    }
+
+    /// <summary>
+    /// Echo lines bypass highlighting and render as a single styled run — the
+    /// editor's stand-in for the AXAML <c>:is(TextBlock).echo</c> selector. An
+    /// explicit <c>#echo</c> colour overrides the class colour, matching
+    /// <see cref="TextLine.Inlines"/> where the run's own Foreground beats the
+    /// class style.
+    /// </summary>
+    private void ColorizeEchoLine(TextLine meta, int start, int end)
+    {
+        var fg    = meta.EchoForeground() ?? FindResource(Settings.DisplaySettings.EchoBrushKey) as IBrush;
+        var style = FindResource(Settings.DisplaySettings.EchoFontStyleKey) as FontStyle? ?? FontStyle.Italic;
+
+        ChangeLinePart(start, end, el =>
+        {
+            if (fg is not null) el.TextRunProperties.SetForegroundBrush(fg);
+            var tf = el.TextRunProperties.Typeface;
+            el.TextRunProperties.SetTypeface(new Typeface(tf.FontFamily, style, tf.Weight, tf.Stretch));
+        });
+    }
+
+    private void Apply(int from, int to, IBrush? fg, IBrush? bg, bool bold, bool mono)
+        => ChangeLinePart(from, to, el =>
+        {
+            if (fg is not null) el.TextRunProperties.SetForegroundBrush(fg);
+            if (bg is not null) el.TextRunProperties.SetBackgroundBrush(bg);
+            if (bold)
+            {
+                var tf = el.TextRunProperties.Typeface;
+                el.TextRunProperties.SetTypeface(
+                    Retypeface(tf, mono ? TextLine.MonoFont : tf.FontFamily, bold: true));
+            }
+        });
+
+    /// <summary>Rebuild a typeface keeping style + stretch, swapping the family and
+    /// (when asked) forcing Bold. <see cref="Typeface"/> is a readonly struct, so
+    /// every change is a fresh instance.</summary>
+    private static Typeface Retypeface(Typeface source, FontFamily family, bool bold)
+        => new(family, source.Style, bold ? FontWeight.Bold : source.Weight, source.Stretch);
+
+    /// <summary>Application-level resource lookup that also reaches into the merged
+    /// dictionaries (the plain <c>Resources[key]</c> indexer only sees keys pushed
+    /// directly, which covers <c>EchoBrush</c> but not the palette includes).
+    /// <para>Looked up per echo line rather than cached: DisplaySettings rewrites
+    /// EchoBrush / EchoFontStyle in Application.Resources whenever the user edits
+    /// them, and a cache would need its own invalidation hook for a lookup that only
+    /// runs for the echo lines actually on screen.</para></summary>
+    internal static object? FindResource(string key)
+    {
+        var app = Application.Current;
+        return app?.Resources.TryGetResource(key, app.ActualThemeVariant, out var v) == true ? v : null;
+    }
+}

--- a/src/Genie.App/Controls/GameTextEditor.cs
+++ b/src/Genie.App/Controls/GameTextEditor.cs
@@ -1,0 +1,455 @@
+using System;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using AvaloniaEdit;
+using AvaloniaEdit.Document;
+using Genie.App.Docking;
+using Genie.App.ViewModels;
+using ReactiveUI;
+
+namespace Genie.App.Controls;
+
+/// <summary>
+/// The experimental AvaloniaEdit-backed renderer for the main Game window
+/// (<c>#config useeditorgamewindow on</c>, default off). It hosts a single
+/// read-only <see cref="TextEditor"/> and mirrors
+/// <see cref="GameTextViewModel.Lines"/> — still the source of truth — into its
+/// document, one buffered line per document line.
+///
+/// <para>Only the <i>rendering</i> moves. Timestamping, the Name-List-Only filter,
+/// gags/substitutes, session logging, Copy All and Save As all stay on the
+/// view-model and are untouched by which renderer is active.</para>
+///
+/// <para>Selected out of the legacy path by type, not by a visibility toggle:
+/// <see cref="EditorGameTextDocument"/> gets its own <c>DataTemplate</c>, so with
+/// the flag off this control is never constructed and the legacy subtree is
+/// exactly what it always was.</para>
+/// </summary>
+public sealed class GameTextEditor : UserControl
+{
+    /// <summary>How close to the bottom still counts as "following the tail",
+    /// in device-independent pixels. Same band <c>AutoScrollState</c> uses for the
+    /// legacy ScrollViewer, so the ↓ Bottom button appears at the same moment.</summary>
+    private const double AtBottomBand = 10.0;
+
+    private readonly TextEditor  _editor;
+    private readonly TextDocument _document = new();
+    private readonly List<GameLineEntry> _entries = [];
+
+    private GameTextDocument?   _host;
+    private GameTextViewModel?  _vm;
+    private FindInWindowModel?  _find;
+
+    private bool _atBottom = true;
+    private bool _paused;
+    private bool _scrollHooked;
+
+    /// <summary>Focus at the moment of a pointer press, restored on release when the
+    /// click produced no selection — the game window must not steal focus from the
+    /// command bar for a plain click (legacy <c>LineSelection</c> only calls
+    /// <c>Focus()</c> after a real drag).</summary>
+    private IInputElement? _focusBeforePress;
+
+    public static readonly DirectProperty<GameTextEditor, bool> IsScrolledUpProperty =
+        AvaloniaProperty.RegisterDirect<GameTextEditor, bool>(
+            nameof(IsScrolledUp), o => o.IsScrolledUp);
+
+    private bool _isScrolledUp;
+
+    /// <summary>True when the view has been scrolled off the tail — drives the
+    /// ↓ Bottom overlay button, mirroring <c>AutoScrollState.IsScrolledUp</c>.</summary>
+    public bool IsScrolledUp
+    {
+        get => _isScrolledUp;
+        private set => SetAndRaise(IsScrolledUpProperty, ref _isScrolledUp, value);
+    }
+
+    /// <summary>Jump to the newest line and resume following it.</summary>
+    public ICommand JumpToBottomCommand { get; }
+
+    public GameTextEditor()
+    {
+        // GameTextEditorControl, not a stock TextEditor: its TextArea leaves
+        // typing and the editing keys unhandled so the window's type-anywhere
+        // redirect (#141) still fires when the game text has focus.
+        _editor = new GameTextEditorControl
+        {
+            Document        = _document,
+            IsReadOnly      = true,
+            ShowLineNumbers = false,
+            Background      = Brushes.Transparent,
+            Padding         = new Thickness(0),
+            // Suppress the built-in Copy/Cut/Paste flyout so a right-click over game
+            // text surfaces the window menu on the hosting Grid — the same problem
+            // the legacy template solves with a local ContextFlyout null.
+            ContextFlyout   = null,
+        };
+
+        var o = _editor.Options;
+        o.EnableHyperlinks              = false;   // we generate our own <d cmd> links
+        o.EnableEmailHyperlinks         = false;
+        o.EnableTextDragDrop            = false;   // read-only; dragging text out is not a thing
+        o.EnableRectangularSelection    = false;
+        o.EnableVirtualSpace            = false;
+        o.HighlightCurrentLine          = false;
+        o.AllowScrollBelowDocument      = false;
+        o.CutCopyWholeLine              = false;   // Ctrl+C with no selection must be a no-op
+        o.AcceptsTab                    = false;   // read-only: Tab is focus navigation, not indent
+
+        var area = _editor.TextArea;
+        area.CaretBrush   = Brushes.Transparent;   // read-only view: no caret
+        area.ContextFlyout = null;
+        area.TextView.ContextFlyout = null;
+        area.TextView.LineTransformers.Add(new GameTextColorizer(EntryAt));
+        area.TextView.ElementGenerators.Add(new GameLinkGenerator(EntryAt, area));
+
+        // The ScrollViewer normally exists by TemplateApplied; LayoutUpdated is the
+        // belt-and-braces retry (it unhooks itself the moment the lookup succeeds)
+        // so a slow template application can't leave paging permanently unwired.
+        _editor.TemplateApplied += (_, _) => HookScrollViewer();
+        _editor.LayoutUpdated   += OnEditorLayoutUpdated;
+
+        // Focus etiquette: capture where focus was on the way DOWN (tunnel, before
+        // the TextArea takes it) and hand it back on release if nothing got selected.
+        AddHandler(PointerPressedEvent, OnPressTunnel, RoutingStrategies.Tunnel);
+        AddHandler(PointerReleasedEvent, OnReleased, RoutingStrategies.Bubble);
+
+        JumpToBottomCommand = ReactiveCommand.Create(JumpToBottom);
+
+        Content = _editor;
+    }
+
+    // ── Host wiring ───────────────────────────────────────────────────────────
+
+    // Subscriptions follow the VISUAL TREE, not the DataContext: a dock re-parent
+    // (tab switch, float, re-dock) detaches and re-attaches the control without
+    // ever changing its DataContext, so unhooking on DataContext alone would leave
+    // a re-attached window permanently frozen. Attach re-seeds from the buffer, so
+    // whatever arrived while detached is picked up.
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        Subscribe();
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        Unsubscribe();
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+        Unsubscribe();
+        Subscribe();
+    }
+
+    private void Subscribe()
+    {
+        if (_host is not null) return;                       // already wired
+        if (this.GetVisualRoot() is null) return;              // wired on attach instead
+        if (DataContext is not GameTextDocument host) return;
+
+        _host = host;
+        _vm   = host.ViewModel;
+        _find = host.Find;
+
+        host.PropertyChanged        += OnHostPropertyChanged;
+        _vm.Lines.CollectionChanged += OnLinesChanged;
+        _find.JumpRequested         += OnFindJump;
+
+        ApplyHostSettings();
+        _paused = host.IsScrollPaused;
+        RebuildAll();
+    }
+
+    private void Unsubscribe()
+    {
+        if (_host is not null) _host.PropertyChanged -= OnHostPropertyChanged;
+        if (_vm   is not null) _vm.Lines.CollectionChanged -= OnLinesChanged;
+        if (_find is not null) _find.JumpRequested -= OnFindJump;
+        _host = null;
+        _vm   = null;
+        _find = null;
+    }
+
+    private void OnHostPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_host is null) return;
+        switch (e.PropertyName)
+        {
+            case nameof(GameTextDocument.IsScrollPaused):
+                SetPaused(_host.IsScrollPaused);
+                break;
+            default:
+                ApplyHostSettings();
+                break;
+        }
+    }
+
+    /// <summary>Push the per-window appearance settings (font, size, foreground,
+    /// wrap, horizontal scrollbar) onto the editor. Re-run on every host property
+    /// change so Layout-tab edits repaint live, exactly like the legacy bindings.</summary>
+    private void ApplyHostSettings()
+    {
+        if (_host is null) return;
+        _editor.FontFamily = _host.ToolFontFamily;
+        _editor.FontSize   = _host.ToolFontSize;
+        // Null means "inherit the global game colour", which is what the legacy
+        // Foreground binding produces — clear the local value rather than leaving
+        // the last explicit brush behind.
+        if (_host.ToolForeground is { } fg) _editor.Foreground = fg;
+        else _editor.ClearValue(ForegroundProperty);
+        _editor.WordWrap = _host.ToolTextWrapping == TextWrapping.Wrap;
+        _editor.HorizontalScrollBarVisibility = _host.ToolHScroll;
+        if (GameTextColorizer.FindResource("Theme.Selection") is IBrush selection)
+            _editor.TextArea.SelectionBrush = selection;
+    }
+
+    private void OnEditorLayoutUpdated(object? sender, EventArgs e)
+    {
+        HookScrollViewer();
+        if (_scrollHooked) _editor.LayoutUpdated -= OnEditorLayoutUpdated;
+    }
+
+    /// <summary>
+    /// Register the editor's own ScrollViewer with the shared PageUp/PageDown
+    /// targeting (#136) and start tracking the tail. The template only produces the
+    /// ScrollViewer on apply, which is why this isn't done in the constructor.
+    ///
+    /// <para>Found by walking the visual tree: <c>TextEditor.ScrollViewer</c> is
+    /// internal in AvaloniaEdit 11.4.1. It is used ONLY for target registration —
+    /// <see cref="PageScroll"/> pages through <c>ScrollViewer</c> methods and Ctrl+F
+    /// resolves the active window from <c>PageScroll.CurrentTarget.DataContext</c>,
+    /// both of which need the real control. Scroll offset itself is always read and
+    /// written through <c>(IScrollable)TextView</c> (see <see cref="RemoveHead"/> and
+    /// <see cref="UpdateAtBottom"/>): the Phase 2 spike found the editor-level offset
+    /// properties did not survive a forced layout pass.</para>
+    /// </summary>
+    private void HookScrollViewer()
+    {
+        if (_scrollHooked) return;
+        if (_editor.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault() is not { } sv) return;
+        _scrollHooked = true;
+        PageScroll.SetIsTarget(sv, true);
+        PageScroll.SetIsDefaultTarget(sv, true);
+        _editor.TextArea.TextView.ScrollOffsetChanged += (_, _) => UpdateAtBottom();
+        UpdateAtBottom();
+    }
+
+    // ── Buffer → document ─────────────────────────────────────────────────────
+
+    /// <summary>Document line number (1-based) → its buffered line. The side list is
+    /// kept strictly parallel to the document: index <c>i</c> is always document
+    /// line <c>i+1</c>, which is what lets the colorizer and the link generator find
+    /// a line's spans from nothing but its line number.</summary>
+    private GameLineEntry? EntryAt(int lineNumber)
+        => lineNumber >= 1 && lineNumber <= _entries.Count ? _entries[lineNumber - 1] : null;
+
+    private void OnLinesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        switch (e.Action)
+        {
+            case NotifyCollectionChangedAction.Add
+                when e.NewItems is not null && e.NewStartingIndex == _entries.Count:
+                foreach (var item in e.NewItems)
+                    if (item is TextLine line) Append(line);
+                if (!_paused && _atBottom)
+                    Dispatcher.UIThread.Post(_editor.ScrollToEnd, DispatcherPriority.Loaded);
+                break;
+
+            case NotifyCollectionChangedAction.Remove when e.OldStartingIndex == 0:
+                RemoveHead(e.OldItems?.Count ?? 0);
+                break;
+
+            case NotifyCollectionChangedAction.Replace
+                when e.NewItems is { Count: 1 } && e.NewItems[0] is TextLine replacement:
+                ReplaceLine(e.NewStartingIndex, replacement);
+                break;
+
+            case NotifyCollectionChangedAction.Reset:
+                RebuildAll();
+                break;
+
+            // Anything else (a mid-buffer insert or a Move) would desynchronise the
+            // side list; nothing in GameTextViewModel produces one, but rebuilding
+            // is cheap insurance against a silently corrupted mapping.
+            default:
+                RebuildAll();
+                break;
+        }
+
+        Debug.Assert(_entries.Count == 0 || _document.LineCount == _entries.Count,
+                     "GameTextEditor: document lines drifted from the side list");
+    }
+
+    private void Append(TextLine line)
+    {
+        var entry = new GameLineEntry(line);
+        var text  = Flatten(line.Text);
+        _document.Insert(_document.TextLength, _entries.Count == 0 ? text : "\n" + text);
+        _entries.Add(entry);
+    }
+
+    private void ReplaceLine(int index, TextLine line)
+    {
+        if (index < 0 || index >= _entries.Count) { RebuildAll(); return; }
+        var docLine = _document.GetLineByNumber(index + 1);
+        var text    = Flatten(line.Text);
+        // The only producer today (RetokenizeAllLines) keeps the text identical and
+        // only wants a repaint; guard the general case anyway.
+        if (!string.Equals(_document.GetText(docLine.Offset, docLine.Length), text, StringComparison.Ordinal))
+            _document.Replace(docLine.Offset, docLine.Length, text);
+        _entries[index] = new GameLineEntry(line);
+        _editor.TextArea.TextView.Redraw(docLine);
+    }
+
+    /// <summary>
+    /// Drop the oldest <paramref name="count"/> lines and hold the reader's place.
+    ///
+    /// <para>AvaloniaEdit does not anchor scroll: removing text above the viewport
+    /// slides everything up under a stationary offset, which is the same
+    /// content-shift bug the legacy renderer has. The fix is exact because the
+    /// <c>HeightTree</c> that produced the current offset is the same one
+    /// <c>GetVisualTopByDocumentLine</c> reads — capture the first visible line's
+    /// visual top before the edit, subtract its visual top after, and apply the
+    /// difference. It stays exact even for trimmed lines that were never rendered
+    /// and carry estimated heights, because those estimates are what the offset
+    /// being corrected was built from.</para>
+    ///
+    /// <para>Only applied when the view is NOT following the tail: when it is, the
+    /// view is pinned to the bottom and compensating would fight the pin.</para>
+    /// </summary>
+    private void RemoveHead(int count)
+    {
+        if (count <= 0) return;
+        if (count >= _entries.Count) { RebuildAll(); return; }
+
+        var view       = _editor.TextArea.TextView;
+        var compensate = !_atBottom && view.VisualLinesValid && view.VisualLines.Count > 0;
+        var landmark   = 0;
+        var topBefore  = 0.0;
+        if (compensate)
+        {
+            landmark  = view.VisualLines[0].FirstDocumentLine.LineNumber;
+            topBefore = view.GetVisualTopByDocumentLine(landmark);
+        }
+
+        // Line (count+1) is the first survivor; its offset is exactly the length of
+        // everything being dropped, delimiters included.
+        _document.Remove(0, _document.GetLineByNumber(count + 1).Offset);
+        _entries.RemoveRange(0, count);
+
+        var moved = landmark - count;
+        if (!compensate || moved < 1) return;
+        var scroll   = (IScrollable)view;
+        var topAfter = view.GetVisualTopByDocumentLine(moved);
+        scroll.Offset = scroll.Offset.WithY(scroll.Offset.Y - (topBefore - topAfter));
+    }
+
+    /// <summary>Re-seed the document from the buffer. Used for <c>#clear</c>
+    /// (Reset), for the first attach — the view-model has usually already logged a
+    /// line or two by then — and as the fallback for any collection change the
+    /// incremental path doesn't model.</summary>
+    private void RebuildAll()
+    {
+        _entries.Clear();
+        if (_vm is null || _vm.Lines.Count == 0)
+        {
+            _document.Text = "";
+            return;
+        }
+
+        var sb = new System.Text.StringBuilder();
+        for (var i = 0; i < _vm.Lines.Count; i++)
+        {
+            var line = _vm.Lines[i];
+            _entries.Add(new GameLineEntry(line));
+            if (i > 0) sb.Append('\n');
+            sb.Append(Flatten(line.Text));
+        }
+        _document.Text = sb.ToString();
+        if (!_paused) Dispatcher.UIThread.Post(_editor.ScrollToEnd, DispatcherPriority.Loaded);
+    }
+
+    /// <summary>One buffered line must occupy exactly one document line or the
+    /// side-list mapping breaks. The parser splits on newlines so embedded ones
+    /// don't occur in practice; flatten defensively rather than corrupt every
+    /// line number after the offender.</summary>
+    private static string Flatten(string text)
+        => text.IndexOf('\n') < 0 && text.IndexOf('\r') < 0
+            ? text
+            : text.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ');
+
+    // ── Auto-follow / Pause Scrolling ─────────────────────────────────────────
+
+    private void UpdateAtBottom()
+    {
+        var scroll = (IScrollable)_editor.TextArea.TextView;
+        var max    = scroll.Extent.Height - scroll.Viewport.Height;
+        _atBottom  = max <= 0 || scroll.Offset.Y >= max - AtBottomBand;
+        IsScrolledUp = !_atBottom;
+    }
+
+    /// <summary>"Pause Scrolling": stop following the tail but keep appending.
+    /// Unlike the legacy path this needs no scrollback-cap suspension — a trim
+    /// while paused is compensated in <see cref="RemoveHead"/>, so the frozen view
+    /// genuinely stays put past the cap.</summary>
+    private void SetPaused(bool paused)
+    {
+        if (_paused == paused) return;
+        _paused = paused;
+        if (!paused) JumpToBottom();   // resuming catches up to whatever arrived
+    }
+
+    private void JumpToBottom()
+    {
+        _atBottom    = true;
+        IsScrolledUp = false;
+        Dispatcher.UIThread.Post(_editor.ScrollToEnd, DispatcherPriority.Loaded);
+    }
+
+    // ── Find (#120) ───────────────────────────────────────────────────────────
+
+    private void OnFindJump(FindInWindowModel.Match match)
+        => Dispatcher.UIThread.Post(() =>
+        {
+            var lineNumber = match.Line + 1;
+            if (lineNumber < 1 || lineNumber > _entries.Count) return;   // trimmed away
+            var line = _document.GetLineByNumber(lineNumber);
+            _editor.ScrollToLine(lineNumber);
+            // Select the hit so it reads at a glance, matching the legacy Find's
+            // SelectionStart/End on the matched line.
+            var from   = line.Offset + Math.Clamp(match.Col, 0, line.Length);
+            var length = Math.Clamp(match.Length, 0, line.EndOffset - from);
+            _editor.Select(from, length);
+        });
+
+    // ── Focus etiquette ───────────────────────────────────────────────────────
+
+    private void OnPressTunnel(object? sender, PointerPressedEventArgs e)
+        => _focusBeforePress = TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement();
+
+    private void OnReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        var previous = _focusBeforePress;
+        _focusBeforePress = null;
+        // A drag that produced a selection keeps focus here so Ctrl+C / Ctrl+A act
+        // on it; a plain click hands focus straight back to wherever it was (the
+        // command bar), which is what the legacy behaviour does.
+        if (previous is null || ReferenceEquals(previous, _editor) || _editor.SelectionLength > 0) return;
+        Dispatcher.UIThread.Post(() => previous.Focus());
+    }
+}

--- a/src/Genie.App/Docking/GameTextDocument.cs
+++ b/src/Genie.App/Docking/GameTextDocument.cs
@@ -96,3 +96,24 @@ public class GameTextDocument : Document, IWindowMenuHost, IFindHost
             : Avalonia.Controls.Primitives.ScrollBarVisibility.Auto;
     }
 }
+
+/// <summary>
+/// The main Game window rendered by <see cref="Controls.GameTextEditor"/>
+/// (AvaloniaEdit) instead of the per-line <c>ItemsControl</c>. Created by
+/// <see cref="GenieDockFactory"/> in place of a plain <see cref="GameTextDocument"/>
+/// when <c>GenieConfig.UseEditorGameWindow</c> is on. Experimental; default off.
+///
+/// <para>Renderer selection is a <b>type</b> distinction rather than a flag on the
+/// document on purpose: <c>App.axaml</c> declares a <c>DataTemplate</c> for this
+/// type ahead of the one for the base type, so the legacy subtree is not merely
+/// hidden — it is never built. That keeps the flag-off path byte-identical, and it
+/// avoids two competing <c>PageScroll</c> targets in one window. Everything else
+/// (the window menu, Find, Copy All, Save As, per-window settings) is inherited
+/// unchanged, and every <c>is GameTextDocument</c> check in the factory still
+/// matches.</para>
+/// </summary>
+public sealed class EditorGameTextDocument : GameTextDocument
+{
+    public EditorGameTextDocument(GameTextViewModel vm, WindowSettings? settings = null)
+        : base(vm, settings) { }
+}

--- a/src/Genie.App/Docking/GenieDockFactory.cs
+++ b/src/Genie.App/Docking/GenieDockFactory.cs
@@ -142,6 +142,23 @@ public class GenieDockFactory : Factory
         WireLastKnownPositionTracking();
     }
 
+    /// <summary>
+    /// Build the main Game document, picking the renderer once. With
+    /// <c>#config useeditorgamewindow off</c> (the default) this is the ordinary
+    /// <see cref="GameTextDocument"/> and nothing about the shipped path changes;
+    /// with it on, the <see cref="EditorGameTextDocument"/> subtype selects the
+    /// AvaloniaEdit template instead. Read once here rather than made
+    /// live-switchable — swapping renderers under a populated scrollback isn't
+    /// worth the complexity, and a restart is a fair price for an experiment.
+    /// </summary>
+    private GameTextDocument NewGameText(Genie.Core.Layout.WindowSettingsStore ws)
+    {
+        var settings = ws.Get("game-text");
+        return _vm.UseEditorGameWindow
+            ? new EditorGameTextDocument(_vm.GameText, settings)
+            : new GameTextDocument(_vm.GameText, settings);
+    }
+
     public override IRootDock CreateLayout()
     {
         // Wire the host-window locator. Dock.Avalonia's FloatDockable silently
@@ -171,7 +188,7 @@ public class GenieDockFactory : Factory
         // Hand each Tool its WindowSettings entry so Layout-tab edits repaint
         // live (font, foreground, background, title).
         var ws       = _vm.WindowSettings;
-        var gameText = new GameTextDocument(_vm.GameText,         ws.Get("game-text"));
+        var gameText = NewGameText(ws);
         var vitals   = new VitalsTool      (_vm.Vitals,           ws.Get("vitals"));
         var room     = new RoomTool        (_vm.Room,             ws.Get("room"));
         var backpack = new BackpackTool    (_vm.Inventory,        ws.Get("backpack"));
@@ -428,7 +445,7 @@ public class GenieDockFactory : Factory
         };
 
         var ws         = _vm.WindowSettings;
-        var gameText   = new GameTextDocument(_vm.GameText,           ws.Get("game-text"));
+        var gameText   = NewGameText(ws);
         var vitals     = new VitalsTool      (_vm.Vitals,             ws.Get("vitals"));
         var room       = new RoomTool        (_vm.Room,               ws.Get("room"));
         var backpack   = new BackpackTool    (_vm.Inventory,          ws.Get("backpack"));

--- a/src/Genie.App/Docking/WindowMenuBehavior.cs
+++ b/src/Genie.App/Docking/WindowMenuBehavior.cs
@@ -5,6 +5,7 @@ using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.VisualTree;
 using Genie.App.Controls;
 
@@ -45,6 +46,22 @@ public static class WindowMenuBehavior
     /// highlighted selection of whichever window the menu was opened on. Bound
     /// from XAML via <c>{x:Static docking:WindowMenuBehavior.CopySelectionCommand}</c>.</summary>
     public static ICommand CopySelectionCommand => _copy;
+
+    /// <summary>The Copy gesture the <b>editor</b> game window actually answers to.
+    /// That renderer inherits Copy/Select-All from AvaloniaEdit's own
+    /// <c>CommandBindings</c>, which match the platform gesture — Cmd+C on macOS —
+    /// rather than the Ctrl-only binding Genie 4 inherited from Windows. Labelling
+    /// it "Ctrl+C" there would advertise a shortcut that does nothing.
+    ///
+    /// <para>Deliberately <b>not</b> used by the legacy game window or the tool
+    /// windows: those handle Ctrl+C themselves (<c>SelectableLinesControl</c>'s key
+    /// handler) and really are Ctrl-bound on every platform, so their menus keep the
+    /// hardcoded label. Resolved per read rather than cached, since
+    /// <c>Application.Current</c> may not be up when this type is first touched.</para></summary>
+    public static KeyGesture CopySelectionGesture =>
+        new(Key.C,
+            Application.Current?.PlatformSettings?.HotkeyConfiguration.CommandModifiers
+            ?? KeyModifiers.Control);
 
     static WindowMenuBehavior()
     {
@@ -121,7 +138,22 @@ public static class WindowMenuBehavior
         var target = _currentTarget ?? PageScroll.CurrentTarget;
         if (target is null) { trace = "no target"; return null; }
 
-        // 1) Game window: cross-line selection owned by the LineSelection
+        // 1) Game window on the experimental AvaloniaEdit renderer: selection is
+        //    native to the editor, so ask it directly. Checked first because a
+        //    TextEditor's subtree contains neither a LineSelection-enabled
+        //    ItemsControl nor a SelectableTextBlock, and it never appears in the
+        //    legacy path — with the renderer flag off this branch cannot match, so
+        //    the shipped resolution order below is unchanged.
+        var editor = target.GetSelfAndVisualDescendants()
+                           .OfType<AvaloniaEdit.TextEditor>()
+                           .FirstOrDefault(e => e.SelectionLength > 0);
+        if (editor?.SelectedText is { Length: > 0 } editorSelection)
+        {
+            trace = $"target={target.GetType().Name} editor len={editorSelection.Length}";
+            return editorSelection;
+        }
+
+        // 2) Game window: cross-line selection owned by the LineSelection
         //    behavior (its rendered per-line SelectionStart/End survive a
         //    right-click; the behavior holds the authoritative range).
         var list = target.GetSelfAndVisualDescendants()
@@ -133,7 +165,7 @@ public static class WindowMenuBehavior
             return cross;
         }
 
-        // 2) Streams / other feeds — and the game window when its behavior
+        // 3) Streams / other feeds — and the game window when its behavior
         //    state is empty but rendered per-line selections remain. Aggregate
         //    EVERY selected block in visual (= line) order: taking just the
         //    first can silently truncate a visible multi-line highlight to a

--- a/src/Genie.App/Genie.App.csproj
+++ b/src/Genie.App/Genie.App.csproj
@@ -54,6 +54,13 @@
     <PackageReference Include="Avalonia.Desktop" Version="11.3.11" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.9" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.11" />
+    <!-- AvaloniaEdit backs the experimental editor-based Game window
+         (GenieConfig.UseEditorGameWindow, default off). Pinned to 11.4.1: it
+         floors at Avalonia >= 11.0.0 (no ceiling), so it resolves against our
+         11.3.11 pin without lifting it. 12.0.0 is NOT usable — it requires
+         Avalonia 12 exactly, which would drag the whole app plus the
+         Avalonia.ReactiveUI → ReactiveUI.Avalonia rename with it. -->
+    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.4.1" />
     <!-- Docking framework. The MVVM model variant (CommunityToolkit.Mvvm-based)
          is used instead of Dock.Model.ReactiveUI so the MDI document layout +
          skinned MDI window chrome are available WITHOUT forcing a ReactiveUI

--- a/src/Genie.App/Highlighting/DefaultHighlights.cs
+++ b/src/Genie.App/Highlighting/DefaultHighlights.cs
@@ -123,6 +123,12 @@ public static class DefaultHighlights
     private static IBrush MakeBrush(byte r, byte g, byte b)
         => new SolidColorBrush(Color.FromRgb(r, g, b));
 
+    /// <summary>The foreground a link span paints with — game-command blue or
+    /// external-URL green. Shared with the AvaloniaEdit renderer's link element
+    /// (<c>Controls.GameLinkGenerator</c>) so both paths colour <c>&lt;d cmd&gt;</c>
+    /// spans identically rather than each keeping their own copy of the palette.</summary>
+    internal static IBrush LinkForeground(bool isUrl) => isUrl ? UrlBrush : LinkBrush;
+
     // ── Tokenizer ─────────────────────────────────────────────────────────────
 
     // ── User-rule brush cache (parsed hex → IBrush) ──────────────────────────
@@ -198,6 +204,51 @@ public static class DefaultHighlights
     {
         if (string.IsNullOrEmpty(text))
             return new[] { new Run(string.Empty) };
+
+        var map = BuildStyleMap(text, links, boldSpans, presetSpans, window);
+        return EmitInlines(text, map);
+    }
+
+    /// <summary>
+    /// The per-character style layers <see cref="BuildStyleMap"/> resolves for a
+    /// line, before anything is committed to a particular renderer's element
+    /// type. <see cref="Tokenize"/> turns these into Avalonia <see cref="Inline"/>s
+    /// for the legacy per-line renderer; <c>Controls.GameTextColorizer</c> turns
+    /// the same maps into AvaloniaEdit <c>ChangeLinePart</c> runs. Both consume
+    /// one implementation of the highlight semantics — the maps ARE the contract.
+    ///
+    /// <para><see cref="Foreground"/> / <see cref="Background"/> / <see cref="Bold"/>
+    /// are all <c>text.Length</c> long and indexed by character position; a null
+    /// brush means "leave the renderer's default". <see cref="Links"/> is the
+    /// validated, start-ordered link span list — empty when links are disabled or
+    /// the line carries none. Characters inside a link span are NOT styled from
+    /// the maps: a link paints as a link (see <see cref="MakeLinkRun"/>), which is
+    /// why the emit pass skips those ranges.</para>
+    /// </summary>
+    public readonly record struct StyleMap(
+        IBrush?[] Foreground,
+        IBrush?[] Background,
+        bool[] Bold,
+        IReadOnlyList<LinkSpan> Links);
+
+    /// <summary>
+    /// Resolve every highlight layer for <paramref name="text"/> into per-character
+    /// maps. This is <see cref="Tokenize"/> minus the final emit pass — same rules,
+    /// same precedence, same side effects (highlight sound / TTS fire here, once per
+    /// matching line, exactly as before).
+    /// <para>Layer order, top to bottom: player names (#154, supreme) → user
+    /// highlight rules (#143) → built-in defaults → MonsterBold colour (#131) →
+    /// preset spans (base). Earlier layers win: each writes only where the channel
+    /// is still null.</para>
+    /// </summary>
+    public static StyleMap BuildStyleMap(string text,
+                                         IReadOnlyList<LinkSpan>? links = null,
+                                         IReadOnlyList<BoldSpan>? boldSpans = null,
+                                         IReadOnlyList<PresetSpan>? presetSpans = null,
+                                         string window = "main")
+    {
+        if (string.IsNullOrEmpty(text))
+            return new StyleMap([], [], [], []);
 
         // Build a per-char color map. Null = use the default TextBlock foreground.
         var brushes = new IBrush?[text.Length];
@@ -376,6 +427,24 @@ public static class DefaultHighlights
             sortedLinks.Sort((a, b) => a.Start.CompareTo(b.Start));
         }
 
+        return new StyleMap(brushes, backgrounds, bolds,
+                            (IReadOnlyList<LinkSpan>?)sortedLinks ?? []);
+    }
+
+    /// <summary>
+    /// The emit pass: walk <paramref name="map"/> and turn it into Avalonia
+    /// <see cref="Inline"/>s. Unchanged from the original <see cref="Tokenize"/>
+    /// tail — an empty <see cref="StyleMap.Links"/> behaves exactly as the old
+    /// null <c>sortedLinks</c> did (no link boundary before <c>text.Length</c>,
+    /// loop breaks after the first styled range).
+    /// </summary>
+    private static IReadOnlyList<Inline> EmitInlines(string text, StyleMap map)
+    {
+        var brushes     = map.Foreground;
+        var backgrounds = map.Background;
+        var bolds       = map.Bold;
+        var sortedLinks = map.Links;
+
         var inlines = new List<Inline>();
         int cursor = 0;
         int linkIdx = 0;
@@ -385,7 +454,7 @@ public static class DefaultHighlights
         // link itself, then continue past.
         while (cursor < text.Length)
         {
-            int nextLinkStart = sortedLinks is not null && linkIdx < sortedLinks.Count
+            int nextLinkStart = linkIdx < sortedLinks.Count
                 ? sortedLinks[linkIdx].Start
                 : text.Length;
 
@@ -393,7 +462,7 @@ public static class DefaultHighlights
             EmitStyledRange(text, brushes, backgrounds, bolds, cursor, nextLinkStart, inlines);
             cursor = nextLinkStart;
 
-            if (sortedLinks is null || linkIdx >= sortedLinks.Count) break;
+            if (linkIdx >= sortedLinks.Count) break;
 
             var link = sortedLinks[linkIdx++];
             var end  = link.Start + link.Length;

--- a/src/Genie.App/ViewModels/GameTextViewModel.cs
+++ b/src/Genie.App/ViewModels/GameTextViewModel.cs
@@ -449,8 +449,10 @@ public record TextLine(string Text, StreamColor Color,
     public bool IsEcho => Color == StreamColor.System;
 
     /// <summary>Monospaced font for <c>#echo mono</c> lines — falls back through
-    /// the chain if the first family is unavailable.</summary>
-    private static readonly FontFamily MonoFont = new("Consolas,Courier New,monospace");
+    /// the chain if the first family is unavailable. Internal (not private) so the
+    /// AvaloniaEdit renderer's colorizer can force the identical family for a mono
+    /// line instead of keeping a second copy of the fallback chain (#178).</summary>
+    internal static readonly FontFamily MonoFont = new("Consolas,Courier New,monospace");
 
     /// <summary>
     /// The line broken into styled <see cref="Inline"/> segments by
@@ -489,6 +491,15 @@ public record TextLine(string Text, StreamColor Color,
             return inlines;
         }
     }
+
+    /// <summary>The explicit <c>#echo</c> colour as a brush, or null when the line
+    /// carries none / it doesn't parse (caller keeps the default echo colour).
+    /// Same parse as the <see cref="Inlines"/> echo branch, exposed so the
+    /// AvaloniaEdit colorizer resolves it identically instead of re-deriving it.</summary>
+    internal IBrush? EchoForeground()
+        => EchoColor is not null && TryParseColor(EchoColor, out var c)
+            ? new SolidColorBrush(c)
+            : null;
 
     /// <summary>Parse a Genie 4 echo colour — a named colour (Yellow, DodgerBlue)
     /// or <c>#rrggbb</c> hex. Returns false (caller keeps the default colour) on

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -1029,6 +1029,14 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// <see cref="RunStartupConnectAsync"/> after the window is shown.</summary>
     public StartupOptions? Startup { get; }
 
+    /// <summary>Render the main Game window with AvaloniaEdit instead of the
+    /// per-line ItemsControl (<c>#config useeditorgamewindow</c>, default off).
+    /// Read once from settings.cfg in the constructor — before the dock layout is
+    /// built and long before GenieCore exists — and consumed by
+    /// <see cref="Genie.App.Docking.GenieDockFactory"/> when it creates the Game
+    /// document. Changing the setting needs a restart.</summary>
+    public bool UseEditorGameWindow { get; private set; }
+
     public MainWindowViewModel() : this(null) { }
 
     public MainWindowViewModel(StartupOptions? startup)
@@ -1056,6 +1064,27 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         _globalLayouts = new Settings.LayoutStore(layoutsDir);
 
         ErrorLog.Initialize(_configDir);
+
+        // ── Game-window renderer (experimental, default off) ───────────────
+        // The dock layout is built further down this constructor, and the
+        // renderer has to be chosen when the Game document is constructed — but
+        // GenieCore (and with it the live GenieConfig) is built lazily, on the
+        // first connect or command. So read settings.cfg once, here, through the
+        // real config parser rather than a bespoke one, so the value always
+        // agrees with `#config useeditorgamewindow`. The instance is discarded:
+        // it exists only to answer this single question.
+        try
+        {
+            var startupConfig = new Genie.Core.Config.GenieConfig(dir);
+            startupConfig.Load();
+            UseEditorGameWindow = startupConfig.UseEditorGameWindow;
+        }
+        catch (Exception ex)
+        {
+            // An unreadable/odd settings.cfg must never stop the window opening;
+            // fall back to the shipped renderer.
+            ErrorLog.Log("MainWindowViewModel.ReadRendererFlag", ex);
+        }
 
         // Announce the resolved data root as the first game-window line.
         // "Which folder is Genie actually reading?" is the first question in

--- a/src/Genie.Core/Config/GenieConfig.cs
+++ b/src/Genie.Core/Config/GenieConfig.cs
@@ -47,6 +47,12 @@ public sealed class GenieConfig
     /// was a WinForms paint-batch knob with no Avalonia equivalent). Clamped to
     /// [100, 100000] on set.</summary>
     public int ScrollbackLines { get; set; } = 2000;
+    /// <summary>Render the main Game window with AvaloniaEdit instead of the
+    /// per-line ItemsControl. Experimental; default off. The legacy renderer
+    /// stays the shipped path until parity is proven. Read ONCE, when the dock
+    /// layout is built — swapping renderers under a populated buffer is not
+    /// worth the complexity, so changing it needs a restart.</summary>
+    public bool UseEditorGameWindow { get; set; }
     public bool ShowSpellTimer { get; set; } = true;
     /// <summary>Built-in Experience tracker ($Skill.* / $TDPs globals + "Experience"
     /// dock panel). Default on. Was the external Plugin_EXPTrackerV5, now in Core.</summary>
@@ -567,6 +573,7 @@ public sealed class GenieConfig
         ("gags", EnableGags.ToString()),
         ("aliases", EnableAliases.ToString()),
         ("scrollbacklines", ScrollbackLines.ToString()),
+        ("useeditorgamewindow", UseEditorGameWindow.ToString()),
         ("spelltimer", ShowSpellTimer.ToString()),
         ("showexperience", ShowExperience.ToString()),
         ("experiencedensity", ExperienceDensity.ToString()),
@@ -678,7 +685,7 @@ public sealed class GenieConfig
     {
         ("Connection",       new[] { "classicconnect", "conndebug", "connectscript", "frontend", "reconnect" }),
         ("Lich",             new[] { "lichautolaunch", "lichruby", "lichpath", "lichargs", "lichstartpause", "lichdebug" }),
-        ("Window / Input",   new[] { "alwaysontop", "ignoreclosealert", "keepinputtext", "sizeinputtogame", "scrollbacklines" }),
+        ("Window / Input",   new[] { "alwaysontop", "ignoreclosealert", "keepinputtext", "sizeinputtogame", "scrollbacklines", "useeditorgamewindow" }),
         ("Display / Parser", new[] { "spelltimer", "showexperience", "experiencedensity", "experiencetrackgain", "experienceg4layout", "showtimetracker", "prompt", "promptbreak", "promptforce", "condensed", "monstercountignorelist", "parsegameonly", "roundtimeoffset", "showlinks", "showimages", "weblinksafety" }),
         ("Master Toggles",   new[] { "highlights", "triggers", "substitutes", "gags", "aliases" }),
         ("Scripting",        new[] { "scriptchar", "separatorchar", "commandchar", "mycommandchar", "triggeroninput", "scripttimeout", "maxgosubdepth", "abortdupescript", "ignorescriptwarnings", "scriptextension", "editor" }),
@@ -722,6 +729,7 @@ public sealed class GenieConfig
                 case "gags": EnableGags = ToBool(value); Notify(ConfigFieldUpdated.MasterToggles); break;
                 case "aliases": EnableAliases = ToBool(value); Notify(ConfigFieldUpdated.MasterToggles); break;
                 case "scrollbacklines": ScrollbackLines = Math.Clamp(UtilityCore.StringToInteger(value), 100, 100000); break;
+                case "useeditorgamewindow": UseEditorGameWindow = ToBool(value); break;
                 case "spelltimer": ShowSpellTimer = ToBool(value); Notify(ConfigFieldUpdated.Trackers); break;
                 case "showexperience": ShowExperience = ToBool(value); Notify(ConfigFieldUpdated.Trackers); break;
                 case "experiencedensity": ExperienceDensity = Math.Clamp(UtilityCore.StringToInteger(value), 0, 4); Notify(ConfigFieldUpdated.Trackers); break;

--- a/tests/Genie.Core.Tests/EditorGameWindowConfigTests.cs
+++ b/tests/Genie.Core.Tests/EditorGameWindowConfigTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using Genie.Core.Config;
+using Genie.Core.Runtime;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// <c>#config useeditorgamewindow</c> — the flag that swaps the main Game window
+/// onto the experimental AvaloniaEdit renderer. The setting is read once, when the
+/// dock layout is built, so the only contract Core owes is that it parses, persists
+/// and reports like every other boolean — and, above all, that it is <b>off</b>
+/// unless the user turned it on. The renderer swap itself lives in Genie.App and
+/// is not reachable from these tests.
+/// </summary>
+public class EditorGameWindowConfigTests
+{
+    private static GenieConfig NewConfig() =>
+        new(new LocalDirectoryService("Genie5Test", AppContext.BaseDirectory));
+
+    [Fact]
+    public void DefaultsOff()
+    {
+        // The acceptance bar for the whole feature: an untouched install renders
+        // through the legacy path.
+        Assert.False(NewConfig().UseEditorGameWindow);
+    }
+
+    [Theory]
+    [InlineData("True", true)]
+    [InlineData("on", true)]
+    [InlineData("False", false)]
+    [InlineData("off", false)]
+    [InlineData("", false)]        // unset / unparseable stays on the shipped renderer
+    [InlineData("banana", false)]
+    public void RoundTrips(string input, bool expected)
+    {
+        var cfg = NewConfig();
+        cfg.SetSetting("useeditorgamewindow", input, showException: false);
+        Assert.Equal(expected, cfg.UseEditorGameWindow);
+        Assert.Equal(expected.ToString(), cfg.GetSetting("useeditorgamewindow"));
+    }
+
+    [Fact]
+    public void IsListedForConfigDisplay()
+    {
+        // ToConfigPairs drives settings.cfg persistence; ConfigCategories drives the
+        // `#config` listing. A key in one and not the other is how settings go
+        // missing from the UI, so assert both.
+        Assert.Contains(NewConfig().ToConfigPairs(), p => p.Key == "useeditorgamewindow");
+        Assert.Contains(GenieConfig.ConfigCategories.SelectMany(c => c.Keys), k => k == "useeditorgamewindow");
+    }
+}

--- a/tests/Genie.Core.Tests/UrlLinkSpanTests.cs
+++ b/tests/Genie.Core.Tests/UrlLinkSpanTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Genie.Core.Events;
+using Genie.Core.Parser;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// External <c>&lt;a href='URL'&gt;label&lt;/a&gt;</c> links, fed verbatim from a
+/// live capture of DR's login "Helpful Information and Resources" block — the
+/// only place the game sends them. Until this capture existed the URL path had
+/// no sample at all, so <c>IsUrl=true</c> spans were untested end to end and
+/// the AvaloniaEdit game-window work had nothing to compare against.
+/// </summary>
+public class UrlLinkSpanTests
+{
+    private static List<TextEvent> Feed(string raw)
+    {
+        var parser = new DrXmlParser(NullLogger<DrXmlParser>.Instance);
+        var events = new List<TextEvent>();
+        using var _ = parser.GameEvents.Subscribe(new Collector(events));
+        parser.Feed(raw);
+        return events;
+    }
+
+    private sealed class Collector : IObserver<GameEvent>
+    {
+        private readonly List<TextEvent> _sink;
+        public Collector(List<TextEvent> sink) => _sink = sink;
+        public void OnNext(GameEvent e) { if (e is TextEvent t) _sink.Add(t); }
+        public void OnError(Exception error) { }
+        public void OnCompleted() { }
+    }
+
+    private static TextEvent Line(IEnumerable<TextEvent> events, string contains)
+        => events.First(e => e.Text.Contains(contains));
+
+    // Verbatim from raw_xml_capture_link.stream: the two "Websites:" rows, each
+    // carrying three <a href> links separated by layout whitespace, plus the
+    // <d> verb row below them for contrast.
+    private const string ResourceBlock =
+        "<pushBold/>Websites:\n" +
+        "<popBold/>     <a href='https://store.play.net/store/purchase/dr'>Simucoin Store</a>    <a href='http://forums.play.net/calendar?game=dragonrealms'>Events Calendar</a>     <a href='https://elanthipedia.play.net/Category:New_player_guides'>Starter Guides</a>\n" +
+        "       <a href='https://elanthipedia.play.net/'>Elanthipedia</a>           <a href='http://www.olwydd.org'>Olwydd's</a>               <a href='https://elanthipedia.play.net/Ranik_Maps'>Maps</a>\n" +
+        "\n" +
+        "<pushBold/>Useful Verbs:\n" +
+        "<popBold/>  <d>SIMUCOINS</d>......Shows your current Simucoin balance and allows you to deliver purchased items.\n";
+
+    [Fact]
+    public void AnchorTag_CommitsUrlLinkSpan_OverItsLabel()
+    {
+        var line = Line(Feed(ResourceBlock), "Simucoin Store");
+
+        Assert.NotNull(line.Links);
+        var span = line.Links!.First();
+        Assert.True(span.IsUrl);
+        Assert.Equal("https://store.play.net/store/purchase/dr", span.Command);
+        Assert.Equal("Simucoin Store", line.Text.Substring(span.Start, span.Length));
+
+        // Routing: the resources block arrives inline on the main game stream
+        // (no <pushStream> in the capture), so the spans land on the window that
+        // actually renders them. Anywhere else they'd parse fine and be dead.
+        Assert.Equal("main", line.Stream);
+    }
+
+    [Fact]
+    public void HrefAndTags_DoNotLeakIntoVisibleText()
+    {
+        var line = Line(Feed(ResourceBlock), "Simucoin Store");
+
+        Assert.DoesNotContain("href", line.Text);
+        Assert.DoesNotContain("<a", line.Text);
+        Assert.DoesNotContain("store.play.net", line.Text);
+    }
+
+    [Fact]
+    public void ThreeLinksOnOneLine_EachGetsItsOwnSpan()
+    {
+        var line = Line(Feed(ResourceBlock), "Events Calendar");
+
+        Assert.Equal(3, line.Links!.Count);
+        Assert.All(line.Links!, s => Assert.True(s.IsUrl));
+
+        // Spans are disjoint, in reading order, and each covers exactly its label.
+        var byStart = line.Links!.OrderBy(s => s.Start).ToList();
+        Assert.Equal(
+            new[] { "Simucoin Store", "Events Calendar", "Starter Guides" },
+            byStart.Select(s => line.Text.Substring(s.Start, s.Length)));
+        Assert.Equal(
+            new[]
+            {
+                "https://store.play.net/store/purchase/dr",
+                "http://forums.play.net/calendar?game=dragonrealms",
+                "https://elanthipedia.play.net/Category:New_player_guides",
+            },
+            byStart.Select(s => s.Command));
+        for (var i = 1; i < byStart.Count; i++)
+            Assert.True(byStart[i].Start >= byStart[i - 1].Start + byStart[i - 1].Length);
+    }
+
+    [Fact]
+    public void QueryStringAndTrailingSlashUrls_SurviveIntact()
+    {
+        var events = Feed(ResourceBlock);
+
+        // '?' and '=' in the href must not be mangled or truncated.
+        var calendar = Line(events, "Events Calendar").Links!
+            .Single(s => s.Command.Contains("forums.play.net"));
+        Assert.Equal("http://forums.play.net/calendar?game=dragonrealms", calendar.Command);
+
+        // A bare-host URL keeps its trailing slash.
+        var elanthipedia = Line(events, "Elanthipedia").Links!
+            .Single(s => s.Command == "https://elanthipedia.play.net/");
+        Assert.Equal("Elanthipedia",
+            Line(events, "Elanthipedia").Text.Substring(elanthipedia.Start, elanthipedia.Length));
+    }
+
+    [Fact]
+    public void ApostropheInLabel_DoesNotTruncateTheSpan()
+    {
+        // "Olwydd's" — the label contains the quote char used for href delimiting.
+        var line = Line(Feed(ResourceBlock), "Olwydd");
+        var span = line.Links!.Single(s => s.Command == "http://www.olwydd.org");
+        Assert.Equal("Olwydd's", line.Text.Substring(span.Start, span.Length));
+    }
+
+    [Fact]
+    public void GameLinkInSameBlock_StaysNonUrl()
+    {
+        // The contrast case: <d> in the same block must NOT be flagged IsUrl,
+        // or clicking a game command would open a browser.
+        var line = Line(Feed(ResourceBlock), "SIMUCOINS");
+        var span = line.Links!.Single();
+        Assert.False(span.IsUrl);
+        Assert.Equal("SIMUCOINS", span.Command);
+    }
+}


### PR DESCRIPTION
Renders the main Game window through `AvaloniaEdit.TextEditor` instead of the current non-virtualising `ItemsControl`, behind `#config useeditorgamewindow` — **default off**.

Opened originally as a proof of concept. It has since been through a full live validation pass (all 16 acceptance items), the two behaviour deltas that were open have been fixed and re-verified live, and the PoC planning artifacts have been removed. I'd like to land it.

**The merge argument is that nothing changes for anyone until they opt in.** The flag defaults off, the legacy renderer is untouched, and `App.axaml` has zero deleted lines against `main` across the whole branch. What merging buys is getting this off a long-lived branch so the 11 stream windows — where the same win repeats — can follow.

## Why

This started as a bug fix. The Game window's "Pause Scrolling" toggle didn't actually pause — incoming text still dragged the view, and scrolling up manually didn't help either.

The cause turned out not to be the pause logic, which is correct. It's that the text windows render each line as its own control in a **non-virtualising `ItemsControl`**. Once the scrollback cap is reached, every new line drops one off the top, and removing that line shifts everything above the viewport upward. Nothing touches `ScrollViewer.Offset`, but the text moves — which reads exactly like the window scrolling itself.

Investigating that surfaced a bigger problem: the per-line design has costs beyond this one bug.

## Benefits

**How these were measured.** Before any of this was written, I built a throwaway headless harness — Avalonia 11.3.11 + Skia, no window — that stood up each renderer, pushed synthetic lines through it to a given scrollback depth, forced a full GC, and read retained managed heap. "Retained" is post-GC steady state, not peak. The harness was thrown away with its session, so treat the table as reported-not-reproducible; the in-app number below you can re-run.

**Memory — the main reason.** The per-line design retains **~8.6 KB per buffered line**, scaling linearly with scrollback. The editor is flat:

| scrollback depth | ItemsControl (today) | AvaloniaEdit |
| --- | --- | --- |
| 500 | 6.9 MB | 0.1 MB |
| 2 000 | 21.6 MB | 0.1 MB |
| 8 000 | 79.2 MB | 0.1 MB |
| 20 000 | 172.3 MB | 0.1 MB |

Across the 12 windows the app actually opens (main + 11 streams, 7 500 lines total): **71.9 MB retained / 255.6 MB heap peak vs ~0 MB / 22.8 MB**, and 3.7× the build time. That isn't tunable — it's what a live control per line costs.

**Measured in the real app since:** `dotnet-gcdump` at the 2000-line cap gives **legacy 32 MB vs editor 22 MB — 10 MB saved on the Game window alone**, with the other 11 windows still on the legacy renderer in both runs. Smaller than the bench figure, for three reasons worth knowing:

1. **The editor mirrors rather than owns.** `GameTextViewModel.Lines` is still the source of truth, so every `TextLine` is retained exactly as in legacy — plus a `GameLineEntry` and a cached `StyleMap` per line. The harness's editor host had no parallel collection, which is why it measured near zero. What's saved is the ~8.6 KB/line of **live controls**, not the line data.
2. **The fill was `#echo`, which distorts both paths in opposite directions.** Echo lines short-circuit legacy to a single `Run` (understating legacy, which normally builds several per line) *and* skip `BuildStyleMap` entirely (understating the editor's cache). Real game text raises both; legacy should rise faster, but that's reasoning, not measurement. A fill from real game output would tighten the figure — it won't change the conclusion.
3. **Only 1 of 12 windows is converted**, so 10 MB is the per-window saving, with the same win available 11 more times.

**The scrolling bug becomes a real fix.** AvaloniaEdit doesn't anchor scroll either, so trimming shifts the viewport the same way (measured: **−1755.41 px** for 100 lines, exactly 100 × the line height). But it exposes an exact fix: subtract the height that vanished above, read from the same `HeightTree` that produced the offset. That cancels the drift to **−0.00 px**, word wrap on or off. On the `ItemsControl` the equivalent compensation needs per-container height guesswork and doesn't come out exact.

One boundary case is deliberate: once trimming reaches the lines actually on screen, the view moves again. That's intended — "paused" means stop scrolling, and content falling out of the buffer has to go somewhere. I'd rather not engineer around it.

**Native cross-line selection.** Selection can span the whole buffer for free. Today that requires `SelectableLinesControl.cs` — 402 lines of hit-test-point-to-(line,char) machinery that exists purely because Avalonia's text selection can't span controls. It stays for the legacy path, but would eventually be deleted.

**Not speed.** Both renderers exceed DR's line rate by one to two orders of magnitude, and the throughput measurements were too noisy to rank them. Please don't read this as a performance change.

## What's here

- AvaloniaEdit 11.4.1 — Avalonia stays pinned at **11.3.11**, not lifted
- `DefaultHighlights` **split, not rewritten**: `BuildStyleMap` yields the per-char foreground/background/bold maps it already built internally; the old emit tail moved verbatim into a private `EmitInlines`. Both renderers share one set of highlight rules
- `GameTextColorizer` (highlights, presets, names, monster-bold, per-line mono), `GameLinkGenerator` (`<d cmd>` and `<a href>` links), `GameTextEditor` (document mirroring, trim compensation, auto-follow/pause, Find, PageScroll), `GameTextArea` (input pass-through)
- Config flag is read once at window construction — not live-switchable by design
- Build clean (0 warnings), tests **764 passed / 0 failed**

**The one place this touches shared code** is the `DefaultHighlights` split, which both renderers now run through. That's the part worth reviewing closely — everything else is new files reachable only with the flag on.

## Flag-off parity

Verified, not assumed:

- `git diff main -- src/Genie.App/App.axaml` has **zero deleted lines** across the whole branch
- `SelectableLinesControl`, `AutoScrollBehavior`, `PageScroll`, `FindInWindow`, `InlinesBehavior` are unmodified
- The renderer is chosen by **subtype** — `EditorGameTextDocument : GameTextDocument` with its own DataTemplate ahead of the base one — rather than by toggling `IsVisible`. That distinction matters: an `IsVisible`-hidden legacy `ScrollViewer` would still register as `PageScroll.IsDefaultTarget`, aiming PageUp/PageDown and Ctrl+F at an invisible control
- Confirmed visually in a live session as well: with the flag off, highlights, presets, names, monster-bold, links and mono blocks all render as before

## Validation

**All 16 acceptance items confirmed live:** colours and bold; monospace `<output>` column alignment (#178); `#echo` colour and mono; bare `<d>` links (room exits) *and* `<d cmd>` links where the command differs from the display text (inventory, including nested-container commands); external `<a href>` URLs; pause holding past the 2000-line cap; no drift while scrolled up; cross-line drag-select and copy; ↓ Bottom, PageUp/PageDown, Find, Copy, Copy All, Save As, Clear, timestamps; and the flag-off visual pass above.

Selection across a trim matches the legacy window — trimmed text leaves the selection and Copy yields the remainder. Presets and name highlights weren't exercised (none configured), but they write into the same per-char brush map as colours and bold, so the validated path is theirs. "Name List Only" is not applicable: it filters at add-time in `GameTextViewModel`, so filtered lines never reach the renderer.

### The two open deltas, now fixed

**Links dispatched on press, so a drag starting on link text navigated instead of selecting.** AvaloniaEdit's element model only exposes `OnPointerPressed` — there is no release hook, and elements are rebuilt on every redraw. The press now merely *arms* the click and leaves `e.Handled` false so `TextArea`'s own selection machinery runs; a new `LinkClickArbiter` watches the `TextArea` for the release and dispatches only if the pointer never moved past 3 px. Same threshold and same latch-once semantics as `SelectableLinesControl` — a drag out and back is still a drag.

**The menu advertised Ctrl+C where the editor answers the platform gesture.** `WindowMenuBehavior.CopySelectionGesture` now resolves the modifier from `PlatformSettings.HotkeyConfiguration.CommandModifiers`, so the label follows the platform (Cmd+C on macOS). Scoped to the editor template only — the legacy and tool-window menus implement Ctrl+C themselves and really are Ctrl-bound everywhere, so their labels stay hardcoded. Find is genuinely Ctrl+F on both renderers, so that label was never wrong.

Both confirmed live: a drag starting on link text now begins a selection instead of firing the link, a plain click still fires it, and the menu shows the ⌘ glyph on macOS.

## Deliberately not in scope

- **Only the Game window is converted.** The 11 stream tools keep the legacy renderer and the original pause/trim bug. That's the natural follow-up, and where the memory win repeats
- **The `DefaultHighlights` refactor is unguarded.** No test covers `Tokenize`/`BuildStyleMap`, before or after — coverage was already absent on `main`. Verified by reading the diff: of 9 deleted lines across the whole branch, 2 are in this file, both null-guard simplifications made safe by passing `sortedLinks ?? []`. No rule was rewritten. Closing it properly needs a `tests/Genie.App.Tests` with `Avalonia.Headless` — `Genie.App` is `SelfContained=true`, so a plain `ProjectReference` hits NETSDK1151, and `MakeLinkRun` constructs a `Cursor`, which needs a platform
- **No URL hover tooltip.** Legacy sets one via `ToolTip.SetTip` in `MakeLinkRun`; porting it needs `PointerHover` plus offset→link hit-testing. URLs still render in the distinct green

## Notes for whoever picks this up next

- Don't delete `SelectableLinesControl.cs` while the legacy path ships
- Don't upgrade to AvaloniaEdit 12.x without a full Avalonia 12 migration — it pins `Avalonia >= 12.0.0`, and `Avalonia.ReactiveUI` is renamed to `ReactiveUI.Avalonia` in that world
- Read and write scroll offset via `(IScrollable)TextView`, **not** `TextEditor.VerticalOffset` / `ScrollToVerticalOffset` — the latter didn't survive a forced layout pass and silently left the view at line 1

The `<a href>` parser coverage that came out of this is also up separately as #212 against `main`, since it's plain `Genie.Core` coverage with no dependency on this work.

