### PR TITLE
fix(scripting): count inline `then {` headers when matching braces

### DIFF
--- a/src/Genie.Core/Scripting/ScriptParser.cs
+++ b/src/Genie.Core/Scripting/ScriptParser.cs
@@ -452,7 +452,7 @@ public static class ScriptParser
         for (int j = openIdx + 1; j < inst.Lines.Count; j++)
         {
             var t = inst.Lines[j].Trimmed;
-            if (t == "{") depth++;
+            if (t == "{" || OpensInlineBrace(t)) depth++;
             else if (t == "}")
             {
                 depth--;
@@ -460,6 +460,33 @@ public static class ScriptParser
             }
         }
         return -1;
+    }
+
+    /// <summary>
+    /// True when a line's own header opens a brace block — `if … then {`,
+    /// `elseif … then {`, `while … then {`, `if_N … then {`, or `else {`.
+    /// FindMatchingBrace must count these as openers; a bare-"{" check pairs
+    /// a nested `if … then {` block's '}' with the OUTER opener, so the outer
+    /// if's false-jump lands inside its own body (#228).
+    /// </summary>
+    private static bool OpensInlineBrace(string t)
+    {
+        if (t.Length < 2 || t[^1] != '{') return false;
+        if (IsElseLine(t) && !IsElseIfLine(t))
+            return t[4..].Trim() == "{";
+        int sp = t.IndexOf(' ');
+        if (sp < 0) return false;
+        var first = t[..sp];
+        bool header = first.Equals("if",     StringComparison.OrdinalIgnoreCase)
+                   || first.Equals("elseif", StringComparison.OrdinalIgnoreCase)
+                   || first.Equals("while",  StringComparison.OrdinalIgnoreCase)
+                   || (first.Length == 4
+                       && first.StartsWith("if_", StringComparison.OrdinalIgnoreCase)
+                       && char.IsDigit(first[3]));
+        if (!header) return false;
+        int thenIdx = FindThenKeyword(t[(sp + 1)..]);
+        if (thenIdx < 0) return false;
+        return t[(sp + 1 + thenIdx + 4)..].Trim() == "{";
     }
 
     private static bool IsElseLine(string t)

--- a/tests/Genie.Core.Tests/ScriptNestedIfBlockTests.cs
+++ b/tests/Genie.Core.Tests/ScriptNestedIfBlockTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Genie.Core.Scripting;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// #228 — nested `if … then {` blocks. FindMatchingBrace only counted a bare
+/// "{" line as an opener, so a nested `if … then {` header's brace was missed
+/// and the nested block's '}' was paired with the OUTER if. A false outer
+/// condition then jumped INTO its own body (right past the nested block) and
+/// executed the tail lines. These tests drive the real engine end-to-end,
+/// mirroring the issue repro.
+/// </summary>
+public class ScriptNestedIfBlockTests
+{
+    private static List<string> RunFixture(string body)
+    {
+        var echoed = new List<string>();
+        var dir = Path.Combine(Path.GetTempPath(), "gc_nestif_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "t.cmd"), body);
+            var engine = new ScriptEngine(dir, new TypeAheadSession(),
+                                          sendCommand: _ => { }, echo: l => echoed.Add(l));
+            engine.TryStart("t", new List<string>());
+            for (int i = 0; i < 200; i++) engine.Tick();
+            return echoed.FindAll(l => l.StartsWith("T:"));
+        }
+        finally { try { Directory.Delete(dir, true); } catch { /* best effort */ } }
+    }
+
+    // The exact shape from the issue: mallet in hand ⇒ the WHOLE outer block
+    // must be skipped, including the lines after the nested if.
+    private const string IssueRepro =
+        "if (!contains(\"%rh\", \"mallet\")) then {\n" +
+        "    echo T:A\n" +
+        "    if (\"%rh\" != \"Empty\") then {\n" +
+        "        echo T:B\n" +
+        "    }\n" +
+        "    echo T:C\n" +
+        "}\n" +
+        "echo T:DONE\n";
+
+    [Fact]
+    public void False_outer_if_skips_entire_block_including_nested_if()
+    {
+        var o = RunFixture("var rh silversteel mallet\n" + IssueRepro);
+
+        Assert.DoesNotContain("T:A", o);
+        Assert.DoesNotContain("T:B", o);
+        Assert.DoesNotContain("T:C", o);
+        Assert.Contains("T:DONE", o);
+    }
+
+    [Fact]
+    public void True_outer_if_with_true_nested_if_runs_everything()
+    {
+        var o = RunFixture("var rh longsword\n" + IssueRepro);
+
+        Assert.Equal(new[] { "T:A", "T:B", "T:C", "T:DONE" }, o.ToArray());
+    }
+
+    [Fact]
+    public void True_outer_if_with_false_nested_if_skips_only_inner_block()
+    {
+        var o = RunFixture("var rh Empty\n" + IssueRepro);
+
+        Assert.Equal(new[] { "T:A", "T:C", "T:DONE" }, o.ToArray());
+    }
+
+    [Fact]
+    public void Nested_next_line_brace_inside_inline_brace_block()
+    {
+        // Mixed styles: outer `then {`, inner brace on its own line.
+        var o = RunFixture(
+            "var x 1\n" +
+            "if (%x = 2) then {\n" +
+            "    echo T:A\n" +
+            "    if (%x = 1) then\n" +
+            "    {\n" +
+            "        echo T:B\n" +
+            "    }\n" +
+            "    echo T:C\n" +
+            "}\n" +
+            "echo T:DONE\n");
+
+        Assert.Equal(new[] { "T:DONE" }, o.ToArray());
+    }
+
+    [Fact]
+    public void Three_levels_of_nesting_skip_as_one_block()
+    {
+        var o = RunFixture(
+            "var x 1\n" +
+            "if (%x = 2) then {\n" +
+            "    echo T:A\n" +
+            "    if (%x = 1) then {\n" +
+            "        echo T:B\n" +
+            "        if (%x = 1) then {\n" +
+            "            echo T:C\n" +
+            "        }\n" +
+            "        echo T:D\n" +
+            "    }\n" +
+            "    echo T:E\n" +
+            "}\n" +
+            "echo T:DONE\n");
+
+        Assert.Equal(new[] { "T:DONE" }, o.ToArray());
+    }
+
+    [Fact]
+    public void False_outer_if_with_nested_block_still_reaches_its_else()
+    {
+        var o = RunFixture(
+            "var x 1\n" +
+            "if (%x = 2) then {\n" +
+            "    echo T:A\n" +
+            "    if (%x = 1) then {\n" +
+            "        echo T:B\n" +
+            "    }\n" +
+            "    echo T:C\n" +
+            "}\n" +
+            "else\n" +
+            "{\n" +
+            "    echo T:E\n" +
+            "}\n" +
+            "echo T:DONE\n");
+
+        Assert.Equal(new[] { "T:E", "T:DONE" }, o.ToArray());
+    }
+
+    [Fact]
+    public void True_branch_with_nested_block_skips_its_else()
+    {
+        var o = RunFixture(
+            "var x 2\n" +
+            "if (%x = 2) then {\n" +
+            "    echo T:A\n" +
+            "    if (%x = 1) then {\n" +
+            "        echo T:B\n" +
+            "    }\n" +
+            "    echo T:C\n" +
+            "}\n" +
+            "else\n" +
+            "{\n" +
+            "    echo T:E\n" +
+            "}\n" +
+            "echo T:DONE\n");
+
+        Assert.Equal(new[] { "T:A", "T:C", "T:DONE" }, o.ToArray());
+    }
+
+    [Fact]
+    public void While_loop_containing_nested_if_terminates_at_its_own_brace()
+    {
+        var o = RunFixture(
+            "var i 0\n" +
+            "while (%i < 2) then {\n" +
+            "    if (%i = 0) then {\n" +
+            "        echo T:FIRST\n" +
+            "    }\n" +
+            "    math i add 1\n" +
+            "}\n" +
+            "echo T:DONE-%i\n");
+
+        Assert.Equal(new[] { "T:FIRST", "T:DONE-2" }, o.ToArray());
+    }
+}


### PR DESCRIPTION
Fixes #228.

## Root cause

`ScriptParser.FindMatchingBrace` builds the if/else jump maps by scanning for brace lines, but only counted a line as an opener when the whole line was a bare `{`. A nested `if (...) then {` carries its opening brace at the end of the header line, so it was never counted — and the nested block's `}` was paired with the **outer** if instead.

When the outer condition evaluated false, `IfFalseJump` therefore landed just past the *inner* block — still inside the outer body — and executed the tail lines. That's exactly the reported trace: with a mallet already in hand, the outer `if` correctly evaluated `False`, yet `echo DEBUG: Should not be called...` and `get my mallet` still ran.

## Fix

A new `OpensInlineBrace()` helper recognizes header lines that open a block with a trailing brace — `if / elseif / while / if_N ... then {` and `else {` — using the same quote-aware `then` scanner the parser already uses, so depth tracking survives arbitrary nesting. The runtime needed no changes; it relies entirely on the parser-built jump maps.

## Tests

New `ScriptNestedIfBlockTests` drives 8 scenarios end-to-end through the real engine:

- the exact issue repro in all three hand states (mallet / other item / empty)
- mixed brace styles (inline `then {` outer, next-line `{` inner)
- three-level nesting skipped as one block
- if/else chains where the true branch contains a nested block (both directions)
- a `while` loop containing a nested if terminating at its own brace

5 of the 8 fail without the fix. Full Genie.Core suite: 996/996 passing.