### PR TITLE
fix(lich): resolve the lichdebug temp directory from the args Lich actually got

### DIFF
--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -936,6 +936,15 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// character/port switch that needs a stop-then-relaunch before connect.</summary>
     private string? _ownedLichLaunchKey;
 
+    /// <summary>The <em>expanded</em> lichargs the owned Lich was actually launched with
+    /// ({character}/{port} already filled). The debug-log tailer resolves <c>--temp=</c>
+    /// from this, not from the live <c>#config lichargs</c> template: a template like
+    /// <c>--temp=temp-{character}</c> would otherwise send the tailer to a literal
+    /// <c>temp-{character}</c> directory, and lichdebug would look like it does nothing.
+    /// It also pins the tail to where the running process writes when the template is
+    /// edited mid-session.</summary>
+    private string? _ownedLichArguments;
+
     /// <summary>Live-tails the owned Lich's <c>temp/debug-*.log</c> into the game window
     /// when <c>#config lichdebug</c> is on. Null when not tailing.</summary>
     private Genie.Core.Connection.LichDebugLogTailer? _lichDebugTailer;
@@ -3554,6 +3563,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                     _ownedLichProcessId = null;
                     _ownedLichProcessStartUtc = null;
                     _ownedLichLaunchKey = null;
+                    _ownedLichArguments = null;
                 }
 
                 // EnsureRunningAsync uses ConfigureAwait(false); marshal progress onto
@@ -3578,6 +3588,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                     _ownedLichProcessId = pid;
                     _ownedLichProcessStartUtc = lich.ProcessStartTimeUtc ?? DateTime.UtcNow;
                     _ownedLichLaunchKey = launchKey;
+                    _ownedLichArguments = lichArgs;   // expanded — the tailer resolves --temp= from these
                     SyncOwnedLichDebugTail();
                 }
             }
@@ -3599,6 +3610,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         _ownedLichProcessId = null;
         _ownedLichProcessStartUtc = null;
         _ownedLichLaunchKey = null;
+        _ownedLichArguments = null;
         Genie.Core.Connection.LichLauncher.TryStop(pid, out var message);
         if (!string.IsNullOrEmpty(message))
             GameText.AddSystemLine(message);
@@ -3621,13 +3633,17 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                         ?? DateTime.UtcNow;
         _ownedLichProcessStartUtc ??= notBefore;
 
-        // lichargs can be edited after the owned Lich was launched, so a malformed
-        // value can reach us even though the launcher validated it at start.
+        // Resolve --temp= from the args the owned process was launched with, not the
+        // live template: placeholders are already expanded there ({character} in a
+        // --temp= path), and a mid-session #config lichargs edit doesn't move where the
+        // running Lich writes. Falling back to the template keeps a tail possible if the
+        // launch args were never recorded; that value can be malformed (the launcher
+        // only validated what it launched), hence the catch.
         string? tempDir;
         try
         {
             tempDir = Genie.Core.Connection.LichDebugLogTailer.ResolveTempDirectory(
-                _core.Config.LichPath, _core.Config.LichArguments);
+                _core.Config.LichPath, _ownedLichArguments ?? _core.Config.LichArguments);
         }
         catch (FormatException ex)
         {

--- a/src/Genie.Core/LichDebugLogTailer.cs
+++ b/src/Genie.Core/LichDebugLogTailer.cs
@@ -31,12 +31,21 @@ public sealed class LichDebugLogTailer : IDisposable
     /// <paramref name="lichPath"/>.
     /// </summary>
     /// <remarks>
-    /// Mirrors <c>lich.rbw</c>'s argument loop (<c>/^--temp=(.+)/</c>,
+    /// <para>Mirrors <c>lich.rbw</c>'s argument loop (<c>/^--temp=(.+)/</c>,
     /// <c>/^--home=(.+)/</c>) and <c>lib/constants.rb</c>
     /// (<c>TEMP_DIR ||= File.join(LICH_DIR, "temp")</c>). Only the <c>=</c> form is
     /// recognised because that is the only form Lich accepts — see
     /// <see cref="LichArgs.TryFindIgnoredDirFlag"/>, which rejects the others at
-    /// launch rather than letting Genie tail a directory Lich silently ignored.
+    /// launch rather than letting Genie tail a directory Lich silently ignored.</para>
+    /// <para><paramref name="lichArgs"/> must be the argument string the process was
+    /// actually launched with — i.e. after <see cref="LichLauncher.TryExpandArguments"/>
+    /// has filled <c>{character}</c> / <c>{port}</c>. Passing the raw
+    /// <c>#config lichargs</c> template makes <c>--temp=temp-{character}</c> resolve to
+    /// a literal <c>temp-{character}</c> directory nothing ever writes to.</para>
+    /// <para>Lich stores a relative <c>--temp=</c> / <c>--home=</c> verbatim, so it
+    /// lands relative to Lich's working directory — which the launcher sets to the
+    /// directory holding <c>lich.rbw</c>, not Genie's own cwd. Relative values are
+    /// rooted there for the same reason.</para>
     /// </remarks>
     /// <exception cref="FormatException">
     /// <paramref name="lichArgs"/> has an unterminated quote. Propagated rather than
@@ -46,21 +55,29 @@ public sealed class LichDebugLogTailer : IDisposable
     public static string? ResolveTempDirectory(string? lichPath, string? lichArgs)
     {
         var tokens = LichArgs.Tokenize(lichArgs);
+        var lichDir = string.IsNullOrWhiteSpace(lichPath)
+            ? null
+            : Path.GetDirectoryName(Path.GetFullPath(lichPath.Trim()));
 
         if (LichArgs.TryParseDirFlag(tokens, "--temp", out var temp))
-            return temp;
+            return RootAtLichDir(temp, lichDir);
 
         // No --temp: TEMP_DIR is {LICH_DIR}/temp, and LICH_DIR is --home= when given,
         // otherwise the directory lich.rbw lives in.
         if (LichArgs.TryParseDirFlag(tokens, "--home", out var home))
-            return Path.Combine(home, "temp");
+            return Path.Combine(RootAtLichDir(home, lichDir), "temp");
 
-        if (string.IsNullOrWhiteSpace(lichPath))
-            return null;
-
-        var dir = Path.GetDirectoryName(Path.GetFullPath(lichPath.Trim()));
-        return string.IsNullOrEmpty(dir) ? null : Path.Combine(dir, "temp");
+        return string.IsNullOrEmpty(lichDir) ? null : Path.Combine(lichDir, "temp");
     }
+
+    /// <summary>Resolve a relative <c>--temp=</c> / <c>--home=</c> value against Lich's
+    /// working directory (<paramref name="lichDir"/>), which is where Lich itself
+    /// resolves it. Absolute values, and any value we have no Lich directory for, are
+    /// returned unchanged.</summary>
+    private static string RootAtLichDir(string path, string? lichDir) =>
+        Path.IsPathRooted(path) || string.IsNullOrEmpty(lichDir)
+            ? path
+            : Path.GetFullPath(Path.Combine(lichDir, path));
 
     /// <summary>
     /// Newest <c>debug-*.log</c> under <paramref name="tempDir"/> whose

--- a/tests/Genie.Core.Tests/LichDebugLogTailerTests.cs
+++ b/tests/Genie.Core.Tests/LichDebugLogTailerTests.cs
@@ -72,6 +72,44 @@ public class LichDebugLogTailerTests
     }
 
     [Fact]
+    public void ResolveTempDirectory_roots_a_relative_temp_at_the_lich_directory()
+    {
+        // Lich keeps --temp= verbatim, so a relative value lands under its working
+        // directory — which the launcher sets to the dir holding lich.rbw. Resolving it
+        // against Genie's own cwd instead would tail a directory that doesn't exist.
+        var home = Path.Combine(Path.GetTempPath(), "lich-home");
+        var lich = Path.Combine(home, "lich.rbw");
+
+        Assert.Equal(
+            Path.Combine(home, "temp-Drazoken"),
+            LichDebugLogTailer.ResolveTempDirectory(lich, "--temp=temp-Drazoken"));
+
+        Assert.Equal(
+            Path.Combine(home, "run", "temp"),
+            LichDebugLogTailer.ResolveTempDirectory(lich, "--home=run"));
+    }
+
+    [Fact]
+    public void ResolveTempDirectory_tails_the_expanded_temp_when_lichargs_uses_placeholders()
+    {
+        // The tailer must be fed the args the process was launched with. Handed the raw
+        // template it resolves a literal `temp-{character}` directory nothing writes to,
+        // and lichdebug presents as doing nothing at all.
+        var home = Path.Combine(Path.GetTempPath(), "lich-home");
+        var lich = Path.Combine(home, "lich.rbw");
+        const string template = "--login {character} --detachable-client={port} --temp=temp-{character}";
+
+        Assert.True(LichLauncher.TryExpandArguments(template, "Drazoken", 8000, out var expanded, out _));
+        Assert.Equal(
+            Path.Combine(home, "temp-Drazoken"),
+            LichDebugLogTailer.ResolveTempDirectory(lich, expanded));
+
+        Assert.Equal(
+            Path.Combine(home, "temp-{character}"),
+            LichDebugLogTailer.ResolveTempDirectory(lich, template));
+    }
+
+    [Fact]
     public void ResolveTempDirectory_throws_rather_than_falling_back_on_a_bad_quote()
     {
         // Silently falling back to {lichdir}/temp would tail the wrong directory


### PR DESCRIPTION
## Summary

Follow-up to #194. The `lichdebug` mirror resolves `--temp=` from the wrong string, so two ordinary `#config lichargs` values send the tailer to a directory nothing writes to — and the symptom is the same silent "lichdebug does nothing" that #194 set out to kill.

**1. Placeholders were never expanded for the tailer.**

`LichLauncher.TryExpandArguments` fills `{character}` / `{port}` before Lich is started, but `SyncOwnedLichDebugTail` re-read the raw `#config lichargs` template. With

```
#config lichargs --login {character} --detachable-client={port} --temp=temp-{character}
```

Lich writes to `temp-Drazoken`; Genie tails a literal `temp-{character}`. The launched process and the tailer disagreed about the one argument they both depend on.

The expanded arguments are now recorded alongside the owned PID (`_ownedLichArguments`, cleared with the rest of the ownership state) and the tailer resolves from those. Second benefit: editing `lichargs` mid-session no longer moves the tail off the directory the *running* process is writing to — the process was launched with the old value and doesn't reread it.

**2. A relative `--temp=` / `--home=` resolved against the wrong directory.**

`temp-{character}` is also relative, and would still have missed after the fix above. `lich.rbw` stores the value verbatim (`TEMP_DIR = $1`), so a relative path resolves against Lich's working directory — which `LichLauncher` sets to `dirname(lich.rbw)`. Genie resolved it against its own cwd, wherever the client happened to be started from.

Relative `--temp=` / `--home=` values are now rooted at the Lich directory. Absolute values are untouched, as is the `{LICH_DIR}/temp` default.

Both are the #194 failure mode one layer along: no error from either side, Lich logging happily, Genie watching a path that will never exist. The `ResolveTempDirectory` docs now state the contract — callers must pass the arguments the process was *launched* with, not the template.

## Test plan

- [x] `dotnet build -c Release` — clean, 0 warnings
- [x] `dotnet test tests/Genie.Core.Tests` — 723/723, including two new `LichDebugLogTailerTests`:
  - `--temp=temp-{character}` resolves correctly through `TryExpandArguments`, and the raw template resolves to the literal directory (pinning the bug so it can't come back)
  - relative `--temp=` / `--home=` root at the Lich directory
- [x] `#config lichargs --login {character} --temp=temp-{character}` + `#config lichdebug true`, Lich-proxy connect with auto-launch — `[lich-debug] tailing …/temp-<Character>/debug-*.log` and live lines
- [x] Same with an absolute `--temp=/path` — unchanged behaviour
- [x] Genie started from a different working directory — relative `--temp=` still binds

## Checklist

- [x] `dotnet build -c Release` succeeds cleanly (warnings OK, errors not)
- [x] Tests / relevant test-harness modes pass for the subsystems I touched
- [x] **No machine-specific paths** committed
- [x] **No AI brand references** in tracked files
- [x] Docs updated if user-visible behaviour changed — no user-visible surface change; the XML docs on `ResolveTempDirectory` carry the contract
- [x] This is a focused PR — one feature or one fix

## Compatibility & policy

- [x] **DR policy acknowledged** — no auto-reconnect, no agentive AI driving commands, no headless mode, no other-player speech off-machine. `lichdebug` remains opt-in and off by default.
