### PR TITLE
build: upgrade target framework to .NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore
         run: dotnet restore Genie.slnx
@@ -130,10 +130,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Publish self-contained win-x64
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,10 +108,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Publish self-contained win-x64
         run: |
@@ -151,10 +151,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Install Velopack CLI
         run: dotnet tool install -g vpk
@@ -267,7 +267,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Install Velopack CLI
         run: dotnet tool install -g vpk
@@ -345,7 +345,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Install Velopack CLI
         run: dotnet tool install -g vpk
@@ -448,7 +448,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Install Velopack CLI
         run: dotnet tool install -g vpk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thanks for your interest. Genie 5 is beta-stage software with a small contributo
 
 ### Prerequisites
 
-- **.NET 8 SDK** — [download](https://dotnet.microsoft.com/download/dotnet/8.0)
+- **.NET 10 SDK** — [download](https://dotnet.microsoft.com/download/dotnet/10.0)
 - A DragonRealms account if you want to test against a live server (free trial accounts work for most testing)
 
 ### Clone + build

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A live DragonRealms session — game stream, Room panel, inventory, and stream t
 
 The Genie 4 codebase is WinForms + Windows-only and hasn't kept pace with modern .NET, cross-platform tooling, or the broader scripting ecosystem. Genie 5 is a clean rewrite that:
 
-- **Runs everywhere** — Windows, macOS, and Linux native, courtesy of [Avalonia UI](https://avaloniaui.net/) and .NET 8
+- **Runs everywhere** — Windows, macOS, and Linux native, courtesy of [Avalonia UI](https://avaloniaui.net/) and .NET 10
 - **Stays compatible** — runs your existing Genie 4 `.cmd` scripts, profile files, and `.xml` zone maps
 - **Plays well with the ecosystem** — supports direct SGE auth, [Lich 5](https://github.com/elanthia-online/lich-5) proxy, and dev-replay from recorded sessions
 - **Is built for inspection** — clean `Genie.Core` library with no UI dependencies; embed it in other clients, plugins, or test harnesses
@@ -78,7 +78,7 @@ The **Setup.exe** / **.pkg** / **AppImage** builds register for in-app updates; 
 
 ### Build from source
 
-Requires the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0).
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
 
 ```sh
 git clone https://github.com/GenieClient/Genie5.git

--- a/docs/IPHONE_OPTIONS.md
+++ b/docs/IPHONE_OPTIONS.md
@@ -13,7 +13,7 @@ built or replaced, and whether it fits the project's
 
 Two facts about the codebase shape every option below:
 
-1. **`Genie.Core` is already portable.** It's a pure .NET 8 class library
+1. **`Genie.Core` is already portable.** It's a pure .NET 10 class library
    with **zero UI dependencies** (see [README architecture](../README.md) and
    `src/Genie.Core/Genie.Core.csproj`). Its package deps — `Jint`,
    `System.Reactive`, `Anthropic.SDK`, `Microsoft.Extensions.Logging` — are
@@ -23,7 +23,7 @@ Two facts about the codebase shape every option below:
    biggest asset for any mobile effort.
 
 2. **`Genie.App` is desktop-bound in several concrete ways.** It targets
-   `net8.0` / `WinExe` and leans on pieces that don't exist or don't fit on
+   `net10.0` / `WinExe` and leans on pieces that don't exist or don't fit on
    iPhone:
    - **Dock.Avalonia** — the dockable multi-panel MDI layout. A dense,
      drag-to-dock desktop paradigm; wrong model for a 6-inch touch screen.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Genie 5 Developer Documentation
 
-Genie 5 is a cross-platform Avalonia / .NET 8 rebuild of [Genie 4](https://github.com/GenieClient) — a long-running client for [DragonRealms](https://www.play.net/dr), Simutronics' text MMO. These docs cover the internals: how the client speaks to the server, how a line of game text turns into UI/scripts/state, how scripts execute, and how the mapper finds and walks paths.
+Genie 5 is a cross-platform Avalonia / .NET 10 rebuild of [Genie 4](https://github.com/GenieClient) — a long-running client for [DragonRealms](https://www.play.net/dr), Simutronics' text MMO. These docs cover the internals: how the client speaks to the server, how a line of game text turns into UI/scripts/state, how scripts execute, and how the mapper finds and walks paths.
 
 The codebase splits into three projects:
 

--- a/docs/build-and-release.md
+++ b/docs/build-and-release.md
@@ -1,6 +1,6 @@
 # Build & Release
 
-Genie 5 builds for Windows, macOS, and Linux from one source tree on .NET 8. The published artifact is **self-contained** — the .NET runtime and native libraries are bundled, so end users don't install anything.
+Genie 5 builds for Windows, macOS, and Linux from one source tree on .NET 10. The published artifact is **self-contained** — the .NET runtime and native libraries are bundled, so end users don't install anything.
 
 There are no platform build scripts checked in (no `build-mac.sh` / `build-win.sh`). Local builds are driven by `dotnet publish` and the publish properties already set in [Genie.App.csproj](../src/Genie.App/Genie.App.csproj); **shipping releases are fully scripted in CI** (see [CI & releases](#ci--releases) below). This page documents the local commands, what the properties do, and how the release pipeline packages each platform.
 
@@ -12,7 +12,7 @@ There are no platform build scripts checked in (no `build-mac.sh` / `build-win.s
 | [Genie.App](../src/Genie.App/Genie.App.csproj) | `WinExe` (`AssemblyName=Genie5`) | The Avalonia GUI. References Genie.Core. |
 | [Genie.Plugins.Abstractions](../src/Genie.Plugins.Abstractions/Genie.Plugins.Abstractions.csproj) | library | The public plugin contract (`IGeniePlugin` / `IPluginHost`) that plugin authors reference. |
 
-Solution file: [Genie.slnx](../Genie.slnx). Target framework: `net8.0`. UI stack: Avalonia + Dock.Avalonia + AvaloniaEdit + ReactiveUI (with ReactiveUI.Fody) — see the csproj for the pinned versions.
+Solution file: [Genie.slnx](../Genie.slnx). Target framework: `net10.0`. UI stack: Avalonia + Dock.Avalonia + AvaloniaEdit + ReactiveUI (with ReactiveUI.Fody) — see the csproj for the pinned versions.
 
 ## Local development
 
@@ -22,7 +22,7 @@ dotnet build -c Release
 dotnet run --project src/Genie.App
 ```
 
-A plain `dotnet build` produces an unbundled `bin/Debug/net8.0/Genie5` you can run directly. The self-contained single-file artifact is only needed for distribution. Run the test suite with `dotnet test tests/Genie.Core.Tests`.
+A plain `dotnet build` produces an unbundled `bin/Debug/net10.0/Genie5` you can run directly. The self-contained single-file artifact is only needed for distribution. Run the test suite with `dotnet test tests/Genie.Core.Tests`.
 
 To run the headless engine harness (no UI):
 

--- a/scripts/deploy-plugins.ps1
+++ b/scripts/deploy-plugins.ps1
@@ -77,7 +77,7 @@ Write-Host "Plugins folder : $PluginsDir"
 $AbstractionsProj = Join-Path $RepoRoot 'src/Genie.Plugins.Abstractions/Genie.Plugins.Abstractions.csproj'
 Write-Host "Building plugin contract (Genie.Plugins.Abstractions)..."
 dotnet build $AbstractionsProj -c Release --nologo -v quiet
-$AbstractionsDll = Join-Path $RepoRoot 'src/Genie.Plugins.Abstractions/bin/Release/net8.0/Genie.Plugins.Abstractions.dll'
+$AbstractionsDll = Join-Path $RepoRoot 'src/Genie.Plugins.Abstractions/bin/Release/net10.0/Genie.Plugins.Abstractions.dll'
 if (-not (Test-Path $AbstractionsDll)) { throw "Contract DLL not found: $AbstractionsDll" }
 
 # ── Build + deploy each gold plugin ──────────────────────────────────────────

--- a/src/Genie.App/Genie.App.csproj
+++ b/src/Genie.App/Genie.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Genie.App</RootNamespace>

--- a/src/Genie.Core/Genie.Core.csproj
+++ b/src/Genie.Core/Genie.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>

--- a/src/Genie.Plugins.Abstractions/Genie.Plugins.Abstractions.csproj
+++ b/src/Genie.Plugins.Abstractions/Genie.Plugins.Abstractions.csproj
@@ -6,7 +6,7 @@
        Genie.Core. This is the assembly whose API gets versioned/frozen for the
        public plugin ecosystem. -->
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>

--- a/tests/Genie.App.Tests/Genie.App.Tests.csproj
+++ b/tests/Genie.App.Tests/Genie.App.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/tests/Genie.Core.Tests/Genie.Core.Tests.csproj
+++ b/tests/Genie.Core.Tests/Genie.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -15,7 +15,7 @@
          Override with -p:CoreRid=… or -p:CoreOutDir=… when needed. -->
     <CoreRid Condition="'$(CoreRid)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</CoreRid>
     <CoreRid Condition="'$(CoreRid)' == ''">$(NETCoreSdkRuntimeIdentifier)</CoreRid>
-    <CoreOutDir Condition="'$(CoreOutDir)' == ''">$(MSBuildThisFileDirectory)../../src/Genie.Core/bin/$(Configuration)/net8.0/$(CoreRid)/</CoreOutDir>
+    <CoreOutDir Condition="'$(CoreOutDir)' == ''">$(MSBuildThisFileDirectory)../../src/Genie.Core/bin/$(Configuration)/net10.0/$(CoreRid)/</CoreOutDir>
     <_GenieCoreProject>$(MSBuildThisFileDirectory)../../src/Genie.Core/Genie.Core.csproj</_GenieCoreProject>
   </PropertyGroup>
 

--- a/wiki/Building-from-Source.md
+++ b/wiki/Building-from-Source.md
@@ -4,7 +4,7 @@ For contributors and the curious. End users only need [Installation](Installatio
 
 ## Prerequisites
 
-- **[.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)** (Windows, macOS, Linux).
+- **[.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)** (Windows, macOS, Linux).
 - A DragonRealms account if you want to test against a live server (free trial accounts work for most testing).
 
 ## Clone and build

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,6 +1,6 @@
 # Genie 5
 
-Genie 5 is a cross-platform client for **[DragonRealms](https://www.play.net/dr)**, Simutronics' text MMO. It's a from-scratch rewrite of [Genie 4](https://github.com/GenieClient) on **.NET 8** and **[Avalonia](https://avaloniaui.net/)**, keeping Genie 4's scripting, mapping, highlighting, and triggering while running natively on **Windows, macOS, and Linux**.
+Genie 5 is a cross-platform client for **[DragonRealms](https://www.play.net/dr)**, Simutronics' text MMO. It's a from-scratch rewrite of [Genie 4](https://github.com/GenieClient) on **.NET 10** and **[Avalonia](https://avaloniaui.net/)**, keeping Genie 4's scripting, mapping, highlighting, and triggering while running natively on **Windows, macOS, and Linux**.
 
 ![Genie 5 in play — dockable panels around the game text, with the Mapper floating](images/interface-default-layout.png)
 

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -83,7 +83,7 @@ If you installed via **`01-Windows-Genie5-Setup.exe`** (Windows) or the **`.pkg`
 
 ## Build from source
 
-For contributors, or to run the bleeding edge. You need the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) and [Git](https://git-scm.com/):
+For contributors, or to run the bleeding edge. You need the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) and [Git](https://git-scm.com/):
 
 ```bash
 git clone https://github.com/GenieClient/Genie5.git

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -17,7 +17,7 @@ Builds from before v5.0.0-alpha.10 are unsigned and always trigger the blue pane
 Make it executable first (`chmod +x 04-Linux-Genie5.AppImage`), then `./04-Linux-Genie5.AppImage`. For the FUSE error, install it — Debian/Ubuntu: `sudo apt install libfuse2` (Fedora usually works out of the box). If text renders oddly on a minimal distro, install `fontconfig`. For a desktop-menu entry, use [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher).
 
 **`dotnet` isn't recognized / build fails (building from source).**
-You need the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) (the SDK, not just the runtime). Verify with `dotnet --version` (should be 8.x). See [Installation](Installation#build-from-source).
+You need the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (the SDK, not just the runtime). Verify with `dotnet --version` (should be 10.x). See [Installation](Installation#build-from-source).
 
 ## Connecting
 


### PR DESCRIPTION
## Summary
- Moves Genie.Core, Genie.App, Genie.Plugins.Abstractions, and both test projects from `net8.0` to `net10.0`
- Updates CI (build/release workflows) to install and use the .NET 10 SDK
- Updates `scripts/deploy-plugins.ps1` and docs/wiki references (README, CONTRIBUTING, build-and-release, IPHONE_OPTIONS, wiki pages) to match

## Test plan
- [x] `dotnet build` succeeds on .NET 10 SDK
- [x] `dotnet test tests/Genie.Core.Tests` and `tests/Genie.App.Tests` pass
- [ ] CI build/release workflows succeed on the new SDK version
