### PR TITLE
build: add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
- Adds a `.gitattributes` with `* text=auto eol=lf` so the same checkout can be used on Linux (devcontainer) and Windows (host) without producing spurious CRLF/LF diffs across the tree.

## Test plan
- [ ] Confirm files normalize to LF on next checkout/`git add --renormalize`