### PR TITLE
fix(scripting): allow mid-word variable shrink breaks on exact-case matches

### DIFF
--- a/src/Genie.Core/Scripting/ScriptEngine.cs
+++ b/src/Genie.Core/Scripting/ScriptEngine.cs
@@ -2893,32 +2893,46 @@ public sealed class ScriptEngine
         // "-1" when only `count` is defined. If nothing resolves, the full
         // candidate is consumed and substituted as empty.
         //
-        // A shrunk candidate may only break where the remainder does NOT start
-        // with a letter — i.e. never in the middle of a word (public #171).
-        // Without this, an UNDEFINED name gets eaten mid-word by a shorter
-        // defined var: `$Outdoorsmanship.Ranks` matched the compass boolean
-        // `$out` → "0doorsmanship.Ranks" (remainder "doorsmanship…" starts with
-        // a letter), and `$SpellTimer.X.active` matched `$spelltime` →
-        // "0r.X.active". (Genie 4 dodges this only via its case-sensitive
-        // VariableList; our globals are case-insensitive.)
+        // A shrunk candidate may break mid-word (remainder starts with a
+        // letter) ONLY when the matched var is stored with EXACT case — that
+        // is precisely the match Genie 4's case-sensitive VariableList would
+        // have made. This is load-bearing for mid-name composition (public
+        // #225): with `counter` defined, `%spell%countermana` must resolve the
+        // inner `%countermana` as `%counter` + "mana" → "%spell1mana" — G4's
+        // documented loop-over-numbered-vars idiom.
         //
-        // But '.', '-', digits AND '_' are all legitimate suffix boundaries —
-        // Genie 4 breaks at any of them. `_` in particular is load-bearing:
-        // `%$selection_DESC` (mm_train #1071) must shrink `$selection_DESC` →
-        // `$selection` + "_DESC", forming `%<value>_DESC`. An earlier version
-        // of this rule wrongly rejected the '_' boundary too, so the inner
-        // global collapsed to "" and the leading `%` survived as a bare sigil
-        // → `!(% = "")` (regression, Jason's live mm_train run). The
-        // documented shrinks `%count-1` and `%%spell.Prep` still work.
+        // A case-INsensitive-only hit stays rejected at mid-word breaks
+        // (public #171): our globals are case-insensitive, so without the
+        // exact-case gate an UNDEFINED name gets eaten by a shorter engine
+        // global G4 would never match — `$Outdoorsmanship.Ranks` matched the
+        // compass boolean `$out` → "0doorsmanship.Ranks", and
+        // `$SpellTimer.X.active` matched `$spelltime` → "0r.X.active".
+        // (An earlier cut of the #171 rule rejected ALL mid-word breaks, which
+        // broke the #225 composition above — the gate reconciles the two.)
+        // Computed pseudo-vars ($spelltime, clock vars) and #var-store hits
+        // have no inspectable stored key, so they remain boundary-only.
+        //
+        // '.', '-', digits AND '_' are all legitimate suffix boundaries —
+        // Genie 4 breaks at any of them, exact case or not. `_` in particular
+        // is load-bearing: `%$selection_DESC` (mm_train #1071) must shrink
+        // `$selection_DESC` → `$selection` + "_DESC", forming `%<value>_DESC`.
+        // An earlier version of the rule wrongly rejected the '_' boundary
+        // too, so the inner global collapsed to "" and the leading `%`
+        // survived as a bare sigil → `!(% = "")` (regression, Jason's live
+        // mm_train run). The documented shrinks `%count-1` and `%%spell.Prep`
+        // still work.
         int nameEnd = j;
         string value = string.Empty;
         bool resolved = false;
         while (nameEnd > nameStart)
         {
-            if (nameEnd == j || !char.IsLetter(s[nameEnd]))
+            var name = s[nameStart..nameEnd];
+            if (TryResolveVar(name, c, inst, out value))
             {
-                var name = s[nameStart..nameEnd];
-                if (TryResolveVar(name, c, inst, out value)) { resolved = true; break; }
+                bool wordBoundary = nameEnd == j || !char.IsLetter(s[nameEnd]);
+                if (wordBoundary || StoredWithExactCase(name, c, inst)) { resolved = true; break; }
+                // Insensitive-only hit mid-word: G4's case-sensitive lookup
+                // would have missed it — keep shrinking.
             }
             nameEnd--;
         }
@@ -2957,6 +2971,30 @@ public sealed class ScriptEngine
             }
         }
         return (value, nameEnd);
+    }
+
+    /// <summary>
+    /// True when <paramref name="name"/> exists in the relevant store with
+    /// EXACTLY this casing — the match Genie 4's case-sensitive VariableList
+    /// would make. Gates mid-word shrink breaks (see ResolveTokenAt): only
+    /// stored vars count (locals for <c>%</c>, globals for <c>$</c>); computed
+    /// pseudo-vars and the #var store can't be case-verified and stay
+    /// boundary-only. Enumerates rather than TryGetValue because the
+    /// case-insensitive dictionaries can't return their canonical key; only
+    /// reached on a case-insensitive HIT at a mid-word position, which is
+    /// rare (a genuine collision), so the scan cost doesn't matter.
+    /// </summary>
+    private bool StoredWithExactCase(string name, char prefix, ScriptInstance inst)
+    {
+        if (prefix == '%')
+        {
+            foreach (var k in inst.Vars.Keys)
+                if (string.Equals(k, name, StringComparison.Ordinal)) return true;
+            return false;
+        }
+        foreach (var kv in Globals)
+            if (string.Equals(kv.Key, name, StringComparison.Ordinal)) return true;
+        return false;
     }
 
     /// <summary>

--- a/tests/Genie.Core.Tests/ScriptMidNameVarTests.cs
+++ b/tests/Genie.Core.Tests/ScriptMidNameVarTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Genie.Core.Scripting;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// Public #225 — a variable embedded in the MIDDLE of another variable's name
+/// must compose like Genie 4: with `counter` defined, `%spell%countermana`
+/// resolves the inner `%countermana` as `%counter` + "mana", forming
+/// `%spell1mana`. The first cut of the #171 word-boundary rule rejected ALL
+/// mid-word shrink breaks, which killed this idiom (the common
+/// loop-over-numbered-vars pattern). The reconciliation: a mid-word break is
+/// legal exactly when the matched var is stored with EXACT case — the match
+/// G4's case-sensitive VariableList would have made — while
+/// case-insensitive-only hits stay boundary-restricted so #171's protection
+/// (undefined `$Outdoorsmanship.Ranks` not eaten by the compass `$out`)
+/// survives. UndefinedDottedVarTests covers the #171 side.
+/// </summary>
+public class ScriptMidNameVarTests
+{
+    private static List<string> RunFixture(string body,
+                                           IDictionary<string, string>? globals = null)
+    {
+        var echoed = new List<string>();
+        var dir = Path.Combine(Path.GetTempPath(), "gc_midname_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "t.cmd"), body);
+            var engine = new ScriptEngine(dir, new TypeAheadSession(),
+                                          sendCommand: _ => { }, echo: l => echoed.Add(l));
+            if (globals is not null)
+                foreach (var (k, v) in globals) engine.Globals[k] = v;
+            engine.TryStart("t", new List<string>());
+            for (int i = 0; i < 400; i++) engine.Tick();
+            return echoed.FindAll(l => l.StartsWith("T:"));
+        }
+        finally { try { Directory.Delete(dir, true); } catch { /* best effort */ } }
+    }
+
+    // The issue's repro, condensed: numbered spell/buff vars walked by a
+    // loop counter, with the counter at the END (%spell%counter), in the
+    // MIDDLE (%spell%countermana), and through a double-eval type prefix
+    // (%%spelltype%countermana).
+    private const string ReproVars =
+        "var buffnum 2\n"    +
+        "var buff1 seer\n"   +
+        "var buff1mana 100\n" +
+        "var buff2 tksh\n"   +
+        "var buff2mana 100\n" +
+        "var spellnum 2\n"   +
+        "var spell1 cv\n"    +
+        "var spell1mana 100\n" +
+        "var spell2 fm\n"    +
+        "var spell2mana 100\n";
+
+    [Fact]
+    public void Mid_name_counter_composes_like_genie4()   // MIDTESTLOOP
+    {
+        var o = RunFixture(ReproVars +
+            "var counter 1\n" +
+            "gosub MIDTESTLOOP\n" +
+            "exit\n" +
+            "MIDTESTLOOP:\n" +
+            "  if (%counter > %spellnum) then return\n" +
+            "  echo T:spell%counter %spell%counter\n" +
+            "  echo T:spell%countermana %spell%countermana\n" +
+            "  math counter add 1\n" +
+            "  goto MIDTESTLOOP\n");
+
+        Assert.Equal(new[]
+        {
+            "T:spell1 cv",
+            "T:spell1mana 100",
+            "T:spell2 fm",
+            "T:spell2mana 100",
+        }, o.ToArray());
+    }
+
+    [Fact]
+    public void Double_eval_type_prefix_composes_like_genie4()   // FULLTESTLOOP
+    {
+        var o = RunFixture(ReproVars +
+            "var counter 1\n" +
+            "gosub FULLTESTLOOP spell %spellnum\n" +
+            "var counter 1\n" +
+            "gosub FULLTESTLOOP buff %buffnum\n" +
+            "exit\n" +
+            "FULLTESTLOOP:\n" +
+            "  var spelltype $1\n" +
+            "  var counternum $2\n" +
+            "  if (%counter > %counternum) then return\n" +
+            "  echo T:%spelltype%counter %%spelltype%counter\n" +
+            "  echo T:%spelltype%countermana %%spelltype%countermana\n" +
+            "  math counter add 1\n" +
+            "  goto FULLTESTLOOP\n");
+
+        Assert.Equal(new[]
+        {
+            "T:spell1 cv",
+            "T:spell1mana 100",
+            "T:spell2 fm",
+            "T:spell2mana 100",
+            "T:buff1 seer",
+            "T:buff1mana 100",
+            "T:buff2 tksh",
+            "T:buff2mana 100",
+        }, o.ToArray());
+    }
+
+    [Fact]
+    public void Global_mid_name_composition_with_exact_case()
+    {
+        // Same idiom through $ globals: $counter mid-name forms $spell3mana.
+        var o = RunFixture("echo T:G=$spell$countermana\n",
+            new Dictionary<string, string>
+            {
+                ["counter"]    = "3",
+                ["spell3mana"] = "99",
+            });
+
+        Assert.Equal(new[] { "T:G=99" }, o.ToArray());
+    }
+
+    [Fact]
+    public void Case_insensitive_only_hit_still_rejected_mid_word()
+    {
+        // `Count` (capital C) must NOT be eaten out of the undefined
+        // `%countdown` — G4's case-sensitive lookup would miss it, and the
+        // #171 protection relies on exactly this rejection.
+        var o = RunFixture(
+            "var Count 5\n" +
+            "echo T:C=%countdown\n");
+
+        Assert.Equal(new[] { "T:C=%countdown" }, o.ToArray());
+    }
+
+    [Fact]
+    public void End_position_and_begin_position_still_work()
+    {
+        // The issue noted begin/end placements kept working — regression-guard
+        // them alongside the fix: counter at the end (%spell%counter) and a
+        // var-typed prefix at the beginning (%%spelltype1).
+        var o = RunFixture(ReproVars +
+            "var counter 2\n" +
+            "var spelltype spell\n" +
+            "echo T:E=%spell%counter\n" +
+            "echo T:B=%%spelltype1\n");
+
+        Assert.Equal(new[] { "T:E=fm", "T:B=cv" }, o.ToArray());
+    }
+}


### PR DESCRIPTION
Fixes #225.

## Root cause

This was a regression from the #171 fix. The variable shrink-search (an undefined `%name`/`$name` shrinks from the right until a defined variable matches) gained a word-boundary rule in July: a shrunk candidate could only break where the remainder does **not** start with a letter. That rule exists because this client's variable stores are case-insensitive — without it, the undefined `$Outdoorsmanship.Ranks` gets eaten mid-word by the compass boolean `$out`, producing `0doorsmanship.Ranks`.

But the blanket ban also outlawed a break Genie 4 makes deliberately: with `counter` defined, `%spell%countermana` must resolve the inner `%countermana` as `%counter` + `"mana"` (remainder starts with a letter), forming `%spell1mana` — the loop-over-numbered-vars idiom from the report. Genie 4 gets *both* behaviors right for one reason: its VariableList is case-sensitive, so `$Outdoorsmanship…` never matches `out`, while `%countermana` happily matches `counter`.

## Fix

The rule now mirrors that distinction instead of banning mid-word breaks outright:

- A mid-word break is legal **when the matched variable is stored with exact case** — precisely the match Genie 4's case-sensitive lookup would have made.
- A case-insensitive-only hit remains boundary-restricted (`.`, `-`, digits, `_`), preserving the #171 protection. Computed pseudo-variables (`$spelltime`, clock vars) and the `#var` store have no inspectable stored key, so they also remain boundary-only.

The exact-case check only runs on a case-insensitive hit at a mid-word position — a genuine collision, which is rare — so the hot substitution path is unaffected.

## Tests

New `ScriptMidNameVarTests` runs the issue's repro script end-to-end through the real engine — the MIDTESTLOOP and FULLTESTLOOP gosub loops, including the `%%spelltype%countermana` double-eval prefix form — asserting the exact Genie 4 output from the report. Also covered: the same composition through `$` globals, and a guard that a case-mismatched hit (`Count` vs `%countdown`) still stays literal.

3 of the 5 fail without the fix. Full Genie.Core suite: 1001/1001 passing, including the existing #171 word-boundary guards (`UndefinedDottedVarTests`), which are untouched.