### PR TITLE
Route Find to AvaloniaEdit's search panel on editor windows

### DIFF
--- a/src/Genie.App/App.axaml
+++ b/src/Genie.App/App.axaml
@@ -127,10 +127,15 @@
             <MenuItem Header="Save As…"
                       Command="{Binding WindowMenu.SaveAsCommand}"
                       IsVisible="{Binding WindowMenu.ShowSaveAs}" />
-            <!-- Find really is Ctrl+F on both renderers (MainWindow's key handler),
-                 so this label is accurate everywhere and stays as-is. -->
+            <!-- Platform gesture again: on this renderer Find opens AvaloniaEdit's
+                 search panel, which answers Cmd+F on macOS both through
+                 MainWindow's handler and through AvaloniaEdit's own binding once
+                 the text has focus. Ctrl+F still opens the in-window Find bar
+                 there, but the platform combo is the one to advertise. The legacy
+                 template below stays hardcoded Ctrl+F, which is all that renderer
+                 has. -->
             <MenuItem Header="Find…"
-                      InputGesture="Ctrl+F"
+                      InputGesture="{x:Static docking:WindowMenuBehavior.FindGesture}"
                       Command="{Binding WindowMenu.FindCommand}"
                       IsVisible="{Binding WindowMenu.ShowFind}" />
             <MenuItem Header="Clear"

--- a/src/Genie.App/Controls/GameTextEditor.cs
+++ b/src/Genie.App/Controls/GameTextEditor.cs
@@ -169,6 +169,8 @@ public sealed class GameTextEditor : UserControl
         host.PropertyChanged        += OnHostPropertyChanged;
         _vm.Lines.CollectionChanged += OnLinesChanged;
         _find.JumpRequested         += OnFindJump;
+        // Claim Find for this window while this renderer is the one showing it.
+        _find.OpenOverride           = OpenSearchPanel;
 
         ApplyHostSettings();
         _paused = host.IsScrollPaused;
@@ -179,7 +181,13 @@ public sealed class GameTextEditor : UserControl
     {
         if (_host is not null) _host.PropertyChanged -= OnHostPropertyChanged;
         if (_vm   is not null) _vm.Lines.CollectionChanged -= OnLinesChanged;
-        if (_find is not null) _find.JumpRequested -= OnFindJump;
+        if (_find is not null)
+        {
+            _find.JumpRequested -= OnFindJump;
+            // Release the claim: a detached renderer must not keep answering Find
+            // for a document some other surface may now be showing.
+            if (_find.OpenOverride == OpenSearchPanel) _find.OpenOverride = null;
+        }
         _host = null;
         _vm   = null;
         _find = null;
@@ -422,6 +430,39 @@ public sealed class GameTextEditor : UserControl
     }
 
     // ── Find (#120) ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Open AvaloniaEdit's own search panel instead of the in-window Find bar —
+    /// the richer UI (live match highlighting through the scrollback, match
+    /// count, regex / match-case / whole-word toggles) and the one this renderer
+    /// already answers Cmd+F with when the text has focus. Wired in as
+    /// <c>FindInWindowModel.OpenOverride</c> for as long as this control is the
+    /// window's renderer.
+    ///
+    /// <para>Mirrors AvaloniaEdit's own <c>SearchInputHandler.ExecuteFind</c>:
+    /// seed the term from a single-line selection, then focus the box on the
+    /// Input priority so it wins over the click/keystroke that opened it.
+    /// Replace mode is forced off — the view is read-only, so the replace row
+    /// would be dead UI.</para>
+    ///
+    /// <para>Returns false before the template has applied (no panel exists yet),
+    /// which drops the caller back to the Find bar rather than silently doing
+    /// nothing.</para>
+    /// </summary>
+    private bool OpenSearchPanel()
+    {
+        if (_editor.SearchPanel is not { } panel) return false;
+
+        panel.IsReplaceMode = false;
+        panel.Open();
+
+        var selection = _editor.TextArea.Selection;
+        if (!selection.IsEmpty && !selection.IsMultiline)
+            panel.SearchPattern = selection.GetText();
+
+        Dispatcher.UIThread.Post(panel.Reactivate, DispatcherPriority.Input);
+        return true;
+    }
 
     private void OnFindJump(FindInWindowModel.Match match)
         => Dispatcher.UIThread.Post(() =>

--- a/src/Genie.App/Docking/FindInWindowModel.cs
+++ b/src/Genie.App/Docking/FindInWindowModel.cs
@@ -47,6 +47,29 @@ public sealed class FindInWindowModel : ReactiveObject
     /// <summary>Raised when a match should be scrolled into view + selected.</summary>
     public event Action<Match>? JumpRequested;
 
+    /// <summary>
+    /// Set by a renderer that ships its own, better find UI — currently only
+    /// <c>GameTextEditor</c>, which hands over to AvaloniaEdit's SearchPanel.
+    /// Returning true means the renderer took the request and this model's bar
+    /// stays shut; false (or no override at all) falls back to the bar.
+    ///
+    /// <para>The routing decision has to live on the view side: only the control
+    /// that actually rendered the window knows which surface is showing it, and
+    /// only it can reach the panel. The model just offers the hook so callers
+    /// (<see cref="Open"/>) stay renderer-agnostic.</para>
+    /// </summary>
+    public Func<bool>? OpenOverride { get; set; }
+
+    /// <summary>Open this window's find UI — the renderer's own if it has one
+    /// (<see cref="OpenOverride"/>), otherwise the in-window bar. Every
+    /// user-facing entry point that should prefer the native UI goes through
+    /// here; setting <see cref="IsOpen"/> directly opts out and forces the bar.</summary>
+    public void Open()
+    {
+        if (OpenOverride?.Invoke() == true) return;
+        IsOpen = true;
+    }
+
     /// <summary>Walk to the previous (older, upward) match.</summary>
     public ICommand OlderCommand { get; }
     /// <summary>Walk to the next (newer, downward) match.</summary>

--- a/src/Genie.App/Docking/GenieDockFactory.cs
+++ b/src/Genie.App/Docking/GenieDockFactory.cs
@@ -962,9 +962,11 @@ public class GenieDockFactory : Factory
             _                   => null
         };
 
-        // Find… (#120) — any window hosting an in-window find bar.
+        // Find… (#120) — any window hosting an in-window find bar. Open() rather
+        // than IsOpen so the menu item lands on the same UI the Find gesture does:
+        // the renderer's own search panel where it has one, the bar otherwise.
         ICommand? find = dockable is IFindHost findHost
-            ? ReactiveCommand.Create(() => { findHost.Find.IsOpen = true; })
+            ? ReactiveCommand.Create(() => { findHost.Find.Open(); })
             : null;
 
         // Word Wrap (#120) — WindowSettings-backed per-window toggle for the

--- a/src/Genie.App/Docking/WindowMenuBehavior.cs
+++ b/src/Genie.App/Docking/WindowMenuBehavior.cs
@@ -63,6 +63,21 @@ public static class WindowMenuBehavior
             Application.Current?.PlatformSettings?.HotkeyConfiguration.CommandModifiers
             ?? KeyModifiers.Control);
 
+    /// <summary>The Find gesture to advertise on the <b>editor</b> game window.
+    /// MainWindow answers the platform combo — Cmd+F on macOS — and routes it to
+    /// AvaloniaEdit's search panel there, which is also the gesture that renderer
+    /// answers by itself once the text has focus. Ctrl+F still opens the in-window
+    /// bar on macOS, but the platform gesture is the one worth labelling.
+    ///
+    /// <para>As with <see cref="CopySelectionGesture"/>: not used by the legacy
+    /// game window or the tool windows, whose Find is Ctrl+F on every platform,
+    /// and resolved per read because <c>Application.Current</c> may not be up
+    /// when this type is first touched.</para></summary>
+    public static KeyGesture FindGesture =>
+        new(Key.F,
+            Application.Current?.PlatformSettings?.HotkeyConfiguration.CommandModifiers
+            ?? KeyModifiers.Control);
+
     static WindowMenuBehavior()
     {
         RefreshOnOpenProperty.Changed.AddClassHandler<ContextMenu>((menu, e) =>

--- a/src/Genie.App/Views/MainWindow.axaml
+++ b/src/Genie.App/Views/MainWindow.axaml
@@ -1039,7 +1039,13 @@
           <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
       </Border.Styles>
-      <StackPanel Orientation="Horizontal" Spacing="4">
+      <!-- MinHeight pins the row to one chip's height (11px text + 1px chip     -->
+      <!-- padding + 1px chip border, top and bottom) so the strip keeps its     -->
+      <!-- height when every chip is hidden. Without it the panel measures 0     -->
+      <!-- and the docked strip shrinks ~19px, reflowing the whole window —      -->
+      <!-- which happens on every posture change, because the server clears the  -->
+      <!-- old posture in one indicator event and sets the new one in the next.  -->
+      <StackPanel Orientation="Horizontal" Spacing="4" MinHeight="20">
         <Border Classes="chip" Background="#223042" BorderBrush="#3a5570"
                 IsVisible="{Binding IconBar.PostureText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                 ToolTip.Tip="Posture — what the server says your body is doing (dead beats everything, then standing / kneeling / sitting / prone).">

--- a/src/Genie.App/Views/MainWindow.axaml
+++ b/src/Genie.App/Views/MainWindow.axaml
@@ -1039,13 +1039,7 @@
           <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
       </Border.Styles>
-      <!-- MinHeight pins the row to one chip's height (11px text + 1px chip     -->
-      <!-- padding + 1px chip border, top and bottom) so the strip keeps its     -->
-      <!-- height when every chip is hidden. Without it the panel measures 0     -->
-      <!-- and the docked strip shrinks ~19px, reflowing the whole window —      -->
-      <!-- which happens on every posture change, because the server clears the  -->
-      <!-- old posture in one indicator event and sets the new one in the next.  -->
-      <StackPanel Orientation="Horizontal" Spacing="4" MinHeight="20">
+      <StackPanel Orientation="Horizontal" Spacing="4">
         <Border Classes="chip" Background="#223042" BorderBrush="#3a5570"
                 IsVisible="{Binding IconBar.PostureText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                 ToolTip.Tip="Posture — what the server says your body is doing (dead beats everything, then standing / kneeling / sitting / prone).">

--- a/src/Genie.App/Views/MainWindow.axaml.cs
+++ b/src/Genie.App/Views/MainWindow.axaml.cs
@@ -847,9 +847,31 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
             }
         }
 
-        // #120: Ctrl+F opens the Find bar on the selected game/stream window —
-        // PageScroll's click-target, so it follows the same "active window"
-        // the PageUp/PageDown keys scroll (main game window before any click).
+        // The platform Find gesture (Cmd+F on macOS, Ctrl+F elsewhere) opens
+        // whichever find UI the selected window's renderer provides: AvaloniaEdit's
+        // search panel on editor-backed windows, the in-window Find bar on the
+        // rest. Targeting is PageScroll's click-target either way, so Find follows
+        // the same "active window" the PageUp/PageDown keys scroll.
+        //
+        // Only reached when the game text does NOT have focus: with focus inside an
+        // editor window, AvaloniaEdit's own TextArea binding matches the same
+        // gesture further down the bubble route and opens the panel itself. Same
+        // destination, so the two paths agree — this one just extends it to the
+        // normal case where focus is sitting in the command bar.
+        if (e.Key == Key.F && e.KeyModifiers == PlatformCommandModifiers &&
+            !IsMacroBound(Key.F, e.KeyModifiers) &&
+            PageScroll.CurrentTarget?.DataContext is Docking.IFindHost platformFindHost)
+        {
+            platformFindHost.Find.Open();
+            e.Handled = true;
+            return;
+        }
+
+        // #120: Ctrl+F opens the Find bar on the same selected window. On Windows
+        // and Linux this is the platform gesture, already handled above; it stays
+        // live on macOS, where Ctrl+F is a separate keystroke from Cmd+F, so the
+        // Genie-4-era shortcut keeps working and stays a way to reach the bar even
+        // on a window whose renderer prefers its own panel.
         // Checked before the generic macro dispatch but only when no ctrl+f
         // macro exists, so an existing user binding keeps winning.
         if (e.Key == Key.F && e.KeyModifiers == KeyModifiers.Control &&
@@ -872,6 +894,22 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
         ViewModel.Core.ProcessInput(macro.Action);
         e.Handled = true;
     }
+
+    /// <summary>The platform's primary command modifier — Meta (Cmd) on macOS,
+    /// Control everywhere else. Read per use rather than cached, since
+    /// <c>Application.Current</c> may not be up when this type is first touched.</summary>
+    private static KeyModifiers PlatformCommandModifiers =>
+        Application.Current?.PlatformSettings?.HotkeyConfiguration.CommandModifiers
+        ?? KeyModifiers.Control;
+
+    /// <summary>True when the user has a macro bound to this keystroke, in which
+    /// case a built-in shortcut on the same keys must stand down (#120). Keystrokes
+    /// that can't be expressed as a macro at all — Cmd-modified ones, since
+    /// <see cref="MacroKeyConverter"/> knows only ctrl/alt/shift — are never
+    /// bound.</summary>
+    private bool IsMacroBound(Key key, KeyModifiers mods)
+        => MacroKeyConverter.ToMacroKey(key, mods) is { } macroKey &&
+           ViewModel?.Core?.Commands?.Macros?.Get(macroKey) is not null;
 
     /// <summary>
     /// Type-anywhere capture (public #141): printable text that reached the


### PR DESCRIPTION
## Summary
- Cmd+F (or the dock menu's Find…) on an AvaloniaEdit-backed game window now opens AvaloniaEdit's own search panel instead of the plain in-window Find bar, giving live match highlighting and regex/case/whole-word toggles. `FindInWindowModel` gains an `OpenOverride` hook so a renderer can claim Find while it's attached; `GameTextEditor` wires it to the `SearchPanel` and releases the claim on detach.
- Ctrl+F still opens the in-window bar everywhere, and non-editor windows are unaffected.

## Test plan
- [ ] Cmd+F on an editor-backed game window opens AvaloniaEdit's search panel with match highlighting
- [ ] Ctrl+F still opens the in-window Find bar on all windows
- [ ] Dock menu's Find… routes to the same UI as the keyboard shortcut
- [ ] A user macro bound to Cmd+F or Ctrl+F takes precedence over the built-in shortcut