### PR TITLE
fix(lich): keep the lichdebug mirror up until the owned Lich exits

### DIFF
--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -949,6 +949,14 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// when <c>#config lichdebug</c> is on. Null when not tailing.</summary>
     private Genie.Core.Connection.LichDebugLogTailer? _lichDebugTailer;
 
+    /// <summary>How long a teardown waits for the owned Lich to actually exit before
+    /// dropping its debug tail anyway. Bounds a Lich that ignores the stop.</summary>
+    private static readonly TimeSpan OwnedLichExitWait = TimeSpan.FromSeconds(15);
+
+    /// <summary>Extra tail time after the owned Lich is gone, so its last buffered
+    /// writes land on disk and get polled before the mirror shuts down.</summary>
+    private static readonly TimeSpan OwnedLichPostExitGrace = TimeSpan.FromSeconds(3);
+
     /// <summary>Base name of the recipe script whose completion should auto-stop
     /// the current capture (null for a manual capture, which the user stops).</summary>
     private string? _activeCaptureScript;
@@ -3555,11 +3563,13 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
             else
             {
                 // Owned PID gone (crash / external kill) — drop the stale claim so a
-                // fresh Launched outcome can take ownership again.
+                // fresh Launched outcome can take ownership again. The tail lingers
+                // instead of stopping dead: whatever Lich wrote as it died is the most
+                // useful thing lichdebug can show here.
                 if (_ownedLichProcessId is int stalePid
                     && !Genie.Core.Connection.LichLauncher.TryIsProcessAlive(stalePid))
                 {
-                    StopOwnedLichDebugTail();
+                    LingerOwnedLichDebugTail(stalePid);
                     _ownedLichProcessId = null;
                     _ownedLichProcessStartUtc = null;
                     _ownedLichLaunchKey = null;
@@ -3606,7 +3616,6 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     private void StopOwnedLich()
     {
         if (_ownedLichProcessId is not int pid) return;
-        StopOwnedLichDebugTail();
         _ownedLichProcessId = null;
         _ownedLichProcessStartUtc = null;
         _ownedLichLaunchKey = null;
@@ -3614,6 +3623,11 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         Genie.Core.Connection.LichLauncher.TryStop(pid, out var message);
         if (!string.IsNullOrEmpty(message))
             GameText.AddSystemLine(message);
+        // Kill first, tail after: Lich logs the FE detach, script shutdown and its
+        // disconnect reason on the way out, and those are the lines lichdebug is
+        // wanted for. LingerOwnedLichDebugTail keeps reading until the process is
+        // actually gone.
+        LingerOwnedLichDebugTail(pid);
     }
 
     /// <summary>
@@ -3675,12 +3689,52 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                     "directory in #config lichargs, Lich only honours the --temp=PATH form.")));
     }
 
+    /// <summary>Stop the debug tail immediately. For "the user turned lichdebug off" —
+    /// a teardown of the Lich process itself should use <see cref="LingerOwnedLichDebugTail"/>
+    /// so the shutdown lines still arrive.</summary>
     private void StopOwnedLichDebugTail()
     {
         var tailer = _lichDebugTailer;
         _lichDebugTailer = null;
         try { tailer?.Dispose(); }
         catch { /* best-effort */ }
+    }
+
+    /// <summary>
+    /// Hand the current tailer off to a background wait that keeps mirroring until
+    /// <paramref name="processId"/> exits (plus <see cref="OwnedLichPostExitGrace"/>),
+    /// then stops it.
+    /// </summary>
+    /// <remarks>
+    /// The field is cleared up front, so a reconnect that launches a fresh Lich starts
+    /// its own tailer immediately instead of waiting on this one — the two read
+    /// different files, and the dying session's last lines are the point of the linger.
+    /// </remarks>
+    private void LingerOwnedLichDebugTail(int processId)
+    {
+        var tailer = _lichDebugTailer;
+        _lichDebugTailer = null;
+        if (tailer is null) return;
+
+        GameText.AddSystemLine(
+            "[lich-debug] Lich is shutting down — still mirroring its final lines.");
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await tailer.StopAfterProcessExitAsync(
+                    processId, OwnedLichExitWait, OwnedLichPostExitGrace);
+            }
+            catch { /* best-effort */ }
+            finally
+            {
+                try { tailer.Dispose(); } catch { /* best-effort */ }
+            }
+
+            Avalonia.Threading.Dispatcher.UIThread.Post(
+                () => GameText.AddSystemLine("[lich-debug] stopped (Lich exited)."));
+        });
     }
 
     private static DateTime? TryGetProcessStartUtc(int processId)

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -936,6 +936,15 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// character/port switch that needs a stop-then-relaunch before connect.</summary>
     private string? _ownedLichLaunchKey;
 
+    /// <summary>The <em>expanded</em> lichargs the owned Lich was actually launched with
+    /// ({character}/{port} already filled). The debug-log tailer resolves <c>--temp=</c>
+    /// from this, not from the live <c>#config lichargs</c> template: a template like
+    /// <c>--temp=temp-{character}</c> would otherwise send the tailer to a literal
+    /// <c>temp-{character}</c> directory, and lichdebug would look like it does nothing.
+    /// It also pins the tail to where the running process writes when the template is
+    /// edited mid-session.</summary>
+    private string? _ownedLichArguments;
+
     /// <summary>Live-tails the owned Lich's <c>temp/debug-*.log</c> into the game window
     /// when <c>#config lichdebug</c> is on. Null when not tailing.</summary>
     private Genie.Core.Connection.LichDebugLogTailer? _lichDebugTailer;
@@ -3554,6 +3563,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                     _ownedLichProcessId = null;
                     _ownedLichProcessStartUtc = null;
                     _ownedLichLaunchKey = null;
+                    _ownedLichArguments = null;
                 }
 
                 // EnsureRunningAsync uses ConfigureAwait(false); marshal progress onto
@@ -3578,6 +3588,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                     _ownedLichProcessId = pid;
                     _ownedLichProcessStartUtc = lich.ProcessStartTimeUtc ?? DateTime.UtcNow;
                     _ownedLichLaunchKey = launchKey;
+                    _ownedLichArguments = lichArgs;   // expanded — the tailer resolves --temp= from these
                     SyncOwnedLichDebugTail();
                 }
             }
@@ -3599,6 +3610,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         _ownedLichProcessId = null;
         _ownedLichProcessStartUtc = null;
         _ownedLichLaunchKey = null;
+        _ownedLichArguments = null;
         Genie.Core.Connection.LichLauncher.TryStop(pid, out var message);
         if (!string.IsNullOrEmpty(message))
             GameText.AddSystemLine(message);
@@ -3621,13 +3633,17 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                         ?? DateTime.UtcNow;
         _ownedLichProcessStartUtc ??= notBefore;
 
-        // lichargs can be edited after the owned Lich was launched, so a malformed
-        // value can reach us even though the launcher validated it at start.
+        // Resolve --temp= from the args the owned process was launched with, not the
+        // live template: placeholders are already expanded there ({character} in a
+        // --temp= path), and a mid-session #config lichargs edit doesn't move where the
+        // running Lich writes. Falling back to the template keeps a tail possible if the
+        // launch args were never recorded; that value can be malformed (the launcher
+        // only validated what it launched), hence the catch.
         string? tempDir;
         try
         {
             tempDir = Genie.Core.Connection.LichDebugLogTailer.ResolveTempDirectory(
-                _core.Config.LichPath, _core.Config.LichArguments);
+                _core.Config.LichPath, _ownedLichArguments ?? _core.Config.LichArguments);
         }
         catch (FormatException ex)
         {

--- a/src/Genie.Core/LichDebugLogTailer.cs
+++ b/src/Genie.Core/LichDebugLogTailer.cs
@@ -151,6 +151,51 @@ public sealed class LichDebugLogTailer : IDisposable
         }
     }
 
+    /// <summary>
+    /// Keep tailing until the owned Lich process has exited, then a little longer, and
+    /// only then <see cref="Stop"/>. Idempotent with <see cref="Stop"/>.
+    /// </summary>
+    /// <remarks>
+    /// Lich writes its most useful diagnostics on the way out — the FE detach, script
+    /// shutdown, the disconnect reason. Stopping the tail the moment Genie asks Lich to
+    /// quit loses exactly those lines, so a stop request only starts a wait here.
+    /// <paramref name="postExitGrace"/> covers the gap between "the process is gone" and
+    /// "its final buffered writes have landed on disk and been polled".
+    /// <paramref name="maxWaitForExit"/> bounds a Lich that never dies.
+    /// </remarks>
+    /// <param name="processId">PID of the owned Lich. Non-positive is treated as already gone.</param>
+    /// <param name="maxWaitForExit">Upper bound on the wait for the process to exit.</param>
+    /// <param name="postExitGrace">Extra tail time after the process is gone.</param>
+    /// <param name="ct">Cancels the wait and stops immediately.</param>
+    public async Task StopAfterProcessExitAsync(
+        int processId,
+        TimeSpan maxWaitForExit,
+        TimeSpan postExitGrace,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var deadline = DateTime.UtcNow + maxWaitForExit;
+            while (processId > 0
+                   && DateTime.UtcNow < deadline
+                   && LichLauncher.TryIsProcessAlive(processId))
+            {
+                await Task.Delay(PollInterval, ct).ConfigureAwait(false);
+            }
+
+            if (postExitGrace > TimeSpan.Zero)
+                await Task.Delay(postExitGrace, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Caller wants the tail down now — fall through to Stop().
+        }
+        finally
+        {
+            Stop();
+        }
+    }
+
     /// <summary>Stop the background loop. Idempotent.</summary>
     public void Stop()
     {

--- a/src/Genie.Core/LichDebugLogTailer.cs
+++ b/src/Genie.Core/LichDebugLogTailer.cs
@@ -31,12 +31,21 @@ public sealed class LichDebugLogTailer : IDisposable
     /// <paramref name="lichPath"/>.
     /// </summary>
     /// <remarks>
-    /// Mirrors <c>lich.rbw</c>'s argument loop (<c>/^--temp=(.+)/</c>,
+    /// <para>Mirrors <c>lich.rbw</c>'s argument loop (<c>/^--temp=(.+)/</c>,
     /// <c>/^--home=(.+)/</c>) and <c>lib/constants.rb</c>
     /// (<c>TEMP_DIR ||= File.join(LICH_DIR, "temp")</c>). Only the <c>=</c> form is
     /// recognised because that is the only form Lich accepts — see
     /// <see cref="LichArgs.TryFindIgnoredDirFlag"/>, which rejects the others at
-    /// launch rather than letting Genie tail a directory Lich silently ignored.
+    /// launch rather than letting Genie tail a directory Lich silently ignored.</para>
+    /// <para><paramref name="lichArgs"/> must be the argument string the process was
+    /// actually launched with — i.e. after <see cref="LichLauncher.TryExpandArguments"/>
+    /// has filled <c>{character}</c> / <c>{port}</c>. Passing the raw
+    /// <c>#config lichargs</c> template makes <c>--temp=temp-{character}</c> resolve to
+    /// a literal <c>temp-{character}</c> directory nothing ever writes to.</para>
+    /// <para>Lich stores a relative <c>--temp=</c> / <c>--home=</c> verbatim, so it
+    /// lands relative to Lich's working directory — which the launcher sets to the
+    /// directory holding <c>lich.rbw</c>, not Genie's own cwd. Relative values are
+    /// rooted there for the same reason.</para>
     /// </remarks>
     /// <exception cref="FormatException">
     /// <paramref name="lichArgs"/> has an unterminated quote. Propagated rather than
@@ -46,21 +55,29 @@ public sealed class LichDebugLogTailer : IDisposable
     public static string? ResolveTempDirectory(string? lichPath, string? lichArgs)
     {
         var tokens = LichArgs.Tokenize(lichArgs);
+        var lichDir = string.IsNullOrWhiteSpace(lichPath)
+            ? null
+            : Path.GetDirectoryName(Path.GetFullPath(lichPath.Trim()));
 
         if (LichArgs.TryParseDirFlag(tokens, "--temp", out var temp))
-            return temp;
+            return RootAtLichDir(temp, lichDir);
 
         // No --temp: TEMP_DIR is {LICH_DIR}/temp, and LICH_DIR is --home= when given,
         // otherwise the directory lich.rbw lives in.
         if (LichArgs.TryParseDirFlag(tokens, "--home", out var home))
-            return Path.Combine(home, "temp");
+            return Path.Combine(RootAtLichDir(home, lichDir), "temp");
 
-        if (string.IsNullOrWhiteSpace(lichPath))
-            return null;
-
-        var dir = Path.GetDirectoryName(Path.GetFullPath(lichPath.Trim()));
-        return string.IsNullOrEmpty(dir) ? null : Path.Combine(dir, "temp");
+        return string.IsNullOrEmpty(lichDir) ? null : Path.Combine(lichDir, "temp");
     }
+
+    /// <summary>Resolve a relative <c>--temp=</c> / <c>--home=</c> value against Lich's
+    /// working directory (<paramref name="lichDir"/>), which is where Lich itself
+    /// resolves it. Absolute values, and any value we have no Lich directory for, are
+    /// returned unchanged.</summary>
+    private static string RootAtLichDir(string path, string? lichDir) =>
+        Path.IsPathRooted(path) || string.IsNullOrEmpty(lichDir)
+            ? path
+            : Path.GetFullPath(Path.Combine(lichDir, path));
 
     /// <summary>
     /// Newest <c>debug-*.log</c> under <paramref name="tempDir"/> whose

--- a/tests/Genie.Core.Tests/LichDebugLogTailerTests.cs
+++ b/tests/Genie.Core.Tests/LichDebugLogTailerTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Genie.Core.Connection;
 using Xunit;
@@ -165,6 +167,99 @@ public class LichDebugLogTailerTests
         {
             try { Directory.Delete(tempDir, recursive: true); } catch { /* ignore */ }
         }
+    }
+
+    [Fact]
+    public async Task StopAfterProcessExitAsync_keeps_mirroring_until_the_process_exits()
+    {
+        // Lich's shutdown lines (FE detach, disconnect reason) are written after Genie
+        // asks it to stop. Cutting the tail at the stop request loses exactly those.
+        var tempDir = Directory.CreateTempSubdirectory("lich-debug-linger-").FullName;
+        using var proc = StartLongLivedProcess();
+        Assert.NotNull(proc);
+
+        try
+        {
+            var logPath = Path.Combine(tempDir, "debug-session.log");
+            await File.WriteAllTextAsync(logPath, "first\n");
+            File.SetLastWriteTimeUtc(logPath, DateTime.UtcNow);
+
+            var shuttingDown = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var bound = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var tailer = new LichDebugLogTailer();
+            tailer.Start(
+                tempDir,
+                DateTime.UtcNow.AddSeconds(-2),
+                onLine: line => { if (line == "shutting down") shuttingDown.TrySetResult(); },
+                onFileBound: _ => bound.TrySetResult());
+
+            await bound.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Stop requested while the process is still alive: the tail must stay up.
+            var stopping = tailer.StopAfterProcessExitAsync(
+                proc!.Id, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(250));
+
+            await File.AppendAllTextAsync(logPath, "shutting down\n");
+            await shuttingDown.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(stopping.IsCompleted);
+
+            // ...and come down once the process is gone.
+            proc.Kill();
+            proc.WaitForExit(5_000);
+            await stopping.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            try { if (!proc!.HasExited) proc.Kill(); } catch { /* ignore */ }
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* ignore */ }
+        }
+    }
+
+    [Fact]
+    public async Task StopAfterProcessExitAsync_gives_up_on_a_lich_that_never_exits()
+    {
+        // A Lich that ignores the stop must not pin the tail (and its file handle) open.
+        using var proc = StartLongLivedProcess();
+        Assert.NotNull(proc);
+
+        var tempDir = Directory.CreateTempSubdirectory("lich-debug-linger-cap-").FullName;
+        try
+        {
+            using var tailer = new LichDebugLogTailer();
+            tailer.Start(tempDir, DateTime.UtcNow, onLine: _ => { });
+
+            await tailer.StopAfterProcessExitAsync(
+                    proc!.Id, TimeSpan.FromMilliseconds(400), TimeSpan.Zero)
+                .WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.False(proc.HasExited);   // gave up on the wait, not on the process
+        }
+        finally
+        {
+            try { if (!proc!.HasExited) proc.Kill(); } catch { /* ignore */ }
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* ignore */ }
+        }
+    }
+
+    private static Process? StartLongLivedProcess()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Process.Start(new ProcessStartInfo
+            {
+                FileName        = "cmd.exe",
+                Arguments       = "/c ping -n 60 127.0.0.1 >NUL",
+                UseShellExecute = false,
+                CreateNoWindow  = true,
+            });
+
+        return Process.Start(new ProcessStartInfo
+        {
+            FileName        = "/bin/sleep",
+            Arguments       = "60",
+            UseShellExecute = false,
+            CreateNoWindow  = true,
+        });
     }
 
     [Fact]

--- a/tests/Genie.Core.Tests/LichDebugLogTailerTests.cs
+++ b/tests/Genie.Core.Tests/LichDebugLogTailerTests.cs
@@ -72,6 +72,44 @@ public class LichDebugLogTailerTests
     }
 
     [Fact]
+    public void ResolveTempDirectory_roots_a_relative_temp_at_the_lich_directory()
+    {
+        // Lich keeps --temp= verbatim, so a relative value lands under its working
+        // directory — which the launcher sets to the dir holding lich.rbw. Resolving it
+        // against Genie's own cwd instead would tail a directory that doesn't exist.
+        var home = Path.Combine(Path.GetTempPath(), "lich-home");
+        var lich = Path.Combine(home, "lich.rbw");
+
+        Assert.Equal(
+            Path.Combine(home, "temp-Drazoken"),
+            LichDebugLogTailer.ResolveTempDirectory(lich, "--temp=temp-Drazoken"));
+
+        Assert.Equal(
+            Path.Combine(home, "run", "temp"),
+            LichDebugLogTailer.ResolveTempDirectory(lich, "--home=run"));
+    }
+
+    [Fact]
+    public void ResolveTempDirectory_tails_the_expanded_temp_when_lichargs_uses_placeholders()
+    {
+        // The tailer must be fed the args the process was launched with. Handed the raw
+        // template it resolves a literal `temp-{character}` directory nothing writes to,
+        // and lichdebug presents as doing nothing at all.
+        var home = Path.Combine(Path.GetTempPath(), "lich-home");
+        var lich = Path.Combine(home, "lich.rbw");
+        const string template = "--login {character} --detachable-client={port} --temp=temp-{character}";
+
+        Assert.True(LichLauncher.TryExpandArguments(template, "Drazoken", 8000, out var expanded, out _));
+        Assert.Equal(
+            Path.Combine(home, "temp-Drazoken"),
+            LichDebugLogTailer.ResolveTempDirectory(lich, expanded));
+
+        Assert.Equal(
+            Path.Combine(home, "temp-{character}"),
+            LichDebugLogTailer.ResolveTempDirectory(lich, template));
+    }
+
+    [Fact]
     public void ResolveTempDirectory_throws_rather_than_falling_back_on_a_bad_quote()
     {
         // Silently falling back to {lichdir}/temp would tail the wrong directory


### PR DESCRIPTION
## Summary

> **Stacked on #205.** That PR is the first commit here; base it away when reviewing, or merge #205 first and this diff drops to the single commit `fix(lich): keep the lichdebug mirror up until the owned Lich exits`. GitHub won't let me set #205's branch as the base from a fork.

Second follow-up to #194. Tearing down a Genie-started Lich stopped the debug tail *before* killing the process, so everything Lich writes on the way out was lost: the frontend detach, script shutdown, and the reason it disconnected. Those lines are most of why anyone turns `lichdebug` on — the mirror went quiet exactly when the session got interesting.

The teardown now stops the process first, then hands the tailer to a new `LichDebugLogTailer.StopAfterProcessExitAsync`, which:

- keeps polling while the owned PID is still alive, so shutdown lines are mirrored as Lich writes them;
- waits a grace period (3s) after the process is gone, so its last buffered writes land on disk and get picked up by one more poll;
- gives up after a cap (15s) — a Lich that ignores the stop must not pin the tail, and its file handle, open forever.

The stale-PID path (owned Lich crashed or was killed externally) lingers the same way instead of stopping dead, since whatever it wrote as it died is the most useful thing the mirror can show there.

Two details worth flagging for review:

- **The tailer field is cleared as the handoff starts.** A reconnect that launches a fresh Lich begins its own tail immediately rather than queueing behind the dying one — they read different files, and the dying session's last lines are the whole point of the linger. The user sees `[lich-debug] Lich is shutting down — still mirroring its final lines.` and then `[lich-debug] stopped (Lich exited).`
- **`#config lichdebug false` still stops instantly.** Turning the mirror off is a user decision about the mirror, not a teardown of Lich; only process teardown lingers.

Known rough edge: on app close the linger runs as a detached background task, so the last few seconds of shutdown lines are written to a window that is going away. Harmless, and stopping the tail immediately on app exit would be a one-line branch — happy to add it if reviewers prefer that.

## Test plan

- [x] `dotnet build -c Release` — clean, 0 warnings
- [x] `dotnet test tests/Genie.Core.Tests` — 725/725, including two new `LichDebugLogTailerTests`:
  - a stop requested while the process is still alive keeps mirroring: a line appended after the request is still emitted, and the returned task stays pending until the process exits
  - a process that never exits is abandoned at the cap, with the process left running (the wait gave up, not the kill)
- [x] `#config lichdebug true`, Lich-proxy connect with auto-launch, then disconnect — Lich's shutdown lines appear after the `[lich]` stop message, followed by `[lich-debug] stopped (Lich exited).`
- [ ] Character switch (stop-then-relaunch) — the dying session's tail finishes while the new session's tail starts
- [ ] Kill the owned Lich externally, then reconnect — crash lines are mirrored before the stale claim is dropped
- [ ] `#config lichdebug false` mid-session — mirror stops immediately, no linger message

## Checklist

- [x] `dotnet build -c Release` succeeds cleanly (warnings OK, errors not)
- [x] Tests / relevant test-harness modes pass for the subsystems I touched
- [x] **No machine-specific paths** committed
- [x] **No AI brand references** in tracked files
- [x] Docs updated if user-visible behaviour changed — behaviour change is confined to the `[lich-debug]` channel and is described by its own messages
- [x] This is a focused PR — one feature or one fix

## Compatibility & policy

- [x] **DR policy acknowledged** — no auto-reconnect, no agentive AI driving commands, no headless mode, no other-player speech off-machine. `lichdebug` remains opt-in and off by default, and the linger is bounded.
