### PR TITLE
feat(app): experimental AvaloniaEdit renderer for Raw XML and Stream windows

### DIFF
--- a/src/Genie.App/App.axaml
+++ b/src/Genie.App/App.axaml
@@ -1669,8 +1669,8 @@
                           FontSize="{Binding ToolFontSize}"
                           Foreground="#7fc4a0" Margin="4">
               <ItemsControl.ItemTemplate>
-                <DataTemplate DataType="x:String">
-                  <SelectableTextBlock Text="{Binding}"/>
+                <DataTemplate DataType="vm:TextLine">
+                  <SelectableTextBlock Text="{Binding Text}"/>
                 </DataTemplate>
               </ItemsControl.ItemTemplate>
             </ItemsControl>

--- a/src/Genie.App/App.axaml
+++ b/src/Genie.App/App.axaml
@@ -1295,6 +1295,59 @@
       </Grid>
     </DataTemplate>
 
+    <!-- ── Stream windows (experimental AvaloniaEdit renderer) ────────────── -->
+    <!-- MUST stay ABOVE the StreamTool template below — see the
+         EditorGameTextDocument comment for why. Only reached when
+         #config useeditorstreamwindow is on — GenieDockFactory constructs the
+         subtype only then, so with the flag off (the default) this template
+         matches nothing and the legacy subtree below is built exactly as it
+         always was. One flag, one template, all 12 Stream instances. -->
+    <DataTemplate DataType="docking:EditorStreamTool">
+      <Grid Background="{Binding ToolBackground}">
+        <controls:GameTextEditor x:Name="streamEditor"
+                                 Width="{Binding $parent[Grid].Bounds.Width}"
+                                 Height="{Binding $parent[Grid].Bounds.Height}"/>
+
+        <Button HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                Margin="0,0,20,8"
+                IsVisible="{Binding #streamEditor.IsScrolledUp}"
+                Command="{Binding #streamEditor.JumpToBottomCommand}"
+                Content="↓ Bottom" FontSize="11" Padding="8,4" Opacity="0.85"/>
+
+        <Border HorizontalAlignment="Right" VerticalAlignment="Top"
+                Margin="0,4,20,0" Padding="4,2" CornerRadius="3"
+                Background="{DynamicResource Theme.ToolbarBg}"
+                BorderBrush="{DynamicResource Theme.Border}" BorderThickness="1"
+                IsVisible="{Binding Find.IsOpen}">
+          <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBox Text="{Binding Find.FindText}" Watermark="Find…"
+                     AutomationProperties.Name="Find in window"
+                     Width="160" FontSize="11" MinHeight="0" Padding="4,2"
+                     controls:FindInWindow.BoxModel="{Binding Find}"/>
+            <TextBlock Text="{Binding Find.Status}" FontSize="10"
+                       Foreground="{DynamicResource Theme.TextMuted}"
+                       VerticalAlignment="Center"/>
+            <Button Content="▲" FontSize="10" Padding="4,1" MinHeight="0" MinWidth="0"
+                    AutomationProperties.Name="Find previous"
+                    AutomationProperties.HelpText="Older match (Enter)"
+                    Command="{Binding Find.OlderCommand}"
+                    ToolTip.Tip="Older match (Enter)"/>
+            <Button Content="▼" FontSize="10" Padding="4,1" MinHeight="0" MinWidth="0"
+                    AutomationProperties.Name="Find next"
+                    AutomationProperties.HelpText="Newer match (Shift+Enter)"
+                    Command="{Binding Find.NewerCommand}"
+                    ToolTip.Tip="Newer match (Shift+Enter)"/>
+            <Button Content="✕" FontSize="10" Padding="4,1" MinHeight="0" MinWidth="0"
+                    Background="Transparent" BorderThickness="0"
+                    AutomationProperties.Name="Close find bar"
+                    AutomationProperties.HelpText="Close (Esc)"
+                    Command="{Binding Find.CloseCommand}"
+                    ToolTip.Tip="Close (Esc)"/>
+          </StackPanel>
+        </Border>
+      </Grid>
+    </DataTemplate>
+
     <!-- ── Streams (shared template for all 5 stream tools) ──────────────── -->
     <DataTemplate DataType="docking:StreamTool">
       <Grid Background="{Binding ToolBackground}">
@@ -1641,6 +1694,32 @@
     <!-- double-click / Enter handlers that inline templates can't express.     -->
     <DataTemplate DataType="docking:ScriptsTool">
       <views:ScriptManagerView DataContext="{Binding ViewModel}"/>
+    </DataTemplate>
+
+    <!-- ── Raw XML window (experimental AvaloniaEdit renderer) ────────────── -->
+    <!-- MUST stay ABOVE the RawXmlTool template below — see the
+         EditorGameTextDocument comment for why. Only reached when
+         #config useeditorrawxmlwindow is on. Stays as minimal as the legacy
+         template: fixed green foreground, no Find, no word-wrap toggle — only
+         the rendering control underneath changes. -->
+    <DataTemplate DataType="docking:EditorRawXmlTool">
+      <Grid RowDefinitions="Auto,*" Margin="4">
+
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="6"
+                    Margin="0,0,0,4">
+          <Button Content="Clear" Command="{Binding ViewModel.ClearCommand}"
+                  FontSize="11" Padding="8,2"
+                  ToolTip.Tip="Clear the buffer"/>
+          <TextBlock Text="Live raw server XML — local view only."
+                     Foreground="{DynamicResource Theme.SectionHeader}" FontSize="11" VerticalAlignment="Center"/>
+        </StackPanel>
+
+        <Border Grid.Row="1" Background="{DynamicResource Theme.PanelBgDeep}" BorderBrush="{DynamicResource Theme.Border}"
+                BorderThickness="1" CornerRadius="3">
+          <controls:GameTextEditor Width="{Binding $parent[Border].Bounds.Width}"
+                                   Height="{Binding $parent[Border].Bounds.Height}"/>
+        </Border>
+      </Grid>
     </DataTemplate>
 
     <!-- ── Raw XML window (#14) — verbatim live server stream ─────────────── -->

--- a/src/Genie.App/Controls/GameTextEditor.cs
+++ b/src/Genie.App/Controls/GameTextEditor.cs
@@ -20,10 +20,12 @@ using ReactiveUI;
 namespace Genie.App.Controls;
 
 /// <summary>
-/// The experimental AvaloniaEdit-backed renderer for the main Game window
-/// (<c>#config useeditorgamewindow on</c>, default off). It hosts a single
-/// read-only <see cref="TextEditor"/> and mirrors
-/// <see cref="GameTextViewModel.Lines"/> — still the source of truth — into its
+/// The experimental AvaloniaEdit-backed renderer shared by the Game, Raw XML,
+/// and Stream windows (<c>#config useeditorgamewindow</c> /
+/// <c>useeditorrawxmlwindow</c> / <c>useeditorstreamwindow</c>, all default
+/// off). It hosts a single read-only <see cref="TextEditor"/> and mirrors
+/// whatever <see cref="ITextEditorHost"/> it is bound to —
+/// <see cref="ITextEditorHost.Lines"/> is still the source of truth — into its
 /// document, one buffered line per document line.
 ///
 /// <para>Only the <i>rendering</i> moves. Timestamping, the Name-List-Only filter,
@@ -31,9 +33,14 @@ namespace Genie.App.Controls;
 /// view-model and are untouched by which renderer is active.</para>
 ///
 /// <para>Selected out of the legacy path by type, not by a visibility toggle:
-/// <see cref="EditorGameTextDocument"/> gets its own <c>DataTemplate</c>, so with
-/// the flag off this control is never constructed and the legacy subtree is
-/// exactly what it always was.</para>
+/// <see cref="EditorGameTextDocument"/>, <see cref="EditorRawXmlTool"/>, and
+/// <see cref="EditorStreamTool"/> each get their own <c>DataTemplate</c>, so
+/// with a flag off this control is never constructed for that window type and
+/// the legacy subtree is exactly what it always was. Colorizing (highlight
+/// rules) and link generation are opt-in per host
+/// (<see cref="ITextEditorHost.EnableColorizing"/> /
+/// <see cref="ITextEditorHost.EnableLinks"/>) — on for Game/Stream, off for
+/// Raw XML, which stays a plain verbatim dump.</para>
 /// </summary>
 public sealed class GameTextEditor : UserControl
 {
@@ -46,9 +53,9 @@ public sealed class GameTextEditor : UserControl
     private readonly TextDocument _document = new();
     private readonly List<GameLineEntry> _entries = [];
 
-    private GameTextDocument?   _host;
-    private GameTextViewModel?  _vm;
+    private ITextEditorHost?    _host;
     private FindInWindowModel?  _find;
+    private bool                _renderersConfigured;
 
     private bool _atBottom = true;
     private bool _paused;
@@ -110,8 +117,9 @@ public sealed class GameTextEditor : UserControl
         area.CaretBrush   = Brushes.Transparent;   // read-only view: no caret
         area.ContextFlyout = null;
         area.TextView.ContextFlyout = null;
-        area.TextView.LineTransformers.Add(new GameTextColorizer(EntryAt));
-        area.TextView.ElementGenerators.Add(new GameLinkGenerator(EntryAt, area));
+        // Colorizing/link-generation are opt-in per host (EnableColorizing /
+        // EnableLinks) — added lazily in Subscribe(), once, the first time a
+        // host resolves. DataContext isn't available yet in the constructor.
 
         // The ScrollViewer normally exists by TemplateApplied; LayoutUpdated is the
         // belt-and-braces retry (it unhooks itself the moment the lookup succeeds)
@@ -160,15 +168,27 @@ public sealed class GameTextEditor : UserControl
     {
         if (_host is not null) return;                       // already wired
         if (this.GetVisualRoot() is null) return;              // wired on attach instead
-        if (DataContext is not GameTextDocument host) return;
+        if (DataContext is not ITextEditorHost host) return;
 
         _host = host;
-        _vm   = host.ViewModel;
         _find = host.Find;
 
-        host.PropertyChanged        += OnHostPropertyChanged;
-        _vm.Lines.CollectionChanged += OnLinesChanged;
-        _find.JumpRequested         += OnFindJump;
+        // Decided once per control instance, the first time a host resolves —
+        // a given DataTemplate instance always binds to the same concrete
+        // host type for its lifetime (visual-tree re-parenting re-attaches the
+        // same host; it never swaps Game for Raw XML under one control).
+        if (!_renderersConfigured)
+        {
+            _renderersConfigured = true;
+            if (host.EnableColorizing)
+                _editor.TextArea.TextView.LineTransformers.Add(new GameTextColorizer(EntryAt));
+            if (host.EnableLinks)
+                _editor.TextArea.TextView.ElementGenerators.Add(new GameLinkGenerator(EntryAt, _editor.TextArea));
+        }
+
+        host.PropertyChanged         += OnHostPropertyChanged;
+        host.Lines.CollectionChanged += OnLinesChanged;
+        if (_find is not null) _find.JumpRequested += OnFindJump;
 
         ApplyHostSettings();
         _paused = host.IsScrollPaused;
@@ -178,10 +198,9 @@ public sealed class GameTextEditor : UserControl
     private void Unsubscribe()
     {
         if (_host is not null) _host.PropertyChanged -= OnHostPropertyChanged;
-        if (_vm   is not null) _vm.Lines.CollectionChanged -= OnLinesChanged;
+        if (_host is not null) _host.Lines.CollectionChanged -= OnLinesChanged;
         if (_find is not null) _find.JumpRequested -= OnFindJump;
         _host = null;
-        _vm   = null;
         _find = null;
     }
 
@@ -190,7 +209,7 @@ public sealed class GameTextEditor : UserControl
         if (_host is null) return;
         switch (e.PropertyName)
         {
-            case nameof(GameTextDocument.IsScrollPaused):
+            case nameof(ITextEditorHost.IsScrollPaused):
                 SetPaused(_host.IsScrollPaused);
                 break;
             default:
@@ -366,16 +385,16 @@ public sealed class GameTextEditor : UserControl
     private void RebuildAll()
     {
         _entries.Clear();
-        if (_vm is null || _vm.Lines.Count == 0)
+        if (_host is null || _host.Lines.Count == 0)
         {
             _document.Text = "";
             return;
         }
 
         var sb = new System.Text.StringBuilder();
-        for (var i = 0; i < _vm.Lines.Count; i++)
+        for (var i = 0; i < _host.Lines.Count; i++)
         {
-            var line = _vm.Lines[i];
+            var line = _host.Lines[i];
             _entries.Add(new GameLineEntry(line));
             if (i > 0) sb.Append('\n');
             sb.Append(Flatten(line.Text));

--- a/src/Genie.App/Controls/ITextEditorHost.cs
+++ b/src/Genie.App/Controls/ITextEditorHost.cs
@@ -1,0 +1,49 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media;
+using Genie.App.Docking;
+using Genie.App.ViewModels;
+
+namespace Genie.App.Controls;
+
+/// <summary>
+/// Contract the AvaloniaEdit-backed <see cref="GameTextEditor"/> control needs
+/// from whatever dock tool or document hosts it. Game
+/// (<see cref="Docking.GameTextDocument"/>), Stream
+/// (<see cref="Docking.StreamTool"/>), and Raw XML
+/// (<see cref="Docking.RawXmlTool"/>) all implement this instead of the
+/// control depending on any one concrete host type.
+/// </summary>
+public interface ITextEditorHost : INotifyPropertyChanged
+{
+    /// <summary>The buffered lines to render — one document line per entry,
+    /// the same source of truth the legacy ItemsControl renderer reads.</summary>
+    ObservableCollection<TextLine> Lines { get; }
+
+    FontFamily ToolFontFamily { get; }
+    double     ToolFontSize   { get; }
+
+    /// <summary>Null means "inherit the global game colour" (Game, Stream);
+    /// hosts with a fixed colour (Raw XML) always return a brush.</summary>
+    IBrush? ToolForeground { get; }
+
+    TextWrapping        ToolTextWrapping { get; }
+    ScrollBarVisibility  ToolHScroll      { get; }
+
+    /// <summary>"Pause Scrolling" window-menu state. Settable so the control
+    /// can resume it on toggle.</summary>
+    bool IsScrollPaused { get; set; }
+
+    /// <summary>Null disables the in-window Find bar entirely (Raw XML).</summary>
+    FindInWindowModel? Find { get; }
+
+    /// <summary>Run highlight-rule colorizing (<see cref="GameTextColorizer"/>)
+    /// over each line. On for Game/Stream; off for Raw XML — a verbatim
+    /// protocol dump with no rule matching.</summary>
+    bool EnableColorizing { get; }
+
+    /// <summary>Detect and render clickable links (<see cref="GameLinkGenerator"/>).
+    /// On for Game/Stream; off for Raw XML.</summary>
+    bool EnableLinks { get; }
+}

--- a/src/Genie.App/Docking/GameTextDocument.cs
+++ b/src/Genie.App/Docking/GameTextDocument.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using Avalonia;
 using Avalonia.Media;
 using Dock.Model.Mvvm.Controls;
@@ -7,9 +8,13 @@ using Genie.Core.Layout;
 
 namespace Genie.App.Docking;
 
-public class GameTextDocument : Document, IWindowMenuHost, IFindHost
+public class GameTextDocument : Document, IWindowMenuHost, IFindHost, ITextEditorHost
 {
     public GameTextViewModel ViewModel { get; }
+
+    public ObservableCollection<TextLine> Lines => ViewModel.Lines;
+    public bool EnableColorizing => true;
+    public bool EnableLinks      => true;
 
     /// <summary>In-window Find bar state (#120). The overlay in the game-text
     /// template binds to this; Ctrl+F / the window menu opens it.</summary>

--- a/src/Genie.App/Docking/GenieDockFactory.cs
+++ b/src/Genie.App/Docking/GenieDockFactory.cs
@@ -159,6 +159,32 @@ public class GenieDockFactory : Factory
             : new GameTextDocument(_vm.GameText, settings);
     }
 
+    /// <summary>Render the Raw XML window via <see cref="EditorRawXmlTool"/> when
+    /// <c>#config useeditorrawxmlwindow</c> is on. Same read-once, type-based
+    /// selection as <see cref="NewGameText"/>.</summary>
+    private RawXmlTool NewRawXmlTool(Genie.Core.Layout.WindowSettingsStore ws)
+    {
+        var settings = ws.Get("raw-xml");
+        return _vm.UseEditorRawXmlWindow
+            ? new EditorRawXmlTool(_vm.RawXml, settings)
+            : new RawXmlTool(_vm.RawXml, settings);
+    }
+
+    /// <summary>Render every Stream window via <see cref="EditorStreamTool"/>
+    /// when <c>#config useeditorstreamwindow</c> is on — one flag governs all
+    /// 12 instances. <paramref name="buffer"/> varies (Logons, Talk, ...); the
+    /// id derivation (<c>buffer.Name.ToLowerInvariant()</c>) matches
+    /// <see cref="StreamTool"/>'s own constructor exactly, so the same
+    /// <see cref="Genie.Core.Layout.WindowSettingsStore"/> entry resolves
+    /// either way.</summary>
+    private StreamTool NewStreamTool(StreamBuffer buffer, Genie.Core.Layout.WindowSettingsStore ws)
+    {
+        var settings = ws.Get(buffer.Name.ToLowerInvariant());
+        return _vm.UseEditorStreamWindow
+            ? new EditorStreamTool(buffer, settings)
+            : new StreamTool(buffer, settings);
+    }
+
     public override IRootDock CreateLayout()
     {
         // Wire the host-window locator. Dock.Avalonia's FloatDockable silently
@@ -193,18 +219,18 @@ public class GenieDockFactory : Factory
         var room     = new RoomTool        (_vm.Room,             ws.Get("room"));
         var backpack = new BackpackTool    (_vm.Inventory,        ws.Get("backpack"));
         var mapper   = new MapperTool      (_vm.Mapper,           ws.Get("mapper"));
-        var logons   = new StreamTool      (_vm.StreamTabs.Logons,   ws.Get("logons"));
-        var talk     = new StreamTool      (_vm.StreamTabs.Talk,     ws.Get("talk"));
-        var whispers = new StreamTool      (_vm.StreamTabs.Whispers, ws.Get("whispers"));
-        var thoughts = new StreamTool      (_vm.StreamTabs.Thoughts, ws.Get("thoughts"));
-        var combat   = new StreamTool      (_vm.StreamTabs.Combat,   ws.Get("combat"));
-        var familiar = new StreamTool      (_vm.StreamTabs.Familiar, ws.Get("familiar"));
-        var death    = new StreamTool      (_vm.StreamTabs.Death,    ws.Get("death"));
-        var assess   = new StreamTool      (_vm.StreamTabs.Assess,   ws.Get("assess"));
-        var atmospherics = new StreamTool  (_vm.StreamTabs.Atmospherics, ws.Get("atmospherics"));
-        var ooc      = new StreamTool      (_vm.StreamTabs.Ooc,      ws.Get("ooc"));
-        var log      = new StreamTool      (_vm.StreamTabs.Log,      ws.Get("log"));
-        var itemlog  = new StreamTool      (_vm.StreamTabs.ItemLog,  ws.Get("itemlog"));
+        var logons   = NewStreamTool(_vm.StreamTabs.Logons,   ws);
+        var talk     = NewStreamTool(_vm.StreamTabs.Talk,     ws);
+        var whispers = NewStreamTool(_vm.StreamTabs.Whispers, ws);
+        var thoughts = NewStreamTool(_vm.StreamTabs.Thoughts, ws);
+        var combat   = NewStreamTool(_vm.StreamTabs.Combat,   ws);
+        var familiar = NewStreamTool(_vm.StreamTabs.Familiar, ws);
+        var death    = NewStreamTool(_vm.StreamTabs.Death,    ws);
+        var assess   = NewStreamTool(_vm.StreamTabs.Assess,   ws);
+        var atmospherics = NewStreamTool(_vm.StreamTabs.Atmospherics, ws);
+        var ooc      = NewStreamTool(_vm.StreamTabs.Ooc,      ws);
+        var log      = NewStreamTool(_vm.StreamTabs.Log,      ws);
+        var itemlog  = NewStreamTool(_vm.StreamTabs.ItemLog,  ws);
         var experience = new ExperienceTool(_vm.Experience,          ws.Get("experience"));
         var analytics  = new AnalyticsTool (_vm.Analytics,           ws.Get("analytics"));
         var activeSpells = new ActiveSpellsTool(_vm.ActiveSpells,    ws.Get("active-spells"));
@@ -214,7 +240,7 @@ public class GenieDockFactory : Factory
         var scene      = new SceneTool     (_vm.Scene,              ws.Get("scene"));
         var mobs       = new MobsTool      (_vm.Mobs,               ws.Get("mobs"));
         var players    = new PlayersTool   (_vm.Players,            ws.Get("players"));
-        var rawXml     = new RawXmlTool    (_vm.RawXml,             ws.Get("raw-xml"));
+        var rawXml     = NewRawXmlTool(ws);
         var injuries   = new InjuriesTool  (_vm.Injuries,           ws.Get("injuries"));
 
         // ── Default ship layout — three vertical columns ─────────────────
@@ -456,18 +482,18 @@ public class GenieDockFactory : Factory
         var room       = new RoomTool        (_vm.Room,               ws.Get("room"));
         var backpack   = new BackpackTool    (_vm.Inventory,          ws.Get("backpack"));
         var mapper     = new MapperTool      (_vm.Mapper,             ws.Get("mapper"));
-        var logons     = new StreamTool      (_vm.StreamTabs.Logons,   ws.Get("logons"));
-        var talk       = new StreamTool      (_vm.StreamTabs.Talk,     ws.Get("talk"));
-        var whispers   = new StreamTool      (_vm.StreamTabs.Whispers, ws.Get("whispers"));
-        var thoughts   = new StreamTool      (_vm.StreamTabs.Thoughts, ws.Get("thoughts"));
-        var combat     = new StreamTool      (_vm.StreamTabs.Combat,   ws.Get("combat"));
-        var familiar   = new StreamTool      (_vm.StreamTabs.Familiar, ws.Get("familiar"));
-        var death      = new StreamTool      (_vm.StreamTabs.Death,    ws.Get("death"));
-        var assess     = new StreamTool      (_vm.StreamTabs.Assess,   ws.Get("assess"));
-        var atmospherics = new StreamTool    (_vm.StreamTabs.Atmospherics, ws.Get("atmospherics"));
-        var ooc        = new StreamTool      (_vm.StreamTabs.Ooc,      ws.Get("ooc"));
-        var log        = new StreamTool      (_vm.StreamTabs.Log,      ws.Get("log"));
-        var itemlog    = new StreamTool      (_vm.StreamTabs.ItemLog,  ws.Get("itemlog"));
+        var logons     = NewStreamTool(_vm.StreamTabs.Logons,   ws);
+        var talk       = NewStreamTool(_vm.StreamTabs.Talk,     ws);
+        var whispers   = NewStreamTool(_vm.StreamTabs.Whispers, ws);
+        var thoughts   = NewStreamTool(_vm.StreamTabs.Thoughts, ws);
+        var combat     = NewStreamTool(_vm.StreamTabs.Combat,   ws);
+        var familiar   = NewStreamTool(_vm.StreamTabs.Familiar, ws);
+        var death      = NewStreamTool(_vm.StreamTabs.Death,    ws);
+        var assess     = NewStreamTool(_vm.StreamTabs.Assess,   ws);
+        var atmospherics = NewStreamTool(_vm.StreamTabs.Atmospherics, ws);
+        var ooc        = NewStreamTool(_vm.StreamTabs.Ooc,      ws);
+        var log        = NewStreamTool(_vm.StreamTabs.Log,      ws);
+        var itemlog    = NewStreamTool(_vm.StreamTabs.ItemLog,  ws);
         var experience = new ExperienceTool  (_vm.Experience,          ws.Get("experience"));
         var analytics  = new AnalyticsTool   (_vm.Analytics,           ws.Get("analytics"));
         var activeSpells = new ActiveSpellsTool(_vm.ActiveSpells,       ws.Get("active-spells"));
@@ -476,7 +502,7 @@ public class GenieDockFactory : Factory
         var scene      = new SceneTool        (_vm.Scene,              ws.Get("scene"));
         var mobs       = new MobsTool         (_vm.Mobs,               ws.Get("mobs"));
         var players    = new PlayersTool      (_vm.Players,            ws.Get("players"));
-        var rawXml     = new RawXmlTool       (_vm.RawXml,             ws.Get("raw-xml"));
+        var rawXml     = NewRawXmlTool(ws);
         var injuries   = new InjuriesTool     (_vm.Injuries,           ws.Get("injuries"));
 
         // Every MDI panel in canonical order, paired with its id.

--- a/src/Genie.App/Docking/GenieDockFactory.cs
+++ b/src/Genie.App/Docking/GenieDockFactory.cs
@@ -926,7 +926,7 @@ public class GenieDockFactory : Factory
             StreamTool st       => ReactiveCommand.CreateFromTask(
                 () => WindowClipboard.CopyLinesAsync(st.Buffer.Lines.Select(l => l.Text))),
             RawXmlTool rx       => ReactiveCommand.CreateFromTask(
-                () => WindowClipboard.CopyLinesAsync(rx.ViewModel.Lines)),
+                () => WindowClipboard.CopyLinesAsync(rx.ViewModel.Lines.Select(l => l.Text))),
             PluginWindowTool pw => ReactiveCommand.CreateFromTask(
                 () => WindowClipboard.CopyLinesAsync(pw.ViewModel.Lines.Select(l => l.Text))),
             BackpackTool bp     => ReactiveCommand.CreateFromTask(
@@ -955,7 +955,7 @@ public class GenieDockFactory : Factory
             BackpackTool bp     => ReactiveCommand.CreateFromTask(
                 () => WindowSaveAs.SaveLinesAsync(bp.Title, bp.ViewModel.Items.Select(l => l.Text))),
             RawXmlTool rx       => ReactiveCommand.CreateFromTask(
-                () => WindowSaveAs.SaveLinesAsync(rx.Title, rx.ViewModel.Lines)),
+                () => WindowSaveAs.SaveLinesAsync(rx.Title, rx.ViewModel.Lines.Select(l => l.Text))),
             PluginWindowTool pw => ReactiveCommand.CreateFromTask(
                 () => WindowSaveAs.SaveLinesAsync(pw.Title, pw.ViewModel.Lines.Select(l => l.Text))),
             RoomTool rm         => ReactiveCommand.CreateFromTask(

--- a/src/Genie.App/Docking/RawXmlTool.cs
+++ b/src/Genie.App/Docking/RawXmlTool.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using Avalonia.Media;
 using Dock.Model.Mvvm.Controls;
 using Genie.App.Controls;
@@ -12,7 +13,7 @@ namespace Genie.App.Docking;
 /// Window → Raw XML. A dev/debug panel, grouped beside the other utility tabs
 /// (Scripts / Scene) in the default layout.
 /// </summary>
-public class RawXmlTool : Tool, IWindowMenuHost
+public class RawXmlTool : Tool, IWindowMenuHost, ITextEditorHost
 {
     public RawXmlViewModel ViewModel { get; }
 
@@ -29,6 +30,27 @@ public class RawXmlTool : Tool, IWindowMenuHost
 
     private double     _toolFontSize = 11;
     public  double     ToolFontSize { get => _toolFontSize; private set => SetProperty(ref _toolFontSize, value); }
+
+    // ── ITextEditorHost (consumed only when useeditorrawxmlwindow is on) ────────
+    // Raw XML stays exactly as minimal under the editor renderer as it is under
+    // the legacy one: a fixed colour (not a resolvable per-window
+    // ToolForeground like Game/Stream get), no word-wrap toggle (NoWrap +
+    // horizontal scroll, matching the legacy "long tags stay on one line"
+    // behavior), no Find, no highlighting/links.
+    private static readonly IBrush RawXmlForeground = new SolidColorBrush(Color.Parse("#7fc4a0"));
+
+    public ObservableCollection<TextLine> Lines           => ViewModel.Lines;
+    public IBrush?                        ToolForeground   => RawXmlForeground;
+    public TextWrapping                   ToolTextWrapping => TextWrapping.NoWrap;
+    public Avalonia.Controls.Primitives.ScrollBarVisibility ToolHScroll
+        => Avalonia.Controls.Primitives.ScrollBarVisibility.Auto;
+
+    private bool _isScrollPaused;
+    public  bool IsScrollPaused { get => _isScrollPaused; set => SetProperty(ref _isScrollPaused, value); }
+
+    public FindInWindowModel? Find             => null;
+    public bool                EnableColorizing => false;
+    public bool                EnableLinks      => false;
 
     public RawXmlTool(RawXmlViewModel vm, WindowSettings? settings = null)
     {
@@ -49,4 +71,18 @@ public class RawXmlTool : Tool, IWindowMenuHost
         ToolFontFamily = WindowSettingsResolver.ResolveFontFamily(s.FontFamily);
         ToolFontSize   = WindowSettingsResolver.ResolveFontSize(s.FontSize);
     }
+}
+
+/// <summary>
+/// The Raw XML window rendered by <see cref="Controls.GameTextEditor"/>
+/// (AvaloniaEdit) instead of the per-line <c>ItemsControl</c>. Created by
+/// <see cref="GenieDockFactory"/> in place of a plain <see cref="RawXmlTool"/>
+/// when <c>GenieConfig.UseEditorRawXmlWindow</c> is on. Experimental; default
+/// off. Same type-based renderer selection as
+/// <see cref="EditorGameTextDocument"/> — see that type's doc comment for why.
+/// </summary>
+public sealed class EditorRawXmlTool : RawXmlTool
+{
+    public EditorRawXmlTool(RawXmlViewModel vm, WindowSettings? settings = null)
+        : base(vm, settings) { }
 }

--- a/src/Genie.App/Docking/StreamTool.cs
+++ b/src/Genie.App/Docking/StreamTool.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using Avalonia;
 using Avalonia.Media;
 using Dock.Model.Mvvm.Controls;
@@ -7,9 +8,13 @@ using Genie.Core.Layout;
 
 namespace Genie.App.Docking;
 
-public class StreamTool : Tool, IWindowMenuHost, IFindHost
+public class StreamTool : Tool, IWindowMenuHost, IFindHost, ITextEditorHost
 {
     public StreamBuffer Buffer { get; }
+
+    public ObservableCollection<TextLine> Lines => Buffer.Lines;
+    public bool EnableColorizing => true;
+    public bool EnableLinks      => true;
 
     /// <summary>In-window Find bar state (#120).</summary>
     public FindInWindowModel Find { get; }
@@ -82,4 +87,20 @@ public class StreamTool : Tool, IWindowMenuHost, IFindHost
             ? Avalonia.Controls.Primitives.ScrollBarVisibility.Disabled
             : Avalonia.Controls.Primitives.ScrollBarVisibility.Auto;
     }
+}
+
+/// <summary>
+/// A Stream window (Logons, Talk, Whispers, ...) rendered by
+/// <see cref="Controls.GameTextEditor"/> (AvaloniaEdit) instead of the
+/// per-line <c>ItemsControl</c>. Created by <see cref="GenieDockFactory"/> in
+/// place of a plain <see cref="StreamTool"/> when
+/// <c>GenieConfig.UseEditorStreamWindow</c> is on — one flag governs every
+/// Stream instance, since they all share this one class. Experimental;
+/// default off. Same type-based renderer selection as
+/// <see cref="EditorGameTextDocument"/> — see that type's doc comment for why.
+/// </summary>
+public sealed class EditorStreamTool : StreamTool
+{
+    public EditorStreamTool(StreamBuffer buffer, WindowSettings? settings = null)
+        : base(buffer, settings) { }
 }

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -1082,6 +1082,23 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// document. Changing the setting needs a restart.</summary>
     public bool UseEditorGameWindow { get; private set; }
 
+    /// <summary>Render the Raw XML window with AvaloniaEdit instead of the
+    /// per-line ItemsControl (<c>#config useeditorrawxmlwindow</c>, default
+    /// off). Same read-once-at-startup contract as
+    /// <see cref="UseEditorGameWindow"/>; consumed by
+    /// <see cref="Genie.App.Docking.GenieDockFactory"/> when it creates the
+    /// Raw XML tool. Changing the setting needs a restart.</summary>
+    public bool UseEditorRawXmlWindow { get; private set; }
+
+    /// <summary>Render every Stream window (Logons, Talk, Whispers, ...) with
+    /// AvaloniaEdit instead of the per-line ItemsControl (<c>#config
+    /// useeditorstreamwindow</c>, default off). One flag governs all 12
+    /// <see cref="Docking.StreamTool"/> instances. Same read-once-at-startup
+    /// contract as <see cref="UseEditorGameWindow"/>; consumed by
+    /// <see cref="Genie.App.Docking.GenieDockFactory"/> when it creates each
+    /// stream tool. Changing the setting needs a restart.</summary>
+    public bool UseEditorStreamWindow { get; private set; }
+
     public MainWindowViewModel() : this(null) { }
 
     public MainWindowViewModel(StartupOptions? startup)
@@ -1130,7 +1147,9 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         {
             var startupConfig = new Genie.Core.Config.GenieConfig(dir);
             startupConfig.Load();
-            UseEditorGameWindow = startupConfig.UseEditorGameWindow;
+            UseEditorGameWindow   = startupConfig.UseEditorGameWindow;
+            UseEditorRawXmlWindow = startupConfig.UseEditorRawXmlWindow;
+            UseEditorStreamWindow = startupConfig.UseEditorStreamWindow;
         }
         catch (Exception ex)
         {

--- a/src/Genie.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Genie.App/ViewModels/MainWindowViewModel.cs
@@ -1099,9 +1099,19 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
     /// stream tool. Changing the setting needs a restart.</summary>
     public bool UseEditorStreamWindow { get; private set; }
 
-    public MainWindowViewModel() : this(null) { }
+    public MainWindowViewModel() : this(null, null) { }
 
-    public MainWindowViewModel(StartupOptions? startup)
+    public MainWindowViewModel(StartupOptions? startup) : this(startup, null) { }
+
+    /// <summary>Test-only entry point: <paramref name="dataDirectoryOverride"/>
+    /// points the whole data root at an isolated directory instead of letting
+    /// <see cref="LocalDirectoryService"/> discover the real per-user Genie5
+    /// AppData folder — everything below (Profiles.Load, Display.Load, the
+    /// Maps migration, ...) then reads/writes under it instead. Null (every
+    /// real caller) keeps normal discovery. Mirrors
+    /// <see cref="Genie.Core.GenieCore"/>'s own <c>dataDirectoryOverride</c>
+    /// parameter.</summary>
+    public MainWindowViewModel(StartupOptions? startup, string? dataDirectoryOverride)
     {
         Startup = startup;
 
@@ -1109,6 +1119,8 @@ public class MainWindowViewModel : ReactiveObject, IActivatableViewModel
         // LocalDirectoryService honors portable mode (Config\ next to the exe)
         // and XDG / AppSupport paths on Linux / macOS.
         var dir       = new LocalDirectoryService("Genie5", AppContext.BaseDirectory);
+        if (!string.IsNullOrWhiteSpace(dataDirectoryOverride))
+            dir.UseExplicitRoot(dataDirectoryOverride);
         _configDir    = dir.Current.ValidateDirectory("Config");
         _profilesPath = Path.Combine(_configDir, "profiles.json");
         _displayPath  = Path.Combine(_configDir, "display.json");

--- a/src/Genie.App/ViewModels/RawXmlViewModel.cs
+++ b/src/Genie.App/ViewModels/RawXmlViewModel.cs
@@ -30,9 +30,13 @@ public class RawXmlViewModel : ReactiveObject
     /// is generous but still finite.</summary>
     private const int MaxLines = 5000;
 
-    /// <summary>One raw line per row. Plain strings (not <c>TextLine</c>) —
-    /// this is a verbatim protocol dump, so no highlighting / inlines.</summary>
-    public ObservableCollection<string> Lines { get; } = [];
+    /// <summary>One raw line per row, as a plain <c>TextLine</c> (Color =
+    /// StreamColor.Main, no Links/BoldSpans/PresetSpans) — this is a verbatim
+    /// protocol dump, so no highlighting/inlines happen. Unified with
+    /// GameTextViewModel/StreamBuffer's shape so the AvaloniaEdit renderer
+    /// (GameTextEditor) can bind against any of the three without a special
+    /// case (#274).</summary>
+    public ObservableCollection<TextLine> Lines { get; } = [];
 
     public ReactiveCommand<Unit, Unit> ClearCommand { get; }
 
@@ -70,7 +74,7 @@ public class RawXmlViewModel : ReactiveObject
             var line = raw.TrimEnd('\r');
             if (line.Length == 0) continue;
 
-            Lines.Add(line);
+            Lines.Add(new TextLine(line, StreamColor.Main));
             if (Lines.Count > MaxLines)
                 Lines.RemoveAt(0);
         }

--- a/src/Genie.Core/Config/GenieConfig.cs
+++ b/src/Genie.Core/Config/GenieConfig.cs
@@ -61,6 +61,11 @@ public sealed class GenieConfig
     /// layout is built — swapping renderers under a populated buffer is not
     /// worth the complexity, so changing it needs a restart.</summary>
     public bool UseEditorGameWindow { get; set; }
+    /// <summary>Render the Raw XML window with AvaloniaEdit instead of the
+    /// per-line ItemsControl. Same experimental contract as
+    /// <see cref="UseEditorGameWindow"/> — default off, read ONCE when the dock
+    /// layout is built, so changing it needs a restart.</summary>
+    public bool UseEditorRawXmlWindow { get; set; }
     public bool ShowSpellTimer { get; set; } = true;
     /// <summary>Built-in Experience tracker ($Skill.* / $TDPs globals + "Experience"
     /// dock panel). Default on. Was the external Plugin_EXPTrackerV5, now in Core.</summary>
@@ -643,6 +648,7 @@ public sealed class GenieConfig
         ("aliases", EnableAliases.ToString()),
         ("scrollbacklines", ScrollbackLines.ToString()),
         ("useeditorgamewindow", UseEditorGameWindow.ToString()),
+        ("useeditorrawxmlwindow", UseEditorRawXmlWindow.ToString()),
         ("spelltimer", ShowSpellTimer.ToString()),
         ("showexperience", ShowExperience.ToString()),
         ("experiencedensity", ExperienceDensity.ToString()),
@@ -775,7 +781,7 @@ public sealed class GenieConfig
     {
         ("Connection",       new[] { "activitytimeout", "classicconnect", "conndebug", "connectscript", "flagscheck", "frontend", "reconnect" }),
         ("Lich",             new[] { "lichautolaunch", "lichruby", "lichpath", "lichargs", "lichstartpause", "lichdebug" }),
-        ("Window / Input",   new[] { "alwaysontop", "ignoreclosealert", "keepinputtext", "sizeinputtogame", "scrollbacklines", "useeditorgamewindow" }),
+        ("Window / Input",   new[] { "alwaysontop", "ignoreclosealert", "keepinputtext", "sizeinputtogame", "scrollbacklines", "useeditorgamewindow", "useeditorrawxmlwindow" }),
         ("Display / Parser", new[] { "spelltimer", "showexperience", "experiencedensity", "experiencetrackgain", "experienceg4layout", "experienceconfigbar", "showtimetracker", "prompt", "promptbreak", "promptforce", "condensed", "monstercountignorelist", "monsterbold", "parsegameonly", "roundtimeoffset", "showlinks", "showimages", "weblinksafety", "injuriespoll", "injurieslayout" }),
         ("Master Toggles",   new[] { "highlights", "triggers", "substitutes", "gags", "aliases" }),
         ("Scripting",        new[] { "scriptchar", "separatorchar", "commandchar", "mycommandchar", "triggeroninput", "warnrawvars", "scripttimeout", "maxgosubdepth", "abortdupescript", "ignorescriptwarnings", "scriptextension", "editor" }),
@@ -821,6 +827,7 @@ public sealed class GenieConfig
                 case "aliases": EnableAliases = ToBool(value); Notify(ConfigFieldUpdated.MasterToggles); break;
                 case "scrollbacklines": ScrollbackLines = Math.Clamp(UtilityCore.StringToInteger(value), 100, 100000); break;
                 case "useeditorgamewindow": UseEditorGameWindow = ToBool(value); break;
+                case "useeditorrawxmlwindow": UseEditorRawXmlWindow = ToBool(value); break;
                 case "spelltimer": ShowSpellTimer = ToBool(value); Notify(ConfigFieldUpdated.Trackers); break;
                 case "showexperience": ShowExperience = ToBool(value); Notify(ConfigFieldUpdated.Trackers); break;
                 case "experiencedensity": ExperienceDensity = Math.Clamp(UtilityCore.StringToInteger(value), 0, 4); Notify(ConfigFieldUpdated.Trackers); break;

--- a/src/Genie.Core/Config/GenieConfig.cs
+++ b/src/Genie.Core/Config/GenieConfig.cs
@@ -66,6 +66,12 @@ public sealed class GenieConfig
     /// <see cref="UseEditorGameWindow"/> — default off, read ONCE when the dock
     /// layout is built, so changing it needs a restart.</summary>
     public bool UseEditorRawXmlWindow { get; set; }
+    /// <summary>Render every Stream window (Logons, Talk, Whispers, ...) with
+    /// AvaloniaEdit instead of the per-line ItemsControl. One flag governs all
+    /// 12 StreamTool instances. Same experimental contract as
+    /// <see cref="UseEditorGameWindow"/> — default off, read ONCE when the dock
+    /// layout is built, so changing it needs a restart.</summary>
+    public bool UseEditorStreamWindow { get; set; }
     public bool ShowSpellTimer { get; set; } = true;
     /// <summary>Built-in Experience tracker ($Skill.* / $TDPs globals + "Experience"
     /// dock panel). Default on. Was the external Plugin_EXPTrackerV5, now in Core.</summary>
@@ -649,6 +655,7 @@ public sealed class GenieConfig
         ("scrollbacklines", ScrollbackLines.ToString()),
         ("useeditorgamewindow", UseEditorGameWindow.ToString()),
         ("useeditorrawxmlwindow", UseEditorRawXmlWindow.ToString()),
+        ("useeditorstreamwindow", UseEditorStreamWindow.ToString()),
         ("spelltimer", ShowSpellTimer.ToString()),
         ("showexperience", ShowExperience.ToString()),
         ("experiencedensity", ExperienceDensity.ToString()),
@@ -781,7 +788,7 @@ public sealed class GenieConfig
     {
         ("Connection",       new[] { "activitytimeout", "classicconnect", "conndebug", "connectscript", "flagscheck", "frontend", "reconnect" }),
         ("Lich",             new[] { "lichautolaunch", "lichruby", "lichpath", "lichargs", "lichstartpause", "lichdebug" }),
-        ("Window / Input",   new[] { "alwaysontop", "ignoreclosealert", "keepinputtext", "sizeinputtogame", "scrollbacklines", "useeditorgamewindow", "useeditorrawxmlwindow" }),
+        ("Window / Input",   new[] { "alwaysontop", "ignoreclosealert", "keepinputtext", "sizeinputtogame", "scrollbacklines", "useeditorgamewindow", "useeditorrawxmlwindow", "useeditorstreamwindow" }),
         ("Display / Parser", new[] { "spelltimer", "showexperience", "experiencedensity", "experiencetrackgain", "experienceg4layout", "experienceconfigbar", "showtimetracker", "prompt", "promptbreak", "promptforce", "condensed", "monstercountignorelist", "monsterbold", "parsegameonly", "roundtimeoffset", "showlinks", "showimages", "weblinksafety", "injuriespoll", "injurieslayout" }),
         ("Master Toggles",   new[] { "highlights", "triggers", "substitutes", "gags", "aliases" }),
         ("Scripting",        new[] { "scriptchar", "separatorchar", "commandchar", "mycommandchar", "triggeroninput", "warnrawvars", "scripttimeout", "maxgosubdepth", "abortdupescript", "ignorescriptwarnings", "scriptextension", "editor" }),
@@ -828,6 +835,7 @@ public sealed class GenieConfig
                 case "scrollbacklines": ScrollbackLines = Math.Clamp(UtilityCore.StringToInteger(value), 100, 100000); break;
                 case "useeditorgamewindow": UseEditorGameWindow = ToBool(value); break;
                 case "useeditorrawxmlwindow": UseEditorRawXmlWindow = ToBool(value); break;
+                case "useeditorstreamwindow": UseEditorStreamWindow = ToBool(value); break;
                 case "spelltimer": ShowSpellTimer = ToBool(value); Notify(ConfigFieldUpdated.Trackers); break;
                 case "showexperience": ShowExperience = ToBool(value); Notify(ConfigFieldUpdated.Trackers); break;
                 case "experiencedensity": ExperienceDensity = Math.Clamp(UtilityCore.StringToInteger(value), 0, 4); Notify(ConfigFieldUpdated.Trackers); break;

--- a/tests/Genie.App.Tests/DataDirectoryOverrideTests.cs
+++ b/tests/Genie.App.Tests/DataDirectoryOverrideTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using Genie.App.ViewModels;
+using Xunit;
+
+namespace Genie.App.Tests;
+
+/// <summary>
+/// <see cref="MainWindowViewModel"/> has no <c>dataDirectoryOverride</c> seam
+/// today (unlike <see cref="Genie.Core.GenieCore"/>, which already has one —
+/// see MapperConfigSyncTests.Harness), so every test that constructs it would
+/// otherwise touch the real per-user Genie5 AppData folder: Profiles.Load,
+/// Display.Load, and a one-time Maps-folder migration all run in the
+/// constructor. This confirms the override actually confines that I/O to an
+/// isolated directory instead.
+/// </summary>
+public class DataDirectoryOverrideTests
+{
+    [Fact]
+    public void DataDirectoryOverride_confines_construction_file_io_to_the_given_directory()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "genie_app_tests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            _ = new MainWindowViewModel(startup: null, dataDirectoryOverride: dir);
+
+            Assert.True(Directory.Exists(Path.Combine(dir, "Config")));
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/tests/Genie.App.Tests/DockFactoryEditorWindowTests.cs
+++ b/tests/Genie.App.Tests/DockFactoryEditorWindowTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Reflection;
+using Dock.Model.Core;
+using Genie.App.Docking;
+using Genie.App.ViewModels;
+using Xunit;
+
+namespace Genie.App.Tests;
+
+/// <summary>
+/// Covers the mechanism <c>useeditorrawxmlwindow</c> / <c>useeditorstreamwindow</c>
+/// actually introduce: a factory-level type swap that applies to every window
+/// instance of a type at once (all 12 Stream tools share one flag).
+///
+/// <para>Runs <see cref="GenieDockFactory.CreateLayout"/> with no live Avalonia
+/// <c>Application</c> — confirmed safe by spike:
+/// <see cref="MainWindowViewModel"/>'s constructor only touches
+/// <c>Application.Current</c> through null-conditional guards, and
+/// <c>CreateLayout</c> only builds Dock.Model POCOs, never an actual
+/// <c>Window</c>. This is coverage the existing <c>useeditorgamewindow</c>
+/// flag doesn't have today.</para>
+///
+/// <para>Each test points <see cref="MainWindowViewModel"/> at an isolated
+/// temp directory via its Task 10 <c>dataDirectoryOverride</c> seam instead of
+/// letting it discover the real per-user Genie5 AppData folder.</para>
+/// </summary>
+public class DockFactoryEditorWindowTests
+{
+    private static readonly string[] StreamIds =
+    [
+        "logons", "talk", "whispers", "thoughts", "combat", "familiar",
+        "death", "assess", "atmospherics", "ooc", "log", "itemlog",
+    ];
+
+    private static void SetFlag(MainWindowViewModel vm, string propertyName, bool value) =>
+        typeof(MainWindowViewModel).GetProperty(propertyName)!.SetValue(vm, value);
+
+    private static IDockable? FindById(IDockable root, string id)
+    {
+        if (root.Id == id) return root;
+        if (root is IDock dock && dock.VisibleDockables is not null)
+            foreach (var child in dock.VisibleDockables)
+            {
+                var found = FindById(child, id);
+                if (found is not null) return found;
+            }
+        return null;
+    }
+
+    /// <summary>
+    /// Deviation from the plan brief's test, documented in task-11-report.md:
+    /// Raw XML, Atmospherics, and OOC are "hidden by default" — the factory
+    /// constructs and registers them in its private <c>_tools</c> lookup for
+    /// the Window menu, but never attaches them to any dock's
+    /// <see cref="IDock.VisibleDockables"/>, so <see cref="FindById"/> alone
+    /// can never reach them (pre-existing behavior; not introduced by this
+    /// feature). Falls back to the factory's private tool registry via
+    /// reflection — the same registry the Window-menu "re-open" toggles read
+    /// from — matching this test's existing reflection-based access to
+    /// private members (see <see cref="SetFlag"/>).
+    /// </summary>
+    private static IDockable ResolveDockable(GenieDockFactory factory, IDockable root, string id)
+    {
+        var found = FindById(root, id);
+        if (found is not null) return found;
+
+        var toolsField = typeof(GenieDockFactory)
+            .GetField("_tools", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var tools = (IDictionary)toolsField.GetValue(factory)!;
+        Assert.True(tools.Contains(id), $"'{id}' was not found in the dock tree or the tool registry.");
+        var entry = tools[id]!;
+        return (IDockable)entry.GetType().GetField("Item1")!.GetValue(entry)!;
+    }
+
+    private sealed class Harness : IDisposable
+    {
+        public MainWindowViewModel Vm { get; }
+        private readonly string _dir;
+
+        public Harness()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "genie_app_tests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            Vm = new MainWindowViewModel(startup: null, dataDirectoryOverride: _dir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Raw_xml_stays_on_the_legacy_type_by_default()
+    {
+        using var h = new Harness();
+        var factory = new GenieDockFactory(h.Vm);
+        var root = factory.CreateLayout();
+
+        Assert.IsType<RawXmlTool>(ResolveDockable(factory, root, "raw-xml"));
+    }
+
+    [Fact]
+    public void Raw_xml_switches_to_the_editor_type_when_the_flag_is_on()
+    {
+        using var h = new Harness();
+        SetFlag(h.Vm, nameof(MainWindowViewModel.UseEditorRawXmlWindow), true);
+        var factory = new GenieDockFactory(h.Vm);
+        var root = factory.CreateLayout();
+
+        Assert.IsType<EditorRawXmlTool>(ResolveDockable(factory, root, "raw-xml"));
+    }
+
+    [Fact]
+    public void Stream_windows_stay_on_the_legacy_type_by_default()
+    {
+        using var h = new Harness();
+        var factory = new GenieDockFactory(h.Vm);
+        var root = factory.CreateLayout();
+
+        foreach (var id in StreamIds)
+            Assert.IsType<StreamTool>(ResolveDockable(factory, root, id));
+    }
+
+    [Fact]
+    public void All_twelve_stream_windows_switch_to_the_editor_type_when_the_flag_is_on()
+    {
+        using var h = new Harness();
+        SetFlag(h.Vm, nameof(MainWindowViewModel.UseEditorStreamWindow), true);
+        var factory = new GenieDockFactory(h.Vm);
+        var root = factory.CreateLayout();
+
+        foreach (var id in StreamIds)
+            Assert.IsType<EditorStreamTool>(ResolveDockable(factory, root, id));
+    }
+}

--- a/tests/Genie.Core.Tests/EditorRawXmlWindowConfigTests.cs
+++ b/tests/Genie.Core.Tests/EditorRawXmlWindowConfigTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using Genie.Core.Config;
+using Genie.Core.Runtime;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// <c>#config useeditorrawxmlwindow</c> — the flag that swaps the Raw XML
+/// window onto the experimental AvaloniaEdit renderer. Same contract as
+/// <c>useeditorgamewindow</c> (see EditorGameWindowConfigTests): parses,
+/// persists, and reports like every other boolean, and is off unless the
+/// user turned it on. The renderer swap itself lives in Genie.App and is
+/// not reachable from these tests.
+/// </summary>
+public class EditorRawXmlWindowConfigTests
+{
+    private static GenieConfig NewConfig() =>
+        new(new LocalDirectoryService("Genie5Test", AppContext.BaseDirectory));
+
+    [Fact]
+    public void DefaultsOff()
+    {
+        Assert.False(NewConfig().UseEditorRawXmlWindow);
+    }
+
+    [Theory]
+    [InlineData("True", true)]
+    [InlineData("on", true)]
+    [InlineData("False", false)]
+    [InlineData("off", false)]
+    [InlineData("", false)]        // unset / unparseable stays on the shipped renderer
+    [InlineData("banana", false)]
+    public void RoundTrips(string input, bool expected)
+    {
+        var cfg = NewConfig();
+        cfg.SetSetting("useeditorrawxmlwindow", input, showException: false);
+        Assert.Equal(expected, cfg.UseEditorRawXmlWindow);
+        Assert.Equal(expected.ToString(), cfg.GetSetting("useeditorrawxmlwindow"));
+    }
+
+    [Fact]
+    public void IsListedForConfigDisplay()
+    {
+        Assert.Contains(NewConfig().ToConfigPairs(), p => p.Key == "useeditorrawxmlwindow");
+        Assert.Contains(GenieConfig.ConfigCategories.SelectMany(c => c.Keys), k => k == "useeditorrawxmlwindow");
+    }
+}

--- a/tests/Genie.Core.Tests/EditorStreamWindowConfigTests.cs
+++ b/tests/Genie.Core.Tests/EditorStreamWindowConfigTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using Genie.Core.Config;
+using Genie.Core.Runtime;
+using Xunit;
+
+namespace Genie.Core.Tests;
+
+/// <summary>
+/// <c>#config useeditorstreamwindow</c> — the flag that swaps every Stream
+/// window (Logons, Talk, Whispers, ...) onto the experimental AvaloniaEdit
+/// renderer at once. Same contract as <c>useeditorgamewindow</c> (see
+/// EditorGameWindowConfigTests): parses, persists, and reports like every
+/// other boolean, and is off unless the user turned it on. The renderer swap
+/// itself lives in Genie.App and is not reachable from these tests.
+/// </summary>
+public class EditorStreamWindowConfigTests
+{
+    private static GenieConfig NewConfig() =>
+        new(new LocalDirectoryService("Genie5Test", AppContext.BaseDirectory));
+
+    [Fact]
+    public void DefaultsOff()
+    {
+        Assert.False(NewConfig().UseEditorStreamWindow);
+    }
+
+    [Theory]
+    [InlineData("True", true)]
+    [InlineData("on", true)]
+    [InlineData("False", false)]
+    [InlineData("off", false)]
+    [InlineData("", false)]
+    [InlineData("banana", false)]
+    public void RoundTrips(string input, bool expected)
+    {
+        var cfg = NewConfig();
+        cfg.SetSetting("useeditorstreamwindow", input, showException: false);
+        Assert.Equal(expected, cfg.UseEditorStreamWindow);
+        Assert.Equal(expected.ToString(), cfg.GetSetting("useeditorstreamwindow"));
+    }
+
+    [Fact]
+    public void IsListedForConfigDisplay()
+    {
+        Assert.Contains(NewConfig().ToConfigPairs(), p => p.Key == "useeditorstreamwindow");
+        Assert.Contains(GenieConfig.ConfigCategories.SelectMany(c => c.Keys), k => k == "useeditorstreamwindow");
+    }
+}


### PR DESCRIPTION
## Summary
- Generalizes the experimental AvaloniaEdit-backed `GameTextEditor` control (previously game-window-only, behind `useeditorgamewindow`) behind a new `ITextEditorHost` contract, and extends it to the Raw XML and Stream windows.
- Adds `useeditorrawxmlwindow` and `useeditorstreamwindow` config keys (default off, read once at dock-layout build time, same experimental contract as the existing game-window flag). `GenieDockFactory` selects `EditorRawXmlTool`/`EditorStreamTool` vs. the legacy `RawXmlTool`/`StreamTool` per flag — one `useeditorstreamwindow` flag governs all 12 Stream instances.
- Colorizing and link generation are opt-in per host (`ITextEditorHost.EnableColorizing` / `EnableLinks`): on for Game/Stream, off for Raw XML, which stays a plain verbatim dump.
- `RawXmlViewModel.Lines` moves from `ObservableCollection<string>` to `ObservableCollection<TextLine>`, matching `GameTextViewModel`/`StreamBuffer`, so the shared renderer has one consistent line type across all three window kinds.
- Adds `MainWindowViewModel`'s `dataDirectoryOverride` test seam (isolates data-dir discovery for tests without touching real per-user AppData) and new coverage: `DataDirectoryOverrideTests`, `DockFactoryEditorWindowTests`, `EditorRawXmlWindowConfigTests`, `EditorStreamWindowConfigTests`.

All flags default off — with them off, the legacy per-line `ItemsControl` rendering is untouched and byte-for-byte the same code path as before.

## Test plan
- [x] `dotnet build src/Genie.App/Genie.App.csproj` — succeeds
- [x] `dotnet test tests/Genie.Core.Tests` — 1147 passed
- [x] `dotnet test tests/Genie.App.Tests` — 81 passed, including the new editor-window/dock-factory/data-directory-override coverage