### PR TITLE
fix(connection): stop dropping blank lines in the chunker

### DIFF
--- a/src/Genie.Core/GameConnection.cs
+++ b/src/Genie.Core/GameConnection.cs
@@ -478,7 +478,7 @@ public sealed class GameConnection : IAsyncDisposable
     /// and emits each as a discrete chunk to both the parser and AI streams.
     /// Incomplete tags are left in the buffer for the next read.
     /// </summary>
-    private void EmitChunks(StringBuilder pending)
+    internal void EmitChunks(StringBuilder pending)
     {
         if (pending.Length == 0) return;
 
@@ -509,8 +509,18 @@ public sealed class GameConnection : IAsyncDisposable
             var chunk = raw.Substring(pos, splitAt - pos);
             pos = splitAt;
 
-            // Skip empty / whitespace-only chunks
-            if (string.IsNullOrWhiteSpace(chunk)) continue;
+            // Publish everything with content. A whitespace-only chunk can only
+            // ever be a '\n'-terminated one (whitespace sitting between two tags
+            // is swallowed into the chunk that ends at the following '>'), i.e. a
+            // BLANK LINE — and dropping those here defeated the parser's
+            // blank-line preservation (public #176) on the live path: DrXmlParser
+            // never saw the newline, so INFO/LOOK/HELP spacing and blank rows
+            // inside a mono block collapsed. Whether a blank is real output or
+            // just a tag-adjacent formatting newline is the PARSER's call — it
+            // has the context (_emittedTextLine) to tell them apart; the chunker
+            // does not. Feeding the parser directly (unit tests, TestHarness
+            // REPLAY) bypasses this method, which is why the drop went unnoticed.
+            if (chunk.Length == 0) continue;
 
             Publish(chunk);
         }

--- a/src/Genie.Core/Genie.Core.csproj
+++ b/src/Genie.Core/Genie.Core.csproj
@@ -20,6 +20,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- The chunker (GameConnection.EmitChunks) is the live path's line
+         splitter and has its own regression tests; it stays internal so it
+         isn't part of Core's public surface. -->
+    <InternalsVisibleTo Include="Genie.Core.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Reactive event streams (no WinForms dependency) -->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />

--- a/src/Genie.Core/TestHarness.cs
+++ b/src/Genie.Core/TestHarness.cs
@@ -677,7 +677,16 @@ core.GameEvents
 
         parsedLog?.WriteLine(display);
 
-        if (isCompare)
+        // COMPARE capture skips blank lines, matching GenerateXmlBaseline's own
+        // empty-line filter. The baseline strips tags and collapses whitespace,
+        // which turns a markup-only line (<pushStream/>, <indicator/>, a compass
+        // block) into exactly the same empty string as a genuine blank — it
+        // cannot represent a blank line, so it drops them all. Capturing them on
+        // the parsed side would report one "only in parsed" empty entry that no
+        // baseline could ever match. COMPARE measures text the parser drops or
+        // reformats; a blank carries no text. The full parsedLog above still
+        // records them — that file is a rendering of the session, not a diff input.
+        if (isCompare && e.Text.Length > 0)
             parsedLines.Add(display);
 
         Console.ForegroundColor = StreamColor(e.Stream);

--- a/tests/Genie.Core.Tests/BlankLineChunkingTests.cs
+++ b/tests/Genie.Core.Tests/BlankLineChunkingTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Genie.Core.Connection;
+using Genie.Core.Events;
+using Genie.Core.Parser;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// The LIVE path's line splitter, <see cref="GameConnection.EmitChunks"/>, used to
+/// drop every whitespace-only chunk. A blank line arrives as exactly that (its own
+/// "\n" chunk), so blank lines never reached the parser on a real connection and
+/// the #176 blank-line preservation in <c>DrXmlParser.EmitLine</c> had nothing to
+/// preserve — INFO/LOOK/HELP spacing collapsed in the game window.
+///
+/// <see cref="BlankLinePreservationTests"/> could not catch this: it calls
+/// <c>parser.Feed(...)</c> directly, as does <c>TestHarness</c> REPLAY. These tests
+/// deliberately run the bytes through the chunker FIRST, so they cover the seam the
+/// other suites skip.
+/// </summary>
+public class BlankLineChunkingTests
+{
+    private sealed class Collector<T> : IObserver<T>
+    {
+        private readonly List<T> _sink;
+        public Collector(List<T> sink) => _sink = sink;
+        public void OnNext(T value) => _sink.Add(value);
+        public void OnError(Exception error) { }
+        public void OnCompleted() { }
+    }
+
+    /// <summary>Run <paramref name="wire"/> through the real chunker and hand back
+    /// the chunks it published, in order.</summary>
+    private static List<string> Chunk(string wire)
+    {
+        var conn = new GameConnection(
+            new ConnectionConfig(), null!, NullLogger<GameConnection>.Instance);
+        var chunks = new List<string>();
+        using var _ = conn.RawXmlStream.Subscribe(new Collector<string>(chunks));
+        conn.EmitChunks(new StringBuilder(wire));
+        return chunks;
+    }
+
+    /// <summary>Chunk <paramref name="wire"/> exactly as the live read loop would,
+    /// then feed those chunks to the parser — the full wire→display path.</summary>
+    private static List<string> TextLines(string wire)
+    {
+        var parser = new DrXmlParser(NullLogger<DrXmlParser>.Instance);
+        var events = new List<GameEvent>();
+        using var _ = parser.GameEvents.Subscribe(new Collector<GameEvent>(events));
+        foreach (var chunk in Chunk(wire)) parser.Feed(chunk);
+        return events.OfType<TextEvent>().Select(t => t.Text).ToList();
+    }
+
+    [Fact]
+    public void Blank_line_chunk_reaches_the_parser()
+    {
+        Assert.Equal(new[] { "line1\n", "\n", "line2\n" }, Chunk("line1\n\nline2\n"));
+    }
+
+    [Fact]
+    public void Whitespace_only_line_is_not_swallowed()
+    {
+        // An all-spaces line (INFO/EXP column spacers, blank rows inside a mono
+        // map block) is content as far as the chunker is concerned.
+        Assert.Equal(new[] { "line1\n", "   \n", "line2\n" }, Chunk("line1\n   \nline2\n"));
+    }
+
+    [Fact]
+    public void Real_blank_survives_the_full_wire_to_text_path()
+    {
+        // The #176 shape, but routed through the chunker the way a live session is.
+        Assert.Equal(
+            new[] { "Redeemer.", "", "Your birthday is more than 1 month away.", "", "Strength : 12" },
+            TextLines("Redeemer.\n\nYour birthday is more than 1 month away.\n\nStrength : 12\n"));
+    }
+
+    [Fact]
+    public void Tag_adjacent_newline_still_emits_no_blank()
+    {
+        // The formatting newline after </component> and </prompt> now REACHES the
+        // parser (it used to be dropped here). Suppressing it is the parser's job
+        // — _emittedTextLine — and it must still do it, or every tag would spam a
+        // blank line into the window.
+        Assert.Equal(
+            new[] { "line1", "", "line2", "line3", "line4" },
+            TextLines(
+                "line1\n\nline2\n" +
+                "<component id='room objs'>a rat</component>\n" +
+                "line3\n" +
+                "<prompt time='1'>&gt;</prompt>\n" +
+                "line4\n"));
+    }
+
+    [Fact]
+    public void Leading_blank_before_any_text_emits_nothing()
+    {
+        Assert.Equal(new[] { "first real line" }, TextLines("\nfirst real line\n"));
+    }
+
+    [Fact]
+    public void Partial_trailing_line_stays_buffered()
+    {
+        // Unchanged behaviour: an incomplete tag / unterminated line is retained
+        // for the next read rather than published early.
+        var conn = new GameConnection(
+            new ConnectionConfig(), null!, NullLogger<GameConnection>.Instance);
+        var chunks = new List<string>();
+        using var _ = conn.RawXmlStream.Subscribe(new Collector<string>(chunks));
+
+        var pending = new StringBuilder("done\npartial<comp");
+        conn.EmitChunks(pending);
+
+        Assert.Equal(new[] { "done\n" }, chunks);
+        Assert.Equal("partial<comp", pending.ToString());
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #176. That fix taught `DrXmlParser.EmitLine` to tell a real blank line from the formatting newline that trails a tag close, and it works — but on a live connection the parser never saw a blank line to preserve, so #176's symptom is still there in the client.

`GameConnection.EmitChunks` splits the stream at every `>` and every `\n`, then dropped any chunk that was whitespace-only. A blank line *is* whitespace-only: it arrives as its own `"\n"` chunk. So blank lines died one layer above the parser.

Worth noting that this condition never removed anything else. Whitespace sitting between two tags is absorbed into the chunk that ends at the following `>` — `<a/> <b/>` splits into `<a/>` and `` <b/>``, never a bare `" "`. The only chunk that can be whitespace-only is one terminated by `\n`, i.e. a blank line. Feeding `"line1\n\nline2\n   \nline3\n"` through the chunker published exactly `line1\n`, `line2\n`, `line3\n`.

So `INFO` / `LOOK` / `HELP` spacing, the spaces-only column spacers in `INFO`/`EXP`, and blank rows inside a `mono` block all collapsed in the game window.

Now only genuinely empty chunks are skipped, and the parser decides. It's the layer that can: `_emittedTextLine` already distinguishes a real blank from a tag-adjacent newline, which is context the chunker doesn't have and shouldn't need.

**Why this survived the test suite.** Parser tests call `parser.Feed(...)` directly, which is the right default for them but skips the chunker entirely — `BlankLinePreservationTests` asserts the exact behaviour that was broken in the client and passes either way. REPLAY/COMPARE *do* run the real socket path, but COMPARE couldn't show it either: `GenerateXmlBaseline` filters empty lines too, so both sides of the diff agreed. New tests run bytes through the chunker first, so the seam is covered now. `EmitChunks` is `internal` rather than `private` for that (`InternalsVisibleTo` the test assembly); no change to the hot path.

**Second commit.** With blanks flowing, the COMPARE capture recorded them while the baseline still filtered them, which showed up as one spurious "only in parsed" empty entry. The baseline is the right side to keep: it strips tags and collapses whitespace, which maps a markup-only line (`<pushStream/>`, `<indicator/>`, a compass block) onto the same empty string as a genuine blank, so it can't represent a blank at all. It already filters the settings dump, `<component>` blocks and prompts on the same reasoning — COMPARE measures text the parser drops or reformats, and a blank carries no text. The parsed side now matches. The full parsed log still records blanks; that file renders the session rather than feeding the diff.

## Test plan

- [x] `dotnet build -c Release` — clean, 0 warnings
- [x] `dotnet test tests/Genie.Core.Tests` — 746/746, including six new `BlankLineChunkingTests` that run bytes through `EmitChunks` before the parser:
  - a blank line survives as its own chunk, and a spaces-only line isn't swallowed
  - the #176 `INFO` shape survives the full wire→text path
  - a tag-adjacent newline still emits **no** blank — the formatting newline after `</component>` and `</prompt>` now reaches the parser, and suppressing it is the parser's job
  - a leading blank before any text still emits nothing
  - a partial trailing line is still retained for the next read
- [x] Reverted the one-line condition and re-ran: four of the six fail against the old code, so they aren't vacuous
- [x] COMPARE against a synthetic recording containing blank lines, markup-only lines and prompts: `0` baseline-unique / `0` parsed-unique with the fix; with the second commit reverted, `1` parsed-unique — the empty entry described above. Baseline-unique stayed `0` throughout, so no text went missing.
- [x] Live session smoke test: confirm `INFO`, `LOOK` and a `mono` block render with their blank lines in the game window

## Checklist

- [x] `dotnet build -c Release` succeeds cleanly (warnings OK, errors not)
- [x] Tests / relevant test-harness modes pass for the subsystems I touched
- [x] **No machine-specific paths** committed
- [x] **No AI brand references** in tracked files
- [x] Docs updated if user-visible behaviour changed — no doc change; this restores the behaviour #176 already documented as intended
- [x] This is a focused PR — one fix, plus the COMPARE adjustment it forces

## Compatibility & policy

- [x] **DR policy acknowledged** — no auto-reconnect, no agentive AI driving commands, no headless mode, no other-player speech off-machine. This only stops discarding bytes the server already sent.
