### PR TITLE
fix(input): forward Backspace/Delete/Enter/arrows to the command bar when unfocused

### DIFF
--- a/src/Genie.App/Controls/GameTextArea.cs
+++ b/src/Genie.App/Controls/GameTextArea.cs
@@ -12,10 +12,10 @@ namespace Genie.App.Controls;
 ///
 /// <para>AvaloniaEdit swallows typing whether or not the editor is read-only:
 /// <c>TextArea.OnTextInput</c> marks the event handled after calling
-/// <c>PerformTextInput</c>, and the Backspace/Delete/Enter key bindings mark
-/// their <c>KeyDown</c> handled from the command handler. <c>IsReadOnly</c> only
-/// stops the document from changing — it does not stop the event from being
-/// consumed.</para>
+/// <c>PerformTextInput</c>, and the Backspace/Delete/Enter/arrow key bindings
+/// mark their <c>KeyDown</c> handled from the command handler. <c>IsReadOnly</c>
+/// only stops the document from changing — it does not stop the event from
+/// being consumed.</para>
 ///
 /// <para>That silently broke type-anywhere (#141). <c>MainWindow</c> listens for
 /// <c>TextInput</c> on the bubble route with <c>handledEventsToo: false</c> and
@@ -27,27 +27,62 @@ namespace Genie.App.Controls;
 /// <para>Nothing suppressed here is behaviour worth keeping: the view is
 /// read-only, so every one of these commands was already a no-op on the
 /// document — apart from the <c>BringCaretToView()</c> that ends the delete and
-/// enter handlers, which yanks a scrolled-back view down to the caret.</para>
+/// enter handlers (which yanks a scrolled-back view down to the caret) and the
+/// arrow keys' own caret-move/scroll, none of which matters when nothing is
+/// ever typed into this view.</para>
 /// </summary>
 internal sealed class GameTextArea : TextArea
 {
     /// <summary>Keys whose editing bindings are dropped so the keystroke keeps
-    /// bubbling to <c>MainWindow</c>: Backspace is the other half of #141
-    /// (it produces no <c>TextInput</c>, so it has its own redirect), Delete and
-    /// Enter are removed for the caret-scroll reason above.</summary>
-    private static readonly Key[] SuppressedEditingKeys = [Key.Back, Key.Delete, Key.Enter];
+    /// bubbling to <c>MainWindow</c>'s forward-to-command-bar handler:
+    /// Backspace is the other half of #141 (it produces no <c>TextInput</c>,
+    /// so it has its own redirect); Delete, Enter and the arrow keys are
+    /// removed so history recall (Up/Down) and submit (Enter) reach the
+    /// command bar even when the Game window has focus, same reasoning as
+    /// the caret-scroll suppression above. All modifier variants of these
+    /// keys go with them (e.g. Ctrl+Left word-jump) — read-only, so none of
+    /// it was doing anything worth keeping anyway.</summary>
+    private static readonly Key[] SuppressedEditingKeys =
+        [Key.Back, Key.Delete, Key.Enter, Key.Up, Key.Down, Key.Left, Key.Right];
 
     public GameTextArea()
     {
-        // The Editing handler copies the shared static binding list into its own
-        // on creation (EditingCommandHandler.Create), so pruning it here affects
-        // this TextArea only. Copy/Cut/Paste are not key bindings — they are
-        // matched from CommandBindings against the platform gesture — so Cmd+C /
-        // Ctrl+C is untouched.
-        foreach (var binding in DefaultInputHandler.Editing.KeyBindings
-                     .Where(b => b.Gesture is { } gesture && SuppressedEditingKeys.Contains(gesture.Key))
-                     .ToList())
-            DefaultInputHandler.Editing.KeyBindings.Remove(binding);
+        // Both the Editing and CaretNavigation nested handlers copy their
+        // own static binding lists into per-instance copies on creation
+        // (EditingCommandHandler.Create / CaretNavigationCommandHandler.Create),
+        // so pruning either here affects this TextArea only.
+        //
+        // Two passes are needed, not one. Most of what we're suppressing —
+        // EditingCommands.Delete/Backspace/EnterParagraphBreak, and every
+        // EditingCommands.Move*/Select* the arrow keys drive — are bare
+        // RoutedCommands with no gesture of their own; they fire purely
+        // through the handler's KeyBindings list, which the first loop
+        // below strips (arrow-key caret movement lives in the separate
+        // CaretNavigation handler, not Editing, hence looping over both).
+        // But AvaloniaEdit's ApplicationCommands.Delete is different: it's
+        // defined with its own baked-in `new KeyGesture(Key.Delete)`, and
+        // TextAreaInputHandler.TextAreaOnKeyDown checks CommandBindings
+        // against each command's own Gesture as a SEPARATE pass, after the
+        // KeyBindings pass — so removing only the KeyBindings entry left
+        // Delete still swallowed by that second pass (#141 follow-up: Delete
+        // wasn't reaching the command bar even though Backspace/Enter, which
+        // have no such gesture-bearing command, worked fine). The second
+        // loop below removes any CommandBindings entry whose command has a
+        // matching baked-in gesture too. Copy/Cut/Paste use the same
+        // gesture-bearing-command pattern but aren't in SuppressedEditingKeys,
+        // so they're untouched.
+        foreach (var handler in new[] { DefaultInputHandler.Editing, DefaultInputHandler.CaretNavigation })
+        {
+            foreach (var binding in handler.KeyBindings
+                         .Where(b => b.Gesture is { } gesture && SuppressedEditingKeys.Contains(gesture.Key))
+                         .ToList())
+                handler.KeyBindings.Remove(binding);
+
+            foreach (var binding in handler.CommandBindings
+                         .Where(b => b.Command.Gesture is { } gesture && SuppressedEditingKeys.Contains(gesture.Key))
+                         .ToList())
+                handler.CommandBindings.Remove(binding);
+        }
     }
 
     /// <summary>Take the stock <see cref="TextArea"/> control theme; Avalonia keys

--- a/src/Genie.App/Views/MainWindow.axaml.cs
+++ b/src/Genie.App/Views/MainWindow.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.VisualTree;
 using Genie.App.Controls;
 using Genie.App.ViewModels;
 using ReactiveUI;
+using System.Windows.Input;
 
 namespace Genie.App.Views;
 
@@ -567,6 +568,23 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
                                        reverse: e.KeyModifiers.HasFlag(KeyModifiers.Shift)))
                     e.Handled = true;
                 break;
+            case Key.Enter:
+                // Submit is normally wired via the XAML <KeyBinding
+                // Gesture="Return">, which Avalonia matches against the
+                // focused element and marks handled BEFORE the routed
+                // KeyDown dispatch even reaches here — so on a real,
+                // physically-typed Enter this case never runs. It only
+                // fires for a KeyDown synthesized by ForwardKeyToBar
+                // (OnGlobalKeyDown's forward-to-bar fallback), which raises
+                // the event directly and so skips the KeyBindings pass.
+                // Same CanExecute guard the KeyBinding itself uses, so the
+                // two paths behave identically.
+                if (((ICommand)cmd.SubmitCommand).CanExecute(null))
+                {
+                    ((ICommand)cmd.SubmitCommand).Execute(null);
+                    e.Handled = true;
+                }
+                break;
             default:
                 _tabMatches = null;       // any other key resets the cycle
                 break;
@@ -658,6 +676,31 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
         Avalonia.Threading.Dispatcher.UIThread.Post(
             () => tb.CaretIndex = tb.Text?.Length ?? 0);
     }
+
+    /// <summary>
+    /// Re-raises a KeyDown for <paramref name="key"/> directly on <paramref
+    /// name="bar"/> (used by <see cref="OnGlobalKeyDown"/> to forward
+    /// navigation/editing keys once no other control claimed them). This is
+    /// a normal routed KeyDownEvent, so it drives the bar's own <c>OnKeyDown</c>
+    /// override (TextBox's built-in Backspace/Delete/caret-move editing) and
+    /// its instance handler <see cref="CommandInput_KeyDown"/> (Up/Down
+    /// history recall, and Enter's submit fallback) exactly as if the key
+    /// had been pressed with the bar already focused. It deliberately does
+    /// NOT go through <c>KeyBindings</c> matching — those are resolved by
+    /// Avalonia's <c>KeyboardDevice</c> against the focused element BEFORE
+    /// routed dispatch even starts (so CommandInput's own <c>&lt;KeyBinding
+    /// Gesture="Return"&gt;</c> only ever fires for a real, physically-typed
+    /// Enter) — which is exactly why <c>CommandInput_KeyDown</c> carries its
+    /// own manual Enter case: it's the fallback for this forwarded path.
+    /// </summary>
+    private static void ForwardKeyToBar(TextBox bar, Key key, KeyModifiers mods) =>
+        bar.RaiseEvent(new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Source = bar,
+            Key = key,
+            KeyModifiers = mods,
+        });
 
     /// <summary>
     /// Handles Ctrl+Right-Click anywhere in the window. If the click landed
@@ -768,23 +811,40 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
             }
         }
 
-        // #141: Backspace while no text control has focus → edit the command
-        // bar, same as the TextInput redirect below (Backspace produces no
-        // TextInput, so it needs its own hook). A focused TextBox handles its
-        // own Backspace and marks it handled before this bubble handler runs;
-        // the guard is belt-and-braces.
-        if (e.Key == Key.Back && e.KeyModifiers == KeyModifiers.None &&
+        // #141: Backspace/Delete/Enter/arrows while no text control has focus →
+        // forward to the command bar, same idea as the TextInput redirect
+        // below (these keys produce no TextInput, so they need their own
+        // hook). Only bare keypresses are forwarded — modified combos are
+        // left alone in case they're macro-bound. A focused TextBox handles
+        // its own copy of these keys and marks the event handled before this
+        // bubble handler runs; the guard is belt-and-braces. The `e.Source`
+        // check stops the re-raised KeyDown below (see ForwardKeyToBar) from
+        // looping back into this same block once it bubbles back up here.
+        if (e.KeyModifiers == KeyModifiers.None &&
+            !ReferenceEquals(e.Source, CommandInput) &&
             FocusManager?.GetFocusedElement() is not TextBox &&
             CommandInput is { } bar)
         {
-            bar.Focus();
-            if (!string.IsNullOrEmpty(bar.Text))
+            switch (e.Key)
             {
-                bar.Text = bar.Text[..^1];
-                bar.CaretIndex = bar.Text.Length;
+                // TextBox's own OnKeyDown implements Backspace/Delete/caret
+                // movement against whatever CaretIndex/selection it already
+                // has, and CommandInput_KeyDown implements Up/Down history
+                // and (for Enter) a manual submit fallback — so re-raising
+                // the KeyDown directly on the bar after focusing gives all
+                // of that for free, no hand-rolled logic needed here.
+                case Key.Back:
+                case Key.Delete:
+                case Key.Left:
+                case Key.Right:
+                case Key.Up:
+                case Key.Down:
+                case Key.Enter:
+                    bar.Focus();
+                    ForwardKeyToBar(bar, e.Key, e.KeyModifiers);
+                    e.Handled = true;
+                    return;
             }
-            e.Handled = true;
-            return;
         }
 
         // #120: Ctrl+F opens the Find bar on the selected game/stream window —


### PR DESCRIPTION
## Summary
- Extends the #141 type-anywhere redirect (previously Backspace-only) so Delete, Enter, and the arrow keys also focus and act on the command bar when no text control has focus. Backspace/Delete/Left/Right/Up/Down are re-raised as a real `KeyDown` on the bar (native `TextBox` editing + `CommandInput_KeyDown`'s history recall, no hand-rolled caret math); Enter is invoked directly since its submit binding is a `<KeyBinding>` that Avalonia resolves against the focused element before routed dispatch starts, so it can't be reached by re-raising the event.
- Fixes two AvaloniaEdit quirks that were silently blocking this in the Game window (`GameTextArea`): arrow-key caret movement lives in a separate `CaretNavigation` input handler from `Editing` (only the latter was pruned before), and `Delete` is bound twice — a plain `KeyBindings` entry (already pruned) plus `ApplicationCommands.Delete`, whose `RoutedCommand` carries its own baked-in `KeyGesture(Key.Delete)` matched in a separate `CommandBindings` pass regardless of the `KeyBindings` list. Both handlers and both binding collections are now pruned for the forwarded keys.

## Test plan
- [x] Verified in a running debug session: Backspace, Delete, Enter, and all four arrow keys now correctly focus and act on the command bar when pressed while the Game window has focus and nothing is typed.
- [x] `dotnet build src/Genie.App/Genie.App.csproj` compiles clean (no `CS` diagnostics).
- [x] Manual retest across the other docked panels (side stream tabs, room/backpack) once merged.