### PR TITLE
fix(commanding): skip immediate duplicate entries in command history

### DIFF
--- a/src/Genie.App/ViewModels/CommandViewModel.cs
+++ b/src/Genie.App/ViewModels/CommandViewModel.cs
@@ -31,7 +31,8 @@ public class CommandViewModel : ReactiveObject
         // Store a password-masked copy in the recall history so an explicit
         // `#connect account password character game` can't be retrieved in
         // plaintext via Up-arrow. The real (unmasked) line is still sent.
-        _history.Add(ConnectCommandMask.Mask(cmd));
+        var masked = ConnectCommandMask.Mask(cmd);
+        if (_history.Count == 0 || _history[^1] != masked) _history.Add(masked);
         _historyIndex = -1;
         CommandText = "";
 

--- a/tests/Genie.App.Tests/CommandHistoryTests.cs
+++ b/tests/Genie.App.Tests/CommandHistoryTests.cs
@@ -186,6 +186,46 @@ public class CommandHistoryTests
         Assert.Equal("   ", vm.CommandText);
     }
 
+    // ── Consecutive duplicates collapse in history ───────────────────────────
+
+    [Fact]
+    public void Immediate_duplicate_submissions_add_only_one_history_entry()
+    {
+        // "look" before the run of duplicates proves the count: with dedup, one
+        // Up reaches "attack" and a second reaches "look" directly. Without
+        // dedup it would take three Ups to get past the repeated "attack"s.
+        var (vm, sent) = NewVm();
+        Submit(vm, "look");
+        Submit(vm, "attack");
+        Submit(vm, "attack");
+        Submit(vm, "attack");
+
+        Assert.Equal(new[] { "look", "attack", "attack", "attack" }, sent);
+
+        vm.HistoryUp();
+        Assert.Equal("attack", vm.CommandText);
+        vm.HistoryUp();
+        Assert.Equal("look", vm.CommandText);
+        vm.HistoryUp();
+        Assert.Equal("look", vm.CommandText);   // stops at the oldest entry
+    }
+
+    [Fact]
+    public void Non_consecutive_duplicates_are_all_recorded()
+    {
+        var (vm, _) = NewVm();
+        Submit(vm, "attack");
+        Submit(vm, "look");
+        Submit(vm, "attack");
+
+        vm.HistoryUp();
+        Assert.Equal("attack", vm.CommandText);
+        vm.HistoryUp();
+        Assert.Equal("look", vm.CommandText);
+        vm.HistoryUp();
+        Assert.Equal("attack", vm.CommandText);
+    }
+
     [Fact]
     public void Connect_passwords_are_masked_in_recall_but_sent_intact()
     {


### PR DESCRIPTION
## Summary
- Command history no longer records immediate/consecutive duplicate entries (e.g. `attack, attack, attack` adds one `attack`), while non-consecutive repeats (`attack, look, attack`) are still recorded in full.
- Every submission is still sent to the game as before — only recall history is affected.
- Comparison is case-sensitive for now.

## Test plan
- [x] Added `Immediate_duplicate_submissions_add_only_one_history_entry` and `Non_consecutive_duplicates_are_all_recorded` to `CommandHistoryTests`
- [x] `dotnet test tests/Genie.App.Tests` — 83/83 passing