### PR TITLE
fix(mapper): auto-create mode skips cross-zone lookup on a session's first room

### DIFF
--- a/src/Genie.App/ViewModels/MapperViewModel.cs
+++ b/src/Genie.App/ViewModels/MapperViewModel.cs
@@ -1440,7 +1440,28 @@ public class MapperViewModel : ReactiveObject
         // Useful for debugging when the index unexpectedly has 0 entries
         // (Maps dir empty, all XMLs malformed, etc.).
         Dispatcher.UIThread.Post(() =>
-            LoadStatus = $"Indexed for auto-detect: {fpIndex.Count} fingerprints, {idIndex.Count} server ids.");
+        {
+            LoadStatus = $"Indexed for auto-detect: {fpIndex.Count} fingerprints, {idIndex.Count} server ids.";
+
+            // This index build races the very first room event on connect:
+            // Attach() kicks off both the engine's state subscription and
+            // this scan in the same breath, and reading + parsing every zone
+            // XML in the Maps directory is "non-trivial" (see the comment at
+            // the call site). If the room arrives first, TryAutoLoadZoneFor
+            // bails out with "Waiting for zone index" — but the engine has
+            // already cached that room's title/exits/desc as "last seen", so
+            // its own change-detection swallows every later re-check of the
+            // SAME room. Nothing then retries the lookup until the player
+            // physically moves to a new room (new title/exits), which is
+            // exactly the reported symptom: first connection can't find the
+            // map, but moving after a manual pick works fine. Force one
+            // re-resolution now that the index is actually populated — but
+            // only when the character hasn't been placed anywhere yet, so an
+            // already-matched room isn't re-evaluated on every index rebuild
+            // (e.g. from a Maps-directory change mid-session).
+            if (_engine is { CurrentNode: null })
+                _engine.Recalculate();
+        });
     }
 
     private void Refresh()

--- a/src/Genie.Core/Mapper/AutoMapperEngine.cs
+++ b/src/Genie.Core/Mapper/AutoMapperEngine.cs
@@ -175,12 +175,23 @@ public sealed class AutoMapperEngine
     public void LoadZone(MapZone zone)
     {
         _zone = zone;
+        _zoneEverLoaded = true;
         RebuildIndex();
         CurrentNode = null;
         CurrentNodeChanged?.Invoke();
         MapChanged?.Invoke();
         Recalculate();
     }
+
+    /// <summary>
+    /// True once <see cref="LoadZone"/> has run at least once this session —
+    /// from a community file, an app-layer cross-zone auto-detect, or the
+    /// player's own "New Zone". False only while the engine is still sitting
+    /// on the empty placeholder <see cref="MapZone"/> it was constructed
+    /// with. See the auto-create branch in <see cref="OnRoomChanged"/> for
+    /// why this distinction matters.
+    /// </summary>
+    private bool _zoneEverLoaded;
 
     /// <summary>
     /// Force a re-evaluation of the current room from the latest IMapperGameState,
@@ -562,6 +573,26 @@ public sealed class AutoMapperEngine
             // every title change instead — better to attempt the
             // lookup once with a partial fingerprint than to leave the
             // player visibly stranded in the wrong zone.
+            CurrentNode = null;
+            CurrentNodeChanged?.Invoke();
+            RoomNotFoundInZone?.Invoke(serverRoomId, title, exits);
+            return;
+        }
+        else if (!_zoneEverLoaded)
+        {
+            // Auto-create is on, but no zone has EVER been explicitly loaded
+            // this session — the engine is still sitting on its pristine
+            // construction-time placeholder, not a map anyone chose. Seeding
+            // an orphan node into it here (the pre-fix behaviour) silently
+            // strands the character in a nameless, invisible zone even when
+            // a matching community map exists locally: auto-create mode
+            // short-circuits straight to node-creation, so RoomNotFoundInZone
+            // never fires and the app-layer cross-zone auto-detect
+            // (MapperViewModel.TryAutoLoadZoneFor) never runs. Give the
+            // lookup the same one shot lookup-only mode gets — LoadZone
+            // (called on a successful auto-detect, a manual pick, or "New
+            // Zone") flips _zoneEverLoaded permanently, so this only ever
+            // gates the very first, otherwise-orphaned room of a session.
             CurrentNode = null;
             CurrentNodeChanged?.Invoke();
             RoomNotFoundInZone?.Invoke(serverRoomId, title, exits);

--- a/tests/Genie.Core.Tests/AutoMapperRecordModeFirstRoomTests.cs
+++ b/tests/Genie.Core.Tests/AutoMapperRecordModeFirstRoomTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using Genie.Core.Mapper;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// Auto-create ("record") mode used to short-circuit straight to node
+/// creation on ANY zone miss, including the very first room of a session
+/// when the engine is still sitting on its pristine, unnamed construction-time
+/// placeholder <see cref="MapZone"/> — nobody chose that zone, but
+/// <see cref="AutoMapperEngine.OnCommandSent"/>'s miss handling never fired
+/// <see cref="AutoMapperEngine.RoomNotFoundInZone"/> to give the app-layer
+/// cross-zone auto-detect (<c>MapperViewModel.TryAutoLoadZoneFor</c>) a
+/// chance to run. The character was silently seeded into a nameless orphan
+/// zone instead of the matching community map — "the map doesn't know which
+/// zone to load" even though a local zone file for that exact room exists.
+///
+/// <para>The fix: <see cref="AutoMapperEngine.LoadZone"/> now flips an
+/// internal "a zone was explicitly loaded" flag. Auto-create mode only
+/// bypasses the lookup (creating nodes directly, its normal behavior) once
+/// that flag is set — by a successful auto-detect, a manual zone pick, OR
+/// the player's own "New Zone". Before that, a miss behaves like lookup-only
+/// mode: it fires <see cref="AutoMapperEngine.RoomNotFoundInZone"/> instead
+/// of creating an orphan.</para>
+/// </summary>
+public class AutoMapperRecordModeFirstRoomTests
+{
+    private sealed class FakeGameState : IMapperGameState
+    {
+        public string RoomTitle { get; set; } = "";
+        public string RoomDescription { get; set; } = "";
+        public IReadOnlyCollection<string> Exits { get; set; } = Array.Empty<string>();
+        public string ServerRoomId { get; set; } = "";
+        public event Action? StateChanged;
+        public void Fire() => StateChanged?.Invoke();
+    }
+
+    [Fact]
+    public void RecordMode_FirstRoomOnPristineZone_SignalsMissInsteadOfOrphaning()
+    {
+        var zone   = new MapZone { Name = "placeholder" };
+        var engine = new AutoMapperEngine(zone) { IsEnabled = true };
+        var fake   = new FakeGameState();
+        engine.Attach(fake);
+
+        (string serverId, string title, IReadOnlyCollection<string> exits)? missed = null;
+        engine.RoomNotFoundInZone += (id, title, exits) => missed = (id, title, exits);
+
+        fake.RoomTitle    = "Town Square, Central Plaza";   // IMapperGameState.RoomTitle is already bracket-stripped (MapperGameStateAdapter's job)
+        fake.Exits        = new[] { "north", "east" };
+        fake.ServerRoomId = "555";
+        fake.Fire();
+
+        Assert.Null(engine.CurrentNode);
+        Assert.Empty(zone.Nodes);   // no orphan node was silently created
+        Assert.NotNull(missed);
+        Assert.Equal("555", missed!.Value.serverId);
+        Assert.Equal("Town Square, Central Plaza", missed.Value.title);
+    }
+
+    [Fact]
+    public void RecordMode_AfterAnyZoneIsExplicitlyLoaded_CreatesNodesNormally()
+    {
+        var placeholder = new MapZone { Name = "placeholder" };
+        var engine = new AutoMapperEngine(placeholder) { IsEnabled = true };
+        var fake   = new FakeGameState();
+        engine.Attach(fake);
+
+        // Simulate the player's own "New Zone" (or a successful auto-detect,
+        // or a manual pick) — either way, LoadZone ran at least once.
+        engine.NewZone("My Own Map");
+
+        fake.RoomTitle    = "Unmapped Clearing";
+        fake.Exits        = new[] { "north" };
+        fake.ServerRoomId = "";
+        fake.Fire();
+
+        // Normal record-mode behavior is preserved: the miss creates a node
+        // in the active zone rather than firing RoomNotFoundInZone.
+        Assert.NotNull(engine.CurrentNode);
+        Assert.Equal("Unmapped Clearing", engine.CurrentNode!.Title);
+        Assert.Single(engine.ActiveZone.Nodes);
+    }
+
+    [Fact]
+    public void LookupOnlyMode_FirstRoomOnPristineZone_StillSignalsMiss()
+    {
+        // Unchanged pre-existing behavior — lookup-only mode (IsEnabled =
+        // false, the default) never creates nodes; every miss fires
+        // RoomNotFoundInZone regardless of whether a zone was ever loaded.
+        var zone   = new MapZone { Name = "placeholder" };
+        var engine = new AutoMapperEngine(zone);
+        var fake   = new FakeGameState();
+        engine.Attach(fake);
+
+        var missFired = false;
+        engine.RoomNotFoundInZone += (_, _, _) => missFired = true;
+
+        fake.RoomTitle = "[Some Room]";
+        fake.Exits     = new[] { "south" };
+        fake.Fire();
+
+        Assert.Null(engine.CurrentNode);
+        Assert.Empty(zone.Nodes);
+        Assert.True(missFired);
+    }
+}


### PR DESCRIPTION
## Summary
- Record/Auto-Create mode short-circuited straight to node creation on any zone miss, including a session's very first room while the engine is still on its pristine, unnamed construction-time placeholder — so `RoomNotFoundInZone` never fired and the cross-zone auto-detect (`MapperViewModel.TryAutoLoadZoneFor`) never ran. The character got silently seeded into a nameless orphan zone instead of the matching local map, even though a zone file for that exact room exists. `AutoMapperEngine` now tracks whether a zone has ever been explicitly loaded this session (`LoadZone` — a successful auto-detect, a manual pick, or "New Zone") and only bypasses the lookup once that's true.
- Closes a related race in `MapperViewModel`: the auto-detect index is built in the background at the same moment room-event wiring starts, so the very first room can arrive before the index is ready. The engine's own change-detection then caches that room as "last seen" and nothing re-checks it once the index lands — `RebuildServerIdIndexAsync` now forces one re-resolution via `Recalculate()` once the index is populated, gated on `CurrentNode` still being null.

## Test plan
- [x] `dotnet build src/Genie.App/Genie.App.csproj` — succeeds
- [x] `dotnet test tests/Genie.Core.Tests` — 1134 passed, including new `AutoMapperRecordModeFirstRoomTests` (verified it fails without the `AutoMapperEngine` fix and passes with it)
- [x] `dotnet test tests/Genie.App.Tests` — 76 passed