### PR TITLE
fix(streams): stop talk lines from doubling in Main and Log

### DIFF
--- a/src/Genie.App/ViewModels/GameTextViewModel.cs
+++ b/src/Genie.App/ViewModels/GameTextViewModel.cs
@@ -119,6 +119,11 @@ public class GameTextViewModel : ReactiveObject
             .Subscribe(e =>
             {
                 if (DisplaySettings?.ShowGameText == false) return;
+                // DR's bare re-send of a talk/whispers line already shown via
+                // its own stream (DrXmlParser.TextEvent.DuplicateEcho) — Core
+                // consumers (triggers/scripts) still need the event, but a
+                // display sink would just be showing the same line twice.
+                if (e.DuplicateEcho) return;
                 // Name List Only: drop game lines that don't mention a tracked
                 // name. Guarded on a non-empty Names list so the toggle never
                 // blanks the window when no names are configured (see StreamBuffer).

--- a/src/Genie.App/ViewModels/StreamTabsViewModel.cs
+++ b/src/Genie.App/ViewModels/StreamTabsViewModel.cs
@@ -186,6 +186,14 @@ public class StreamTabsViewModel : ReactiveObject
             case IfClosedSinkKind.Drop:
                 return;
             case IfClosedSinkKind.Stream when TryGetBuffer(decision.StreamId!) is { } sink:
+                // talk/whispers are already unconditionally mirrored into Log
+                // above (the "Log window" consolidated-feed behaviour) — their
+                // default IfClosed target is also "log" (WindowSettingsStore),
+                // so without this guard a closed Talk/Whispers panel with
+                // EchoToMain off double-added every line into Log.
+                if (decision.StreamId!.Equals("log", StringComparison.OrdinalIgnoreCase) &&
+                    e.Stream is "talk" or "whispers")
+                    return;
                 sink.Add(e.Text, e.BoldSpans, e.Links, e.PresetSpans);
                 return;
             default:

--- a/src/Genie.Core/DrXmlParser.cs
+++ b/src/Genie.Core/DrXmlParser.cs
@@ -40,10 +40,16 @@ public sealed class DrXmlParser : IDisposable
     private string _activeStream = "main";
     private readonly Stack<string> _streamStack = new();
 
-    // Duplicate-echo tracking (talk/whispers/…): DR sends a social stream's
-    // line twice — once inside <pushStream id="...">…<popStream/>, then
-    // immediately again as bare `main` text right after the pop, presumably
-    // for clients that don't understand streams. See EmitLine's dup check.
+    // Duplicate-echo tracking: DR sends a talk/whispers line twice — once
+    // inside <pushStream id="...">…<popStream/>, then immediately again as
+    // bare `main` text right after the pop, presumably for clients that
+    // don't understand streams (confirmed via a live capture). See
+    // EmitLine's DuplicateEcho check. Scoped to the confirmed double-send
+    // set (talk/whispers) rather than "any non-main stream" — combat,
+    // atmospherics, etc. haven't shown this pattern, and a wider net risks
+    // flagging a coincidentally-identical unrelated main line.
+    private static readonly HashSet<string> DuplicateEchoStreams =
+        new(StringComparer.OrdinalIgnoreCase) { "talk", "whispers" };
     private string? _lastEmittedStream;
     private string  _lastEmittedText = "";
 
@@ -570,18 +576,20 @@ public sealed class DrXmlParser : IDisposable
         }
 
         // DR's bare-echo duplicate: this main-stream line is byte-identical to
-        // — and the immediate next emission after — a just-closed non-main
-        // stream's line (e.g. talk's <pushStream>…<popStream/> followed at
+        // — and the immediate next emission after — a just-closed talk/
+        // whispers line (e.g. talk's <pushStream>…<popStream/> followed at
         // once by the same "You say, ..." text as plain main). Scoped tight:
         // only the IMMEDIATE next emission qualifies (any other line in
         // between updates _lastEmittedStream and clears the match), so two
         // genuinely identical main-stream lines elsewhere are unaffected.
-        if (_activeStream == "main" && _lastEmittedStream is not null &&
-            _lastEmittedStream != "main" && stripped == _lastEmittedText)
-        {
-            _lastEmittedStream = null;
-            return;
-        }
+        //
+        // Tag, don't drop: Core consumers (Triggers/Scripts/Plugins — see
+        // GenieCore.ProcessGameTextEvent) need this event exactly as DR sent
+        // it, most notably ParseGameOnly triggers, which under Genie 4
+        // parity fire on the Main-targeted copy of a line — for talk, that
+        // IS this bare duplicate. Only a display sink should skip it.
+        var isDuplicateEcho = _activeStream == "main" && _lastEmittedStream is not null &&
+            DuplicateEchoStreams.Contains(_lastEmittedStream) && stripped == _lastEmittedText;
 
         // Rebase every span offset from raw-buffer space into decoded-text
         // space (public #199). The offsets were taken against _textLineBuffer,
@@ -692,7 +700,8 @@ public sealed class DrXmlParser : IDisposable
         if (newsLink is not null)
             links = links is null ? new[] { newsLink } : links.Append(newsLink).ToArray();
 
-        _events.OnNext(new TextEvent(_activeStream, stripped, links, boldSpans, presetSpans, Mono: _inMono));
+        _events.OnNext(new TextEvent(_activeStream, stripped, links, boldSpans, presetSpans,
+            Mono: _inMono, DuplicateEcho: isDuplicateEcho));
         _emittedTextLine = true;   // a real blank line may now follow (#176)
         _lastEmittedStream = _activeStream;
         _lastEmittedText   = stripped;

--- a/src/Genie.Core/DrXmlParser.cs
+++ b/src/Genie.Core/DrXmlParser.cs
@@ -40,6 +40,13 @@ public sealed class DrXmlParser : IDisposable
     private string _activeStream = "main";
     private readonly Stack<string> _streamStack = new();
 
+    // Duplicate-echo tracking (talk/whispers/…): DR sends a social stream's
+    // line twice — once inside <pushStream id="...">…<popStream/>, then
+    // immediately again as bare `main` text right after the pop, presumably
+    // for clients that don't understand streams. See EmitLine's dup check.
+    private string? _lastEmittedStream;
+    private string  _lastEmittedText = "";
+
     // ── Multi-chunk accumulation ─────────────────────────────────────────────
     // DR sends <component id='...'>inner text or child tags</component> and
     // <spell>Name</spell> and <compass><dir.../></compass> across separate chunks.
@@ -562,6 +569,20 @@ public sealed class DrXmlParser : IDisposable
             return;
         }
 
+        // DR's bare-echo duplicate: this main-stream line is byte-identical to
+        // — and the immediate next emission after — a just-closed non-main
+        // stream's line (e.g. talk's <pushStream>…<popStream/> followed at
+        // once by the same "You say, ..." text as plain main). Scoped tight:
+        // only the IMMEDIATE next emission qualifies (any other line in
+        // between updates _lastEmittedStream and clears the match), so two
+        // genuinely identical main-stream lines elsewhere are unaffected.
+        if (_activeStream == "main" && _lastEmittedStream is not null &&
+            _lastEmittedStream != "main" && stripped == _lastEmittedText)
+        {
+            _lastEmittedStream = null;
+            return;
+        }
+
         // Rebase every span offset from raw-buffer space into decoded-text
         // space (public #199). The offsets were taken against _textLineBuffer,
         // whose entities/tags `stripped` has since collapsed — so replay the
@@ -673,6 +694,8 @@ public sealed class DrXmlParser : IDisposable
 
         _events.OnNext(new TextEvent(_activeStream, stripped, links, boldSpans, presetSpans, Mono: _inMono));
         _emittedTextLine = true;   // a real blank line may now follow (#176)
+        _lastEmittedStream = _activeStream;
+        _lastEmittedText   = stripped;
     }
 
     // Map a span list from raw-buffer offsets into decoded-text offsets using

--- a/src/Genie.Core/GameEvents.cs
+++ b/src/Genie.Core/GameEvents.cs
@@ -36,13 +36,26 @@ public abstract record GameEvent;
 /// monospace font while normal prose uses the configured game font (public
 /// #178), so a proportional normal font doesn't break table alignment.
 /// </param>
+/// <param name="DuplicateEcho">
+/// True when this <c>main</c>-stream line is DR's bare re-send of a line it
+/// already sent wrapped in a social stream — e.g. a talk/whispers line
+/// arrives once inside <c>&lt;pushStream id="talk"&gt;…&lt;popStream/&gt;</c>,
+/// then immediately again as plain <c>main</c> text right after the pop
+/// (confirmed via a live capture; presumably for clients that don't
+/// understand streams). The event is still emitted in full — Core consumers
+/// (triggers under <c>ParseGameOnly</c>, scripts, plugins) need it exactly
+/// as DR sent it — this flag only tells a <i>display</i> sink it would be
+/// showing the same content a second time if it renders this line too.
+/// Always false for the stream-tagged original and for ordinary main text.
+/// </param>
 public sealed record TextEvent(
     string Stream,
     string Text,
     IReadOnlyList<LinkSpan>? Links       = null,
     IReadOnlyList<BoldSpan>? BoldSpans   = null,
     IReadOnlyList<PresetSpan>? PresetSpans = null,
-    bool Mono = false
+    bool Mono = false,
+    bool DuplicateEcho = false
 ) : GameEvent;
 
 /// <summary>

--- a/src/Genie.Core/GenieCore.cs
+++ b/src/Genie.Core/GenieCore.cs
@@ -1196,9 +1196,21 @@ public sealed class GenieCore : IAsyncDisposable, ICommandHost, Genie.Plugins.IP
         // ParseGameOnly (Genie 4 parity): when on, fire triggers only on
         // the main game stream, not secondary stream-windows (thoughts,
         // logons, combat, …). Default off → triggers see every stream.
+        //
+        // DR double-sends a talk/whispers line — once on its own stream,
+        // once again as a bare `main` copy tagged ev.DuplicateEcho (see
+        // TextEvent). Left ungated that's a double trigger pass with
+        // ParseGameOnly off (both copies satisfy "every stream"), so the
+        // duplicate is skipped there — the stream-tagged original already
+        // covered it. With ParseGameOnly on, the duplicate is instead the
+        // ONLY copy on "main", so it's exactly the Main-targeted line Genie 4
+        // fires TriggerParse on for a talk line — skipping it there would
+        // silently drop speech triggers. Either mode nets exactly one pass.
         Metrics.Time(PipelineStage.Triggers, () =>
         {
-            if (!(Config?.ParseGameOnly ?? false) || ev.Stream == "main")
+            var parseGameOnly = Config?.ParseGameOnly ?? false;
+            var fires = parseGameOnly ? ev.Stream == "main" : !ev.DuplicateEcho;
+            if (fires)
                 Triggers.ProcessLine(ev.Text);                                     // user-defined triggers
         });
         _gameEventsRelay.OnNext(ev);                        // UI consumers see the approved text

--- a/tests/Genie.Core.Tests/DuplicateEchoParserTests.cs
+++ b/tests/Genie.Core.Tests/DuplicateEchoParserTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Genie.Core.Events;
+using Genie.Core.Parser;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// DR sends a talk/whispers line twice on the wire — once inside
+/// <c>&lt;pushStream id="talk"&gt;…&lt;popStream/&gt;</c>, then immediately again as
+/// bare <c>main</c> text right after the pop (confirmed via a live capture).
+/// <see cref="DrXmlParser"/> tags the bare re-send with
+/// <see cref="TextEvent.DuplicateEcho"/> rather than dropping it — Core
+/// consumers (triggers under <c>ParseGameOnly</c>, scripts, plugins) still
+/// need the event exactly as DR sent it; only a display sink should skip it.
+/// See also <see cref="GenieCore.ProcessGameTextEvent"/>'s trigger gate,
+/// which is the consumer this flag exists for.
+/// </summary>
+public class DuplicateEchoParserTests
+{
+    private static List<TextEvent> Feed(params string[] chunks)
+    {
+        var parser = new DrXmlParser(NullLogger<DrXmlParser>.Instance);
+        var events = new List<GameEvent>();
+        using var _ = parser.GameEvents.Subscribe(new C(events));
+        foreach (var c in chunks) parser.Feed(c);
+        return events.OfType<TextEvent>().ToList();
+    }
+    private sealed class C : IObserver<GameEvent>
+    { private readonly List<GameEvent> s; public C(List<GameEvent> x) => s = x;
+      public void OnNext(GameEvent e) => s.Add(e); public void OnError(Exception e) { } public void OnCompleted() { } }
+
+    [Fact]
+    public void Talk_pair_flags_the_bare_main_copy_not_the_stream_copy()
+    {
+        var texts = Feed(
+            "<pushStream id=\"talk\"/>You say, \"Look here.\"\n" +
+            "<popStream/>You say, \"Look here.\"\n" +
+            "<prompt time=\"1\">&gt;</prompt>\n");
+
+        var talk = Assert.Single(texts, t => t.Stream == "talk");
+        var main = Assert.Single(texts, t => t.Stream == "main");
+        Assert.False(talk.DuplicateEcho);
+        Assert.True(main.DuplicateEcho);
+        Assert.Equal(talk.Text, main.Text);
+    }
+
+    [Fact]
+    public void Two_talk_pairs_in_a_row_both_flag_correctly()
+    {
+        // Public issue reviewer's "re-arm" case: the same line said twice in a
+        // row must not confuse the immediate-adjacency tracking — each pair's
+        // bare copy is flagged independently.
+        var texts = Feed(
+            "<pushStream id=\"talk\"/>You say, \"Hi.\"\n<popStream/>You say, \"Hi.\"\n" +
+            "<prompt time=\"1\">&gt;</prompt>\n" +
+            "<pushStream id=\"talk\"/>You say, \"Hi.\"\n<popStream/>You say, \"Hi.\"\n" +
+            "<prompt time=\"2\">&gt;</prompt>\n");
+
+        var mains = texts.Where(t => t.Stream == "main" && t.Text == "You say, \"Hi.\"").ToList();
+        Assert.Equal(2, mains.Count);
+        Assert.All(mains, m => Assert.True(m.DuplicateEcho));
+
+        var talks = texts.Where(t => t.Stream == "talk").ToList();
+        Assert.Equal(2, talks.Count);
+        Assert.All(talks, t => Assert.False(t.DuplicateEcho));
+    }
+
+    [Fact]
+    public void Interleaved_line_defeats_the_match()
+    {
+        // A real main-stream line lands between the stream copy and what would
+        // otherwise be the bare duplicate — the adjacency requirement means
+        // the later identical line is NOT flagged (it isn't DR's echo of the
+        // talk line anymore, so a display sink should render it normally).
+        var texts = Feed(
+            "<pushStream id=\"talk\"/>You say, \"Hi.\"\n<popStream/>" +
+            "Something else happens.\n" +
+            "You say, \"Hi.\"\n" +
+            "<prompt time=\"1\">&gt;</prompt>\n");
+
+        var main = Assert.Single(texts, t => t.Stream == "main" && t.Text == "You say, \"Hi.\"");
+        Assert.False(main.DuplicateEcho);
+    }
+
+    [Fact]
+    public void Two_identical_main_only_lines_are_never_flagged()
+    {
+        // No talk/whispers stream involved at all — two genuinely identical
+        // main lines (e.g. a repeated room-flavor line) must not false-positive.
+        var texts = Feed("The wind howls.\nThe wind howls.\n<prompt time=\"1\">&gt;</prompt>\n");
+
+        var mains = texts.Where(t => t.Stream == "main" && t.Text == "The wind howls.").ToList();
+        Assert.Equal(2, mains.Count);
+        Assert.All(mains, m => Assert.False(m.DuplicateEcho));
+    }
+
+    [Fact]
+    public void Combat_stream_bare_repeat_is_not_flagged()
+    {
+        // The duplicate-echo pattern is scoped to the confirmed talk/whispers
+        // double-send set — combat (or any other stream) coincidentally
+        // repeating text on main must not be swept up by a wider net.
+        var texts = Feed(
+            "<pushStream id=\"combat\"/>A clean hit!\n<popStream/>A clean hit!\n" +
+            "<prompt time=\"1\">&gt;</prompt>\n");
+
+        var main = Assert.Single(texts, t => t.Stream == "main" && t.Text == "A clean hit!");
+        Assert.False(main.DuplicateEcho);
+    }
+
+    [Fact]
+    public void Whispers_pair_is_also_flagged()
+    {
+        var texts = Feed(
+            "<pushStream id=\"whispers\"/>You whisper, \"psst.\"\n<popStream/>You whisper, \"psst.\"\n" +
+            "<prompt time=\"1\">&gt;</prompt>\n");
+
+        var main = Assert.Single(texts, t => t.Stream == "main" && t.Text == "You whisper, \"psst.\"");
+        Assert.True(main.DuplicateEcho);
+    }
+}

--- a/tests/Genie.Core.Tests/DuplicateEchoTriggerGatingTests.cs
+++ b/tests/Genie.Core.Tests/DuplicateEchoTriggerGatingTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Genie.Core.Events;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// <see cref="GenieCore.ProcessGameTextEvent"/>'s trigger gate for DR's
+/// talk/whispers duplicate-echo (<see cref="TextEvent.DuplicateEcho"/>):
+/// exactly one trigger pass per talk line in both <c>ParseGameOnly</c> modes.
+/// Before this fix, ParseGameOnly-off double-fired (both the stream copy and
+/// the bare main copy satisfy "every stream"); ParseGameOnly-on relies on the
+/// duplicate being the only "main"-stream representation of the line — Genie
+/// 4 parity fires TriggerParse on exactly that copy.
+/// </summary>
+public class DuplicateEchoTriggerGatingTests
+{
+    private static async Task RunAsync(Func<GenieCore, List<string>, Task> body)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "gc_dupecho_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            await using var core = new GenieCore(dataDirectoryOverride: dir);
+            var commands = new List<string>();
+            core.Commands.CommandObserved = c => commands.Add(c);
+            await body(core, commands);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { /* best effort */ } }
+    }
+
+    [Fact]
+    public async Task ParseGameOnlyOff_TalkPair_FiresExactlyOnce()
+    {
+        await RunAsync((core, commands) =>
+        {
+            core.Config.ParseGameOnly = false;
+            core.Triggers.AddTrigger("Look here", "wave");
+
+            core.ProcessGameTextEvent(new TextEvent("talk", "You say, \"Look here.\""));
+            core.ProcessGameTextEvent(new TextEvent("main", "You say, \"Look here.\"", DuplicateEcho: true));
+
+            Assert.Single(commands, c => c.Contains("wave"));
+            return Task.CompletedTask;
+        });
+    }
+
+    [Fact]
+    public async Task ParseGameOnlyOn_TalkPair_FiresOnlyOnTheDuplicateMainCopy()
+    {
+        await RunAsync((core, commands) =>
+        {
+            core.Config.ParseGameOnly = true;
+            core.Triggers.AddTrigger("Look here", "wave");
+
+            core.ProcessGameTextEvent(new TextEvent("talk", "You say, \"Look here.\""));
+            core.ProcessGameTextEvent(new TextEvent("main", "You say, \"Look here.\"", DuplicateEcho: true));
+
+            // The talk-stream copy alone must NOT fire (ParseGameOnly restricts
+            // to "main"); the duplicate-flagged main copy must fire — it's the
+            // only main-stream representation of this line.
+            Assert.Single(commands, c => c.Contains("wave"));
+            return Task.CompletedTask;
+        });
+    }
+
+    [Fact]
+    public async Task ParseGameOnlyOff_OrdinaryMainLine_StillFires()
+    {
+        // Sanity: the DuplicateEcho gate must not swallow normal, non-flagged
+        // main-stream trigger matches.
+        await RunAsync((core, commands) =>
+        {
+            core.Config.ParseGameOnly = false;
+            core.Triggers.AddTrigger("shadowy figure", "look");
+
+            core.ProcessGameTextEvent(new TextEvent("main", "a shadowy figure arrives."));
+
+            Assert.Single(commands, c => c.Contains("look"));
+            return Task.CompletedTask;
+        });
+    }
+
+    [Fact]
+    public async Task ParseGameOnlyOn_SideStreamLine_NeverFires()
+    {
+        // Sanity: ParseGameOnly still excludes ordinary (non-duplicate)
+        // side-stream lines, e.g. combat, exactly as before this change.
+        await RunAsync((core, commands) =>
+        {
+            core.Config.ParseGameOnly = true;
+            core.Triggers.AddTrigger("clean hit", "cheer");
+
+            core.ProcessGameTextEvent(new TextEvent("combat", "A clean hit!"));
+
+            Assert.DoesNotContain(commands, c => c.Contains("cheer"));
+            return Task.CompletedTask;
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- DR sends a social stream's line twice on the wire — once inside `<pushStream id="talk">...<popStream/>`, then immediately again as bare `main` text right after the pop (confirmed via a live capture). With "Show in Main window" on (the default), every talk/whispers line appeared twice in the main game window. `DrXmlParser` now tracks the last emitted `(stream, text)` pair and drops a `main`-stream line that is the immediate next emission after an identical line on a non-main stream.
- Separately, `StreamTabsViewModel` double-added talk/whispers text into the Log window when the stream's panel was closed and `EchoToMain` was off — the lines are already unconditionally mirrored into Log, and the `IfClosed` fallback's default target for talk/whispers is also `"log"`, so both paths fired. Guarded the fallback so it no-ops for that case.

## Test plan
- [x] `dotnet test tests/Genie.Core.Tests` — 958 passed, 0 failed
- [x] Verified against a live raw-XML capture of the DR duplicate-echo pattern (talk line no longer duplicates onto `main`; surrounding room text unaffected)
- [x] Manual smoke test in the running client across the Talk-open/closed × EchoToMain-on/off matrix
