### PR TITLE
fix(streams): stop double-printing a stream's lines in Main when its panel is closed

### DIFF
--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -556,6 +556,31 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     [Reactive] public bool RawXmlVisible   { get; private set; }   // hidden by default (opt-in, #14)
     [Reactive] public bool InjuriesVisible { get; private set; }   // hidden by default (opt-in, #18)
 
+    /// <summary>
+    /// Is a text stream's dock panel currently open? Handed to
+    /// <see cref="StreamTabsViewModel.Attach"/> so the closed-panel fallback
+    /// (mirror the line into Main so it isn't lost) is decided next to the
+    /// EchoToMain echo, which the same event also has to consider. The
+    /// visibility flags live here, the routing rule lives there.
+    /// <para>
+    /// Streams with no case fall through as visible, i.e. never mirrored:
+    /// "main" needs no mirroring, and atmospherics / log / itemlog are
+    /// deliberately excluded (they're opt-in or already consolidated feeds).
+    /// </para>
+    /// </summary>
+    private bool IsStreamPanelVisible(string stream) => stream.ToLowerInvariant() switch
+    {
+        "logons"   => LogonsVisible,
+        "talk"     => TalkVisible,
+        "whispers" => WhispersVisible,
+        "thoughts" => ThoughtsVisible,
+        "combat"   => CombatVisible,
+        "familiar" => FamiliarVisible,
+        "death"    => DeathVisible,
+        "assess"   => AssessVisible,
+        _          => true,
+    };
+
     // ── Toggle commands (one per dockable) ───────────────────────────────────
     public ReactiveCommand<Unit, Unit> ToggleGameCommand     { get; }
     public ReactiveCommand<Unit, Unit> ToggleVitalsCommand   { get; }
@@ -4385,7 +4410,7 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         Room.Attach(_core);
         Inventory.Attach(_core);
         Mapper.Attach(_core);
-        StreamTabs.Attach(_core, GameText);
+        StreamTabs.Attach(_core, GameText, IsStreamPanelVisible);
         Experience.Attach(_core);
         ActiveSpells.Attach(_core);
         TimeTracker.Attach(_core);
@@ -4596,31 +4621,6 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
                     _containerNouns.TryRemove(e.TargetId, out _);
                 else
                     _containerNouns[e.TargetId] = e.Title;
-            });
-
-        // ── Fallback: when a stream tool is hidden, mirror its text into the
-        // main Game window so the player still sees it. The StreamBuffer
-        // continues to accumulate either way, so the history is preserved
-        // when the tool is re-opened.
-        _core.GameEvents
-            .OfType<TextEvent>()
-            .ObserveOn(RxApp.MainThreadScheduler)
-            .Subscribe(e =>
-            {
-                var streamVisible = e.Stream.ToLowerInvariant() switch
-                {
-                    "logons"   => LogonsVisible,
-                    "talk"     => TalkVisible,
-                    "whispers" => WhispersVisible,
-                    "thoughts" => ThoughtsVisible,
-                    "combat"   => CombatVisible,
-                    "familiar" => FamiliarVisible,
-                    "death"    => DeathVisible,
-                    "assess"   => AssessVisible,
-                    _          => true   // main + non-tool streams: nothing to mirror
-                };
-                if (!streamVisible)
-                    GameText.AddStreamLine(e.Stream, e.Text);
             });
 
         // Surface timed connect-progress (TLS attempt, per-SGE-step timings,

--- a/src/Genie.App/ViewModels/StreamTabsViewModel.cs
+++ b/src/Genie.App/ViewModels/StreamTabsViewModel.cs
@@ -52,9 +52,22 @@ public class StreamTabsViewModel : ReactiveObject
     /// stream with its <c>EchoToMain</c> toggle on can also post into Main.</summary>
     private GameTextViewModel? _main;
 
-    public void Attach(GenieCore core, GameTextViewModel? main = null)
+    /// <summary>
+    /// Is this stream's dock panel currently open? Supplied by
+    /// <see cref="MainWindowViewModel"/> (which owns the per-tool visibility
+    /// flags) so the closed-panel fallback can be decided here, alongside the
+    /// <c>EchoToMain</c> echo, rather than from a second subscription racing
+    /// over the same event. Absent (or unknown stream) ⇒ treated as open, i.e.
+    /// no fallback.
+    /// </summary>
+    private Func<string, bool>? _isPanelVisible;
+
+    public void Attach(GenieCore core,
+                       GameTextViewModel? main = null,
+                       Func<string, bool>? isPanelVisible = null)
     {
-        _main = main;
+        _main           = main;
+        _isPanelVisible = isPanelVisible;
 
         // Hand each buffer the live Names engine so the per-window "Name List
         // Only" right-click toggle can filter to lines mentioning a tracked
@@ -87,14 +100,8 @@ public class StreamTabsViewModel : ReactiveObject
                 // links and preset colours just like the main window does.
                 buf?.Add(e.Text, e.BoldSpans, e.Links, e.PresetSpans);
 
-                // Per-stream "Also show in Main" (Layout tab). When on, echo the
-                // line into the main game window in addition to its own panel.
-                // buf.Settings is the same WindowSettings instance the Layout tab
-                // mutates, so the toggle takes effect live with no re-subscribe —
-                // exactly like the Timestamp / NameListOnly toggles above. Carry
-                // the spans so the echoed combat hit is gold in Main too (#187).
-                if (buf?.Settings?.EchoToMain == true)
-                    _main?.EchoStreamToMain(e.Text, e.BoldSpans, e.Links, e.PresetSpans);
+                if (buf is not null)
+                    RouteToMain(buf, e);
 
                 // The Log window is a consolidated conversation feed: mirror
                 // the speech streams into it (matches the Genie 4 / dylb0t
@@ -102,6 +109,53 @@ public class StreamTabsViewModel : ReactiveObject
                 if (e.Stream is "talk" or "whispers")
                     Log.Add(e.Text, e.BoldSpans, e.Links, e.PresetSpans);
             });
+    }
+
+    /// <summary>
+    /// Decide whether a side-stream line also lands in the main game window,
+    /// and in which form. The two routes are mutually exclusive — a line is
+    /// mirrored into Main at most once:
+    /// <list type="bullet">
+    /// <item><b>EchoToMain on</b> (the default) — Genie 4's per-stream "also
+    /// show in Main". Echoed plain, no prefix, whether the stream's own panel
+    /// is open or closed.</item>
+    /// <item><b>EchoToMain off, panel closed</b> — the visibility fallback, so
+    /// text isn't silently lost while its window is hidden. Prefixed
+    /// <c>[stream]</c> to mark where it came from.</item>
+    /// <item><b>EchoToMain off, panel open</b> — nothing; the panel has it.</item>
+    /// </list>
+    /// <para>
+    /// Both routes are settled here, from the one subscription that already
+    /// resolved the buffer, so they cannot both fire for the same event — the
+    /// bug that showed up as every combat line appearing twice in Main (once
+    /// plain, once <c>[combat] …</c>) the moment the Combat panel was closed.
+    /// Reading <c>buf.Settings</c> rather than the settings store also keeps
+    /// the decision on the same instance the echo uses; a buffer with no
+    /// settings yet (pre dock-build) reads as "not echoing" and falls through
+    /// to the fallback, so a line can never vanish.
+    /// </para>
+    /// <para>
+    /// Where a closed panel's text goes is hard-wired to Main here.
+    /// <see cref="WindowSettings.IfClosed"/> — which can name a different
+    /// target window (talk → conversation, and so on) — is still unimplemented;
+    /// honouring it means resolving that id to a sink and following the chain
+    /// when the target is itself closed. This is the single place that changes.
+    /// </para>
+    /// </summary>
+    private void RouteToMain(StreamBuffer buf, TextEvent e)
+    {
+        // buf.Settings is the same WindowSettings instance the Layout tab
+        // mutates, so the toggle takes effect live with no re-subscribe —
+        // exactly like the Timestamp / NameListOnly toggles. Carry the spans so
+        // the echoed combat hit is gold in Main too (#187).
+        if (buf.Settings?.EchoToMain == true)
+        {
+            _main?.EchoStreamToMain(e.Text, e.BoldSpans, e.Links, e.PresetSpans);
+            return;
+        }
+
+        if (_isPanelVisible?.Invoke(e.Stream) == false)
+            _main?.AddStreamLine(e.Stream, e.Text);
     }
 }
 


### PR DESCRIPTION
## The bug

Close a stream window (Combat, Talk, …) and every one of its lines starts showing up in the main game window **twice** — once plain, once prefixed `[combat]`.

Two independent subscriptions were mirroring the same `TextEvent` into Main, neither aware of the other:

- `StreamTabsViewModel` echoed the line whenever the stream's `EchoToMain` ("also show in Main window") toggle was on. That path runs whether the panel is open or closed, and `EchoToMain` defaults to on.
- `MainWindowViewModel` had a separate closed-panel fallback that mirrored the line with a `[stream]` prefix whenever the tool was hidden.

With the panel open only the first fired, which is why this only surfaced on close.

## The fix

Fold the fallback into the subscription that had already resolved the buffer, as one `RouteToMain` decision:

- `EchoToMain` on → echo plain, no prefix (panel open or closed)
- `EchoToMain` off + panel closed → bracketed `[stream]` fallback
- `EchoToMain` off + panel open → nothing, the panel has it

The two routes are now branches of a single if/else rather than separate subscribers, so they can't both fire for one event.

Routing now also reads `buf.Settings` — the same `WindowSettings` instance the echo path uses — instead of looking the id up in the store a second time. The two can't drift, and a buffer with no settings yet (before the dock is built) reads as "not echoing" and falls through to the fallback rather than dropping the line.

`MainWindowViewModel` keeps ownership of the visibility flags and hands `StreamTabsViewModel` an `IsStreamPanelVisible` predicate.

## Behaviour

Unchanged apart from the duplicate. Same eight streams get the fallback; atmospherics/log/itemlog still fall through as visible.

| Panel | EchoToMain | Main window |
| --- | --- | --- |
| open | on | plain line (unchanged) |
| open | off | nothing (unchanged) |
| closed | on | plain line only — **was duplicated** |
| closed | off | `[combat] …` fallback (unchanged) |

## Test plan

- [x] Combat window open: combat lines appear in the Combat panel and once, unprefixed, in Main
- [x] Close the Combat window: lines still appear once in Main, unprefixed — no `[combat]` duplicate
- [x] Turn "Also show in Main window" **off** for Combat, panel open: lines appear only in the Combat panel
- [x] With it off, close the panel: lines appear in Main prefixed `[combat]`
- [x] Re-open the panel: scrollback preserved (the buffer accumulates either way)
- [x] Toggling the setting takes effect live, without a reconnect
