### PR TITLE
fix(experience): track live exp pulses under BRIEFEXP ON

### DIFF
--- a/src/Genie.Core/Extensions/Builtin/ExperienceExtension.cs
+++ b/src/Genie.Core/Extensions/Builtin/ExperienceExtension.cs
@@ -15,6 +15,11 @@ namespace Genie.Core.Extensions.Builtin;
 ///
 /// <para>Skill names are accepted dynamically from the stream; the 35 learning-state
 /// names are hardcoded (they effectively never change in DR).</para>
+///
+/// <para>Both live-pulse shapes are handled: DR's per-character <c>BRIEFEXP</c>
+/// setting swaps the mindstate word for a <c>[ n/34]</c> number, so a character
+/// with BRIEFEXP ON emits <c>Stealth:  550 73% [ 5/34]</c> where another emits
+/// <c>Stealth:  550 73% dabbling</c>.</para>
 /// </summary>
 public sealed class ExperienceExtension : IGameExtension
 {
@@ -88,6 +93,16 @@ public sealed class ExperienceExtension : IGameExtension
     private static readonly Regex SkillLineRe = new(
         @"([A-Z][A-Za-z '\-]+?):\s+(\d+)\s+(\d+)%\s+([a-z][a-z ]*?)(?=\s*\(|\s{2,}|$)",
         RegexOptions.Compiled);
+
+    /// <summary>BRIEFEXP-ON form of the live pulse: the mindstate arrives as
+    /// <c>[ 5/34]</c> instead of the word ("dabbling"). <c>BRIEFEXP</c> is a
+    /// per-character DR setting, so one character's Experience window would go
+    /// stale between manual <c>exp</c> dumps while another's updated live — the
+    /// full-dump text table always spells the mindstate out, which is why the
+    /// manual path kept working. Matches Lich's <c>BriefExpOn</c> pattern.</summary>
+    private static readonly Regex SkillLineBriefRe = new(
+        @"([A-Z][A-Za-z '\-]*?):\s+(\d+)\s+(\d+)%\s*\[\s*(\d+)\s*/\s*34\s*\]",
+        RegexOptions.Compiled);
     private static readonly Regex TdpRe = new(
         @"Time Development Points:\s*(\d+)", RegexOptions.Compiled);
 
@@ -146,7 +161,12 @@ public sealed class ExperienceExtension : IGameExtension
             _host.Globals[$"{Var(sub)}.LearningRate"] = "0";
             return;
         }
-        ApplyLine(inner);
+        // The component id always carries the FULL skill name; the body doesn't.
+        // Under BRIEFEXP ON, DR abbreviates it there ("IM", "Aug", "Outdoors"),
+        // which would register a second, duplicate entry alongside the full-named
+        // one the `exp` dump produces. Lich sidesteps this the same way, reading
+        // the name from <d cmd='skill Inner Magic'> rather than the text.
+        ApplyLine(inner, sub);
     }
 
     public void OnGameLine(string line)
@@ -154,8 +174,17 @@ public sealed class ExperienceExtension : IGameExtension
         // The `exp`/`experience` full dump arrives as plain text (two skills per
         // line). The skill regex is specific enough to be safe across streams.
         if (line.IndexOf('%') >= 0 && line.IndexOf(':') >= 0)
-            foreach (Match m in SkillLineRe.Matches(line))
-                Apply(m.Groups[1].Value.Trim(), m.Groups[2].Value, m.Groups[3].Value, m.Groups[4].Value);
+        {
+            // The dump spells the mindstate out even under BRIEFEXP ON, but a
+            // frontend-echoed pulse can reach this path too — accept both shapes.
+            var brief = SkillLineBriefRe.Matches(line);
+            if (brief.Count > 0)
+                foreach (Match m in brief)
+                    ApplyBrief(m.Groups[1].Value.Trim(), m.Groups[2].Value, m.Groups[3].Value, m.Groups[4].Value);
+            else
+                foreach (Match m in SkillLineRe.Matches(line))
+                    Apply(m.Groups[1].Value.Trim(), m.Groups[2].Value, m.Groups[3].Value, m.Groups[4].Value);
+        }
 
         var tdp = TdpRe.Match(line);
         if (tdp.Success)
@@ -193,19 +222,46 @@ public sealed class ExperienceExtension : IGameExtension
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
-    private void ApplyLine(string line)
+    /// <summary>Parse one pulse body. <paramref name="skillName"/> overrides the name
+    /// the regex reads out of the text — callers that know the canonical name (the
+    /// component id) must pass it, because BRIEFEXP ON abbreviates the name in the
+    /// body.</summary>
+    private void ApplyLine(string line, string? skillName = null)
     {
+        // BRIEFEXP ON first: its "[ n/34]" tail can't match the word form, but
+        // checking the numeric shape up front keeps the two mutually exclusive.
+        var b = SkillLineBriefRe.Match(line);
+        if (b.Success)
+        {
+            ApplyBrief(skillName ?? b.Groups[1].Value.Trim(), b.Groups[2].Value, b.Groups[3].Value, b.Groups[4].Value);
+            return;
+        }
         var m = SkillLineRe.Match(line);
         if (m.Success)
-            Apply(m.Groups[1].Value.Trim(), m.Groups[2].Value, m.Groups[3].Value, m.Groups[4].Value);
+            Apply(skillName ?? m.Groups[1].Value.Trim(), m.Groups[2].Value, m.Groups[3].Value, m.Groups[4].Value);
     }
 
     private void Apply(string name, string rankText, string pctText, string mindstateText)
     {
         if (!int.TryParse(rankText, out var rank) || !int.TryParse(pctText, out var pct)) return;
         mindstateText = mindstateText.Trim();
-        var mind = MindstateValue(mindstateText);
+        Apply(name, rank, pct, MindstateValue(mindstateText), mindstateText);
+    }
 
+    /// <summary>BRIEFEXP-ON variant: the mindstate is already the 0–34 number, so
+    /// the learning-rate word is looked up rather than parsed. Out-of-range values
+    /// are clamped — the globals and the renderer both index
+    /// <see cref="MindStates"/> directly.</summary>
+    private void ApplyBrief(string name, string rankText, string pctText, string mindText)
+    {
+        if (!int.TryParse(rankText, out var rank) || !int.TryParse(pctText, out var pct) ||
+            !int.TryParse(mindText, out var mind)) return;
+        mind = Math.Clamp(mind, 0, MindStates.Length - 1);
+        Apply(name, rank, pct, mind, MindStates[mind]);
+    }
+
+    private void Apply(string name, int rank, int pct, int mind, string mindstateText)
+    {
         var v = Var(name);
         _host.Globals[$"{v}.Ranks"]            = rank.ToString();
         _host.Globals[$"{v}.LearningRate"]     = mind.ToString();

--- a/tests/Genie.Core.Tests/ExperienceDensityTests.cs
+++ b/tests/Genie.Core.Tests/ExperienceDensityTests.cs
@@ -219,4 +219,123 @@ public class ExperienceDensityTests
         // Baseline re-captured after the reset, so the session total starts at zero.
         Assert.Contains("Total gained: +0.00 ranks", host.Window);
     }
+
+    // ── BRIEFEXP ON: numeric "[ n/34]" mindstate in the live pulse ─────────────
+    // DR's per-character BRIEFEXP setting swaps the mindstate word for a number, so
+    // the Experience window went stale between manual `exp` dumps on any character
+    // that had it on — the dump always spells the mindstate out, which is why the
+    // manual path kept working while the live pulses were silently dropped.
+
+    [Fact]
+    public void OnGameEvent_BriefExpOn_UpdatesWindow()
+    {
+        var host = new FakeHost();
+        var ext  = new ExperienceExtension();
+        ext.Initialize(host);
+
+        ext.OnGameEvent(Exp("Stealth", "550 73% [ 5/34]"));   // BRIEFEXP ON pulse
+        ext.OnPrompt();
+
+        Assert.Contains("Learning Skills: 1", host.Window);
+        Assert.Contains("Stealth", host.Window);
+        // Rendered through the same table as the word form: mindstate 5 = "thinking".
+        Assert.Contains("550 73%  thinking (5/34)", host.Window);
+    }
+
+    [Fact]
+    public void OnGameEvent_BriefExpOn_PublishesSameGlobalsAsWordForm()
+    {
+        var host = new FakeHost();
+        var ext  = new ExperienceExtension();
+        ext.Initialize(host);
+
+        ext.OnGameEvent(Exp("Small Edged", "142 71% [13/34]"));
+
+        Assert.Equal("142", host.Globals["Small_Edged.Ranks"]);
+        Assert.Equal("13",  host.Globals["Small_Edged.LearningRate"]);
+        Assert.Equal("examining", host.Globals["Small_Edged.LearningRateName"]);
+    }
+
+    [Fact]
+    public void OnGameEvent_BriefExpOn_RaisesSkillUpdated()
+    {
+        var host = new FakeHost();
+        var ext  = new ExperienceExtension();
+        ext.Initialize(host);
+
+        (string Name, int Rank, int Pct, int Mind)? seen = null;
+        ext.SkillUpdated += (n, r, p, m) => seen = (n, r, p, m);
+
+        ext.OnGameEvent(Exp("Thievery", "1750 0% [34/34]"));   // mind lock, top of range
+
+        Assert.Equal(("Thievery", 1750, 0, 34), seen);
+    }
+
+    [Fact]
+    public void OnGameEvent_BriefExpOn_UsesComponentIdNameNotTheAbbreviation()
+    {
+        var host = new FakeHost();
+        var ext  = new ExperienceExtension();
+        ext.Initialize(host);
+
+        // BRIEFEXP ON abbreviates the name in the body; the id keeps the full one.
+        ext.OnGameEvent(new ComponentEvent("exp Inner Magic", "IM: 112 20% [32/34]"));
+        ext.OnGameEvent(new ComponentEvent("exp Outdoorsmanship", "Outdoors: 243 76% [22/34]"));
+        ext.OnPrompt();
+
+        Assert.Contains("Inner Magic", host.Window);
+        Assert.Contains("Outdoorsmanship", host.Window);
+        Assert.Equal("32", host.Globals["Inner_Magic.LearningRate"]);
+        Assert.DoesNotContain("IM ", host.Window);
+        Assert.False(host.Globals.ContainsKey("IM.Ranks"));
+    }
+
+    [Fact]
+    public void OnGameEvent_BriefExpOn_DoesNotDuplicateSkillsSeenInTheDump()
+    {
+        var host = new FakeHost();
+        var ext  = new ExperienceExtension();
+        ext.Initialize(host);
+
+        // `exp` dump (full names) then a live brief pulse (abbreviated body) for the
+        // same skills — one row each, not two.
+        ext.OnGameLine("      Inner Magic:  112 20% clear        Locksmithing:  135 72% dabbling");
+        ext.OnGameEvent(new ComponentEvent("exp Inner Magic", "IM: 112 20% [32/34]"));
+        ext.OnGameEvent(new ComponentEvent("exp Locksmithing", "Locks: 135 72% [ 1/34]"));
+        ext.OnPrompt();
+
+        Assert.Contains("Learning Skills: 2", host.Window);
+    }
+
+    [Fact]
+    public void OnGameLine_BriefExpOn_IsNotMisreadAsWordForm()
+    {
+        var host = new FakeHost();
+        var ext  = new ExperienceExtension();
+        ext.Initialize(host);
+
+        // A frontend-echoed brief pulse arriving as plain text must parse as the
+        // numeric form, not fall through to the word regex.
+        ext.OnGameLine("Athletics:  300 22% [ 9/34]");
+        ext.OnPrompt();
+
+        Assert.Equal("9", host.Globals["Athletics.LearningRate"]);
+        Assert.Contains("concentrating", host.Window);
+    }
+
+    [Fact]
+    public void OnGameLine_WordForm_StillParsesUnderTheBriefCheck()
+    {
+        var host = new FakeHost();
+        var ext  = new ExperienceExtension();
+        ext.Initialize(host);
+
+        // The `exp` dump packs two skills per line and spells the mindstate out.
+        ext.OnGameLine("      Attunement:  550 73% dabbling        Stealth:  142 71% examining");
+        ext.OnPrompt();
+
+        Assert.Contains("Learning Skills: 2", host.Window);
+        Assert.Equal("1",  host.Globals["Attunement.LearningRate"]);
+        Assert.Equal("13", host.Globals["Stealth.LearningRate"]);
+    }
 }


### PR DESCRIPTION
## Problem

On some characters the Experience window never updated from the live game feed — a manual `exp` would populate it, but the periodic per-skill pulses did nothing. It looked profile- or guild-specific; it isn't. The variable is DR's per-character **`BRIEFEXP`** setting (`TOGGLE BRIEFEXP`), which changes the shape of the live push:

```xml
<!-- BRIEFEXP OFF -->
<component id='exp Stealth'>Stealth:  550 73% dabbling</component>

<!-- BRIEFEXP ON -->
<component id='exp Inner Magic'><d cmd='skill Inner Magic'>IM:  112 20% [32/34]</d></component>
```

`SkillLineRe` required a lowercase mindstate **word** after the percent:

```
...(\d+)%\s+([a-z][a-z ]*?)(?=\s*\(|\s{2,}|$)
```

`[32/34]` starts with `[`, so every pulse from a BRIEFEXP-ON character failed to match and was silently dropped. `_dirty` was never set, `OnPrompt` never re-rendered, and the panel sat stale until the next manual `exp` — the full dump spells the mindstate out regardless of the setting, which is why that path kept working and masked the bug.

Same drop had two knock-on effects:

- `$Skill.*.Ranks` / `$Skill.*.LearningRate` went stale for scripts between manual dumps.
- `SkillUpdated` never fired, so the Analytics skill-history recorder logged nothing for those characters.

`GameStateEngine`'s `SkillStore` was unaffected — its regex ignores the tail — which is why the pathfinder looked healthy.

Lich carries both patterns explicitly (`BriefExpOn` / `BriefExpOff` in `drinfomon/drparser.rb`); Genie only had the OFF form.

## Change

- Add `SkillLineBriefRe` for the `[ n/34]` form and split `Apply` so the numeric mindstate is used directly, with the learning-rate word looked up from the canonical `MindStates` table (clamped 0–34). Both entry points try the brief shape first; the two shapes can't cross-match, so the word form is untouched.
- Take the skill name from the **component id** rather than the body text. BRIEFEXP ON abbreviates the name in the body (`IM`, `Aug`, `Outdoors`, `Scholar`, `Locks`) while the id keeps the full name — parsing the body registered a second, duplicate row beside the full-named one from the dump. Lich avoids this the same way, reading the name from the `<d cmd='skill …'>` attribute. This also fixes the clear-pulse path, which already keyed off the id and so could never remove an abbreviated entry.

No config, no new surface — the tracker just understands both shapes DR sends.

## Tests

Seven cases added to `ExperienceDensityTests`: brief-form render, globals parity with the word form, `SkillUpdated` at the top of the range (mind lock, `[34/34]`), component-id name precedence over the abbreviation, no duplicate rows when a dump and a brief pulse describe the same skill, and word-form non-regression through the new brief-first ordering.

`dotnet test` — 728 passed, 0 failed.

## Test plan

- [x] Character with `BRIEFEXP ON`: Experience window updates from live pulses without typing `exp`
- [x] Character with `BRIEFEXP OFF`: unchanged behaviour
- [x] Skills with abbreviated names (Inner Magic, Augmentation, Outdoorsmanship, Scholarship, Locksmithing) show one row each under the full name
- [x] Learning-rate words match what the game reports (`[32/34]` renders as `enthralled`)
- [x] Toggling `BRIEFEXP` mid-session keeps the window updating
