### PR TITLE
fix(macos): name the application menu "Genie 5"

### DIFF
--- a/src/Genie.App/App.axaml
+++ b/src/Genie.App/App.axaml
@@ -6,6 +6,7 @@
              xmlns:controls="using:Genie.App.Controls"
              xmlns:core="using:Dock.Model.Core"
              x:Class="Genie.App.App"
+             Name="Genie 5"
              RequestedThemeVariant="Dark">
 
   <!-- Genie 4-style skinned chrome for windowed (MDI) child windows. Overrides


### PR DESCRIPTION
## Summary

On macOS the application menu was titled **"Avalonia Application"** instead of "Genie 5". Avalonia sets the NSApplication name at runtime from `Application.Name`, which we never set, so it fell back to its default.

This is not a packaging problem: the bundle's `CFBundleName` / `CFBundleDisplayName` are honoured for the Dock (which already showed the right name and icon) but never reach the menu bar, so it has to be fixed in the app.

One attribute on the `<Application>` root:

```diff
               x:Class="Genie.App.App"
+              Name="Genie 5"
               RequestedThemeVariant="Dark">
```

Refs #214 — deliberately **not** "Closes", because that issue also covers the app menu's first item still reading "About Avalonia". That string comes from Avalonia's default app menu (the app declares no `NativeMenu`) and needs a separate, larger change; I couldn't find it as a literal in any Avalonia 11.3.11 assembly or in `libAvaloniaNative.dylib`. Leaving #214 open to track it.

## Test plan

Note this can't be seen via `dotnet run` — with no `.app` bundle, macOS shows no menu-bar app name at all. It needs a bundle.

- Built a local `.app` bundle by hand per `docs/build-and-release.md` (macOS 15, Apple Silicon, `5.0.0-beta.4`), pointing at the build output.
- Launched it and read the registered name — **before**: `"LSDisplayName"="Avalonia Application"`; **after**: `"LSDisplayName"="Genie 5"`, with no `Info.plist` change and no re-pack between the two runs, so the attribute is the only variable.
- Confirmed visually in the menu bar: the application menu now reads "Genie 5".
- Confirmed the Dock label and icon are unchanged (they were already correct).

Blast radius is small — `Application.Name` is metadata that Avalonia uses for the macOS app name; nothing binds to it in this codebase (no `NativeMenu`, no `MacOSPlatformOptions`). No behaviour change on Windows or Linux.

## Checklist

- [x] `dotnet build -c Release` succeeds cleanly (warnings OK, errors not)
- [x] `dotnet test tests/Genie.Core.Tests -c Release` passes (CI runs this on every PR), plus relevant test-harness modes for the subsystems I touched — 800/800 passed
- [x] **No machine-specific paths** committed (no `C:\Users\…`, no hard-coded home dirs, no local absolute paths — use `AppPaths` / config)
- [x] **No AI brand references** in tracked files (the public repo stays vendor-neutral)
- [x] Docs updated if user-visible behaviour changed (README / CONTRIBUTING / `docs/`) — n/a, no doc states the menu-bar name
- [x] This is a focused PR — one feature or one fix

## Compatibility & policy

- [x] **DR policy acknowledged** — this change introduces no auto-reconnect, no agentive AI driving commands, no headless mode, and ships no other-player speech off-machine without consent. Anything that constrains how a player runs the client is opt-in and off by default. (See `docs/POLICY.md`.)
